### PR TITLE
fix resize_lora not working with paths that contain spaces

### DIFF
--- a/library/resize_lora_gui.py
+++ b/library/resize_lora_gui.py
@@ -54,8 +54,8 @@ def resize_lora(
 
     run_cmd = f'{PYTHON} "{os.path.join("networks","resize_lora.py")}"'
     run_cmd += f' --save_precision {save_precision}'
-    run_cmd += f' --save_to {save_to}'
-    run_cmd += f' --model {model}'
+    run_cmd += f' --save_to "{save_to}"'
+    run_cmd += f' --model "{model}"'
     run_cmd += f' --new_rank {new_rank}'
     run_cmd += f' --device {device}'
     if not dynamic_method == 'None':


### PR DESCRIPTION
While it might be better to use `shlex` (not sure, just thinking about cross-platform compat) i.e. 

```
run_cmd += f' --save_to {shlex.quote(save_to)}'

subprocess.run(shlex.split(run_cmd))
```

to keep it simple and similar to how it works in other parts, added the missing quotes to allow the resizer to work with paths that contain spaces. 