### PR TITLE
Add the version of scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ huggingface-hub==0.12.0
 tensorflow==2.12.0
 numpy==1.22
 xformers==0.0.16
+torch==1.13.1
 # For locon support
 lycoris_lora==0.1.2
 # for kohya_ss library

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 accelerate==0.15.0
 albumentations==1.3.0
+scipy==1.9.1
 altair==4.2.2
 bitsandbytes==0.35.0
 dadaptation==1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ lion-pytorch==0.0.6
 opencv-python==4.7.0.68
 pytorch-lightning==1.9.0
 safetensors==0.2.6
-tensorboard==2.10.1
+tensorboard==2.12.0
 tk==0.1.0
 toml==0.10.2
 transformers==4.26.0
@@ -24,7 +24,9 @@ requests==2.28.2
 timm==0.6.12
 # tensorflow<2.11
 huggingface-hub==0.12.0
-tensorflow==2.10.1
+tensorflow==2.12.0
+numpy==1.22
+xformers==0.0.16
 # For locon support
 lycoris_lora==0.1.2
 # for kohya_ss library

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ tensorflow==2.12.0
 numpy==1.22
 xformers==0.0.16
 torch==1.13.1
+torchvision==0.14.1
 # For locon support
 lycoris_lora==0.1.2
 # for kohya_ss library


### PR DESCRIPTION
The latest version of scipy is 1.10.1 and 1.10.1 is automatically installed without limiting the old version which albumentation requires.