### PR TITLE
Change step of network_alpha from 1 to 0.1

### DIFF
--- a/lora_gui.py
+++ b/lora_gui.py
@@ -815,10 +815,10 @@ def lora_tab(
                 label='Convolution Rank (Dimension)',
             )
             conv_alpha = gr.Slider(
-                minimum=1,
+                minimum=0.1,
                 maximum=512,
                 value=1,
-                step=1,
+                step=0.1,
                 label='Convolution Alpha',
             )
         # Show of hide LoCon conv settings depending on LoRA type selection

--- a/lora_gui.py
+++ b/lora_gui.py
@@ -796,11 +796,11 @@ def lora_tab(
                 interactive=True,
             )
             network_alpha = gr.Slider(
-                minimum=1,
+                minimum=0.1,
                 maximum=1024,
                 label='Network Alpha',
                 value=1,
-                step=1,
+                step=0.1,
                 interactive=True,
             )
 


### PR DESCRIPTION
In LyCORIS, Kohaku [implies](https://github.com/KohakuBlueleaf/LyCORIS#conventional-lora) the value of `network_alpha` could be (or should be, in some case) lower than 1.
Currently, the gui rounds up to 1 when you set network_alpha to 0.3 or any other value lower than 1.
This PR makes this possible.