### PR TITLE
Small fix to default to pre-existing git branch if detected in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ This will store your a backup file with your current locally installed pip packa
     - Fix an issue that images are loaded twice in Windows environment.
     - Add Min-SNR Weighting strategy. Details are in [#308](https://github.com/kohya-ss/sd-scripts/pull/308). Thank you to AI-Casanova for this great work!
         - Add `--min_snr_gamma` option to training scripts, 5 is recommended by paper.
-        - The Min SNR gamma fiels can be found unser the advanced training tab in all trainers.
+        - The Min SNR gamma fields can be found under the advanced training tab in all trainers.
     - Fixed the error while images are ended with capital image extensions. Thanks to @kvzn. https://github.com/bmaltais/kohya_ss/pull/454
 * 2023/03/26 (v21.3.5)
     - Fix for https://github.com/bmaltais/kohya_ss/issues/230
@@ -278,7 +278,7 @@ This will store your a backup file with your current locally installed pip packa
 * 2023/03/25 (v21.3.4)
     - Added untested support for MacOS base on this gist: https://gist.github.com/jstayco/9f5733f05b9dc29de95c4056a023d645
 
-    Let me know how this work. From the look of it it appear to be well tought out. I modified a few things to make it fit better with the rest of the code in the repo.
+    Let me know how this work. From the look of it it appears to be well-thought-out. I modified a few things to make it fit better with the rest of the code in the repo.
     - Fix for issue https://github.com/bmaltais/kohya_ss/issues/433 by implementing default of 0.
     - Removed non applicable save_model_as choices for LoRA and TI.
 * 2023/03/24 (v21.3.3)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ This will store your a backup file with your current locally installed pip packa
     - Fix for issue https://github.com/bmaltais/kohya_ss/issues/433 by implementing default of 0.
     - Removed non applicable save_model_as choices for LoRA and TI.
 * 2023/03/24 (v21.3.3)
-    - Add support for custom user gui files. THey will be created at installation time or when upgrading is missing. You will see two files in the root of the folder. One named `gui-user.bat` and the other `gui-user.ps1`. Edit the file based on your prefered terminal. Simply add the parameters you want to pass the gui in there and execute it to start the gui with them. Enjoy!
+    - Add support for custom user gui files. THey will be created at installation time or when upgrading is missing. You will see two files in the root of the folder. One named `gui-user.bat` and the other `gui-user.ps1`. Edit the file based on your preferred terminal. Simply add the parameters you want to pass the gui in there and execute it to start the gui with them. Enjoy!
 * 2023/03/23 (v21.3.2)
     - Fix issue reported: https://github.com/bmaltais/kohya_ss/issues/439
 * 2023/03/23 (v21.3.1)

--- a/setup.sh
+++ b/setup.sh
@@ -356,10 +356,15 @@ update_kohya_ss() {
           git -C "$DIR" pull "$GIT_REPO" "$BRANCH" >&3
         fi
 
-        if ! git -C "$DIR" switch "$BRANCH" >&4; then
-          echo "Branch $BRANCH did not exist. Creating it." >&4
-          git -C "$DIR" switch -c "$BRANCH" >&4
+        if [ "$MANUAL_BRANCH_SWITCH" = false ]; then
+          git -C "$DIR" switch "$BRANCH" >&3
+        else
+          if ! git -C "$DIR" switch "$BRANCH" >&4; then
+            echo "Branch $BRANCH did not exist. Creating it." >&4
+            git -C "$DIR" switch -c "$BRANCH" >&4
+          fi
         fi
+
       fi
     else
       echo "You need to install git."

--- a/setup.sh
+++ b/setup.sh
@@ -357,7 +357,7 @@ update_kohya_ss() {
         fi
 
         if [ "$MANUAL_BRANCH_SWITCH" = false ]; then
-          git -C "$DIR" switch "$BRANCH" >&3
+          git -C "$DIR" switch "$(git rev-parse --abbrev-ref HEAD)" >&3
         else
           if ! git -C "$DIR" switch "$BRANCH" >&4; then
             echo "Branch $BRANCH did not exist. Creating it." >&4

--- a/setup.sh
+++ b/setup.sh
@@ -588,10 +588,10 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
   configure_accelerate
   echo -e "Setup finished! Run ./gui.sh to start."
 elif [[ "$OSTYPE" == "cygwin" ]]; then
-  # Cygwin is a standalone suite of Linux utilies on Windows
+  # Cygwin is a standalone suite of Linux utilities on Windows
   echo "This hasn't been validated on cygwin yet."
 elif [[ "$OSTYPE" == "msys" ]]; then
-  # MinGW has the msys environment which is a standalone suite of Linux utilies on Windows
+  # MinGW has the msys environment which is a standalone suite of Linux utilities on Windows
   # "git bash" on Windows may also be detected as msys.
   echo "This hasn't been validated in msys (mingw) on Windows yet."
 fi

--- a/upgrade.bat
+++ b/upgrade.bat
@@ -10,7 +10,7 @@ if %errorlevel%==1 (
 git pull
 
 :: Activate the virtual environment
-call .\venv\Scripts\activate.baT
+call .\venv\Scripts\activate.bat
 
 :: Upgrade the required packages
 pip install --upgrade -r requirements.txt


### PR DESCRIPTION
Defaults to pre-existing git branch if detected, will switch to arbitrary branch if specified by user, will default to master on new installs.