### PR TITLE
fix wrong keyword argument

### DIFF
--- a/library/basic_caption_gui.py
+++ b/library/basic_caption_gui.py
@@ -53,10 +53,10 @@ def caption_images(
             )
         if find_text:
             find_replace(
-                folder=images_dir,
+                folder_path=images_dir,
                 caption_file_ext=caption_ext,
-                find=find_text,
-                replace=replace_text,
+                search_text=find_text,
+                replace_text=replace_text,
             )
     else:
         if prefix or postfix:


### PR DESCRIPTION
in [bmaltais/kohya_ss@`baf009d` (#403)](https://github.com/bmaltais/kohya_ss/pull/403/commits/baf009d2b1b86f5dc45a9952df9e30f6cf81bb24)

during refactoring find_replace function, some keyword args changed but missed to modify its caller.