### PR TITLE
Add existing lora resize UI to the utilities tab

### DIFF
--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -7,6 +7,7 @@ from textual_inversion_gui import ti_tab
 from library.utilities import utilities_tab
 from library.extract_lora_gui import gradio_extract_lora_tab
 from library.merge_lora_gui import gradio_merge_lora_tab
+from library.resize_lora_gui import gradio_resize_lora_tab
 from lora_gui import lora_tab
 
 
@@ -44,6 +45,7 @@ def UI(**kwargs):
             )
             gradio_extract_lora_tab()
             gradio_merge_lora_tab()
+            gradio_resize_lora_tab()
 
     # Show the interface
     launch_kwargs = {}


### PR DESCRIPTION
I noticed that the UI for resizing lora using kohya's sd_scripts is already coded, but it's not added to the Utilities tab in the UI. This PR basically adds it there.