### PR TITLE
fixed the batch size logic for supporting multi-gpu training & added pyTorch 2.0 supports

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1842,8 +1842,11 @@ def replace_unet_cross_attn_to_xformers():
         out = self.to_out[0](out)
         out = self.to_out[1](out)
         return out
-
-    diffusers.models.attention.CrossAttention.forward = forward_xformers
+    # support for pyTorch 2.0
+    if torch.__version__ >= "2.0":
+        diffusers.models.attention._use_memory_efficient_attention_xformers = True
+    else:
+        diffusers.models.attention.CrossAttention.forward = forward_xformers
 
 
 # endregion
@@ -2744,6 +2747,7 @@ def prepare_accelerator(args: argparse.Namespace):
         mixed_precision=args.mixed_precision,
         log_with=log_with,
         logging_dir=logging_dir,
+        split_batches=True,
     )
 
     # accelerateの互換性問題を解決する

--- a/train_network.py
+++ b/train_network.py
@@ -234,7 +234,7 @@ def train(args):
 
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset_group,
-        batch_size=1,
+        batch_size=args.train_batch_size,
         shuffle=True,
         collate_fn=collater,
         num_workers=n_workers,
@@ -317,7 +317,7 @@ def train(args):
     train_util.resume_from_local_or_hf_if_specified(accelerator, args)
 
     # epoch数を計算する
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) * args.train_batch_size / args.gradient_accumulation_steps)
     num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
     if (args.save_n_epoch_ratio is not None) and (args.save_n_epoch_ratio > 0):
         args.save_every_n_epochs = math.floor(num_train_epochs / args.save_n_epoch_ratio) or 1

--- a/train_network.py
+++ b/train_network.py
@@ -325,6 +325,7 @@ def train(args):
     # 学習する
     # TODO: find a way to handle total batch size when there are multiple datasets
     total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
+    args.max_train_steps = num_train_epochs * len(train_dataloader)
 
     if is_main_process:
         print("running training / 学習開始")


### PR DESCRIPTION
here should not hardcode the batch size as 1, otherwise then training it on multi-GPU its actually multiplies the training steps, which will cause the overall training time is not to decrease 