### PR TITLE
Add the version of scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 accelerate==0.15.0
 albumentations==1.3.0
+scipy==1.9.1
 altair==4.2.2
 bitsandbytes==0.35.0
 dadaptation==1.5


### PR DESCRIPTION
The latest version of scipy is 1.10.1 and 1.10.1 is automatically installed without limiting the old version which albumentation requires.