### PR TITLE
Docker: Upgrade to Python 3.10 and remove venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV TZ=Europe/London
 RUN apt update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt update && \
-    apt-get install -y git curl python3-tk libgl1 libglib2.0-0 libgoogle-perftools-dev \
-	                   python3.10 python3-html5lib python3-apt python3-pip python3.10-distutils && \
+    apt-get install -y git curl libgl1 libglib2.0-0 libgoogle-perftools-dev \
+	                   python3.10 python3.10-tk python3-html5lib python3-apt python3-pip python3.10-distutils && \
 	rm -rf /var/lib/apt/lists/*
 
 # Set python 3.10 as default

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY requirements.txt setup.py .
 RUN python3 -m pip install --use-pep517 -U -r requirements.txt
 
 # Upgrade to Torch 2.0
-RUN python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch>=2.0.0+cu121 xformers==0.0.17 \
+RUN python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch>=2.0.0+cu121 xformers==0.0.17 accelerate \
 	                       --extra-index-url https://download.pytorch.org/whl/cu121
 
 # Fix missing libnvinfer7
@@ -43,4 +43,5 @@ RUN sed -i 's/import library.huggingface_util/# import library.huggingface_util/
 
 STOPSIGNAL SIGINT
 ENV LD_PRELOAD=libtcmalloc.so
+ENV PATH="$PATH:/home/appuser/.local/bin"
 CMD python3 "./kohya_gui.py" ${CLI_ARGS} --listen 0.0.0.0 --server_port 7860

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ USER appuser
 
 WORKDIR /app
 
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 RUN python3 -m pip install wheel
 
 # Install requirements
@@ -36,6 +37,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu/libnvinfer.so /usr/lib/x86_64-linux-gnu/libn
 USER appuser
 COPY --chown=appuser . .
 
+# https://github.com/kohya-ss/sd-scripts/issues/405#issuecomment-1509851709
 RUN sed -i 's/import library.huggingface_util/# import library.huggingface_util/g' train_network.py && \
     sed -i 's/import library.huggingface_util/# import library.huggingface_util/g' library/train_util.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,30 @@ FROM nvcr.io/nvidia/pytorch:23.04-py3 as base
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/London
 
-RUN apt-get update && \
-    apt-get install -y git curl python3-venv python3-tk libgl1 libglib2.0-0 libgoogle-perftools-dev && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt update && \
+    apt-get install -y git curl python3-tk libgl1 libglib2.0-0 libgoogle-perftools-dev \
+	                   python3.10 python3-html5lib python3-apt python3-pip python3.10-distutils && \
+	rm -rf /var/lib/apt/lists/*
+
+# Set python 3.10 as default
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 3 && \
+	update-alternatives --config python3
 
 RUN useradd -m -s /bin/bash appuser
 USER appuser
 
 WORKDIR /app
 
-RUN python3 -m venv ./venv && . ./venv/bin/activate && \
-    python3 -m pip install wheel
+RUN python3 -m pip install wheel
 
 # Install requirements
 COPY requirements.txt setup.py .
-RUN . ./venv/bin/activate && \
-    python3 -m pip install --use-pep517 -U -r requirements.txt
+RUN python3 -m pip install --use-pep517 -U -r requirements.txt
 
 # Upgrade to Torch 2.0
-RUN . ./venv/bin/activate && \
-    python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch>=2.0.0+cu121 xformers==0.0.17 \
+RUN python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch>=2.0.0+cu121 xformers==0.0.17 \
 	                       --extra-index-url https://download.pytorch.org/whl/cu121
 
 # Fix missing libnvinfer7
@@ -37,4 +41,4 @@ RUN sed -i 's/import library.huggingface_util/# import library.huggingface_util/
 
 STOPSIGNAL SIGINT
 ENV LD_PRELOAD=libtcmalloc.so
-CMD . ./venv/bin/activate && python3 "./kohya_gui.py" ${CLI_ARGS} --listen 0.0.0.0 --server_port 7860
+CMD python3 "./kohya_gui.py" ${CLI_ARGS} --listen 0.0.0.0 --server_port 7860

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 3 && \
 	update-alternatives --config python3
 
+RUN python3 -m pip install -e /opt/pytorch/pytorch
+
 RUN useradd -m -s /bin/bash appuser
 USER appuser
 
@@ -26,8 +28,7 @@ COPY requirements.txt setup.py .
 RUN python3 -m pip install --use-pep517 -U -r requirements.txt
 
 # Upgrade to Torch 2.0
-RUN python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch>=2.0.0+cu121 xformers==0.0.17 accelerate \
-	                       --extra-index-url https://download.pytorch.org/whl/cu121
+RUN python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch xformers==0.0.17 accelerate
 
 # Fix missing libnvinfer7
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 3 && \
 	update-alternatives --config python3
 
-RUN ln -s /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.10/dist-packages
-
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
-
-RUN useradd -m -s /bin/bash appuser
-USER appuser
 
 WORKDIR /app
 RUN python3 -m pip install wheel
@@ -32,6 +27,7 @@ USER root
 RUN ln -s /usr/lib/x86_64-linux-gnu/libnvinfer.so /usr/lib/x86_64-linux-gnu/libnvinfer.so.7 && \
     ln -s /usr/lib/x86_64-linux-gnu/libnvinfer_plugin.so /usr/lib/x86_64-linux-gnu/libnvinfer_plugin.so.7
 
+RUN useradd -m -s /bin/bash appuser
 USER appuser
 COPY --chown=appuser . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 3 && \
 	update-alternatives --config python3
 
+RUN ln -s /usr/local/lib/python3.8/dist-packages /usr/local/lib/python3.10/dist-packages
+
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
-RUN python3 -m pip install -e /opt/pytorch/pytorch
 
 RUN useradd -m -s /bin/bash appuser
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,22 +13,18 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 3 && \
 	update-alternatives --config python3
 
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 RUN python3 -m pip install -e /opt/pytorch/pytorch
 
 RUN useradd -m -s /bin/bash appuser
 USER appuser
 
 WORKDIR /app
-
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 RUN python3 -m pip install wheel
 
 # Install requirements
 COPY requirements.txt setup.py .
 RUN python3 -m pip install --use-pep517 -U -r requirements.txt
-
-# Upgrade to Torch 2.0
-RUN python3 -m pip install --use-pep517 --no-deps -U triton==2.0.0 torch xformers==0.0.17 accelerate
 
 # Fix missing libnvinfer7
 USER root


### PR DESCRIPTION
Previous docker image used Python 3.8, I upgraded it to python 3.10. I also removed venv for smaller image sizes.