### PR TITLE
Fix for git-based captioning on posix systems

### DIFF
--- a/library/git_caption_gui.py
+++ b/library/git_caption_gui.py
@@ -28,7 +28,7 @@ def caption_images(
 
     print(f'GIT captioning files in {train_data_dir}...')
     run_cmd = (
-        f'.\\venv\\Scripts\\python.exe "finetune/make_captions_by_git.py"'
+        f'{PYTHON} "./finetune/make_captions_by_git.py"'
     )
     if not model_id == '':
         run_cmd += f' --model_id="{model_id}"'
@@ -44,7 +44,10 @@ def caption_images(
     print(run_cmd)
 
     # Run the command
-    subprocess.run(run_cmd)
+    if os.name == 'posix':
+        os.system(run_cmd)
+    else:
+        subprocess.run(run_cmd)
 
     # Add prefix and postfix
     add_pre_postfix(

--- a/library/git_caption_gui.py
+++ b/library/git_caption_gui.py
@@ -28,7 +28,7 @@ def caption_images(
 
     print(f'GIT captioning files in {train_data_dir}...')
     run_cmd = (
-        f'{PYTHON} "./finetune/make_captions_by_git.py"'
+        f'{PYTHON} finetune/make_captions_by_git.py'
     )
     if not model_id == '':
         run_cmd += f' --model_id="{model_id}"'


### PR DESCRIPTION
Just a quick fix that resolves an issue invoking python as a subprocess on POSIX systems when attempting to use git-based captioning.