### PR TITLE
[bugfix] Added support for Multi-GPUs training LoRA network 

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -1842,8 +1842,11 @@ def replace_unet_cross_attn_to_xformers():
         out = self.to_out[0](out)
         out = self.to_out[1](out)
         return out
-
-    diffusers.models.attention.CrossAttention.forward = forward_xformers
+    # support for pyTorch 2.0
+    if torch.__version__ >= "2.0":
+        diffusers.models.attention._use_memory_efficient_attention_xformers = True
+    else:
+        diffusers.models.attention.CrossAttention.forward = forward_xformers
 
 
 # endregion
@@ -2744,6 +2747,7 @@ def prepare_accelerator(args: argparse.Namespace):
         mixed_precision=args.mixed_precision,
         log_with=log_with,
         logging_dir=logging_dir,
+        split_batches=True,
     )
 
     # accelerateの互換性問題を解決する

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -679,7 +679,6 @@ class LoRANetwork(torch.nn.Module):
                         if is_linear or is_conv2d:
                             lora_name = prefix + "." + name + "." + child_name
                             lora_name = lora_name.replace(".", "_")
-                            if is_unet and lora_name in lora_names: continue
 
                             dim = None
                             alpha = None

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+cd /proj/suchka/image-generation/kohya_ss
+./gui.sh --listen 192.168.0.190 --server_port 7800

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,0 @@
-cd /proj/suchka/image-generation/kohya_ss
-./gui.sh --listen 192.168.0.190 --server_port 7800

--- a/train_network.py
+++ b/train_network.py
@@ -234,7 +234,7 @@ def train(args):
 
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset_group,
-        batch_size=1,
+        batch_size=args.train_batch_size,
         shuffle=True,
         collate_fn=collater,
         num_workers=n_workers,
@@ -317,7 +317,7 @@ def train(args):
     train_util.resume_from_local_or_hf_if_specified(accelerator, args)
 
     # epoch数を計算する
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) * args.train_batch_size / args.gradient_accumulation_steps)
     num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
     if (args.save_n_epoch_ratio is not None) and (args.save_n_epoch_ratio > 0):
         args.save_every_n_epochs = math.floor(num_train_epochs / args.save_n_epoch_ratio) or 1

--- a/train_network.py
+++ b/train_network.py
@@ -317,7 +317,7 @@ def train(args):
     train_util.resume_from_local_or_hf_if_specified(accelerator, args)
 
     # epoch数を計算する
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) * args.train_batch_size / args.gradient_accumulation_steps)
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) * accelerator.num_processes / args.gradient_accumulation_steps)
     num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
     if (args.save_n_epoch_ratio is not None) and (args.save_n_epoch_ratio > 0):
         args.save_every_n_epochs = math.floor(num_train_epochs / args.save_n_epoch_ratio) or 1

--- a/train_network.py
+++ b/train_network.py
@@ -325,6 +325,7 @@ def train(args):
     # 学習する
     # TODO: find a way to handle total batch size when there are multiple datasets
     total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
+    args.max_train_steps = num_train_epochs * len(train_dataloader)
 
     if is_main_process:
         print("running training / 学習開始")

--- a/train_network.py
+++ b/train_network.py
@@ -234,7 +234,7 @@ def train(args):
 
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset_group,
-        batch_size=args.train_batch_size,
+        batch_size=accelerator.num_processes,
         shuffle=True,
         collate_fn=collater,
         num_workers=n_workers,


### PR DESCRIPTION
should able accelerator split_batches=True to allow the accelerator to balance to the training set to each of the GPUs, in this way the overall training time be reduced, the previous code just duplicates the entire training set to each of the GPUs, in that way no matter how many GPU been used, its not reduce the training time, instead of just multiplied the training step.

i saw the code train batch size has been applied to the dataset_group, the DataLoader's batch_size need to be at least same as accelerator.num_processes, for accelerator to know how to balance the dataset.

Additionally: 
I have add support for this script to work with pyTorch 2.0, in torch 2.0 it shipped with xformer support code in their attention layer, so just need to turn it on, instead of inject the xformer logic