### PR TITLE
Remove bitsandbytes version to fix CUDA version 12x compatible problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 accelerate==0.15.0
 albumentations==1.3.0
 altair==4.2.2
-bitsandbytes==0.35.0
+bitsandbytes==0.35.0; sys_platform == 'win32'
+bitsandbytes==0.38.1; (sys_platform == "darwin" or sys_platform == "linux")
 dadaptation==1.5
 diffusers[torch]==0.10.2
 easygui==0.98.3


### PR DESCRIPTION
Tested on RTX4090 + cu121 + python3.10.11 + Ubuntu 22.04, it works fine for me. Please verify Windows and other os please.