### PR TITLE
Optimize the LD_LIBRARY_PATH environment variable that cannot be obta…

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# If it is run with the sudo command, get the complete LD_LIBRARY_PATH environment variable of the system and assign it to the current environment,
+# because it will be used later.
+if [ -n "$SUDO_USER" ] || [ -n "$SUDO_COMMAND" ] ; then
+    echo "The sudo command resets the non-essential environment variables, we keep the LD_LIBRARY_PATH variable."
+    export LD_LIBRARY_PATH=$(sudo -i printenv LD_LIBRARY_PATH)
+fi
+
 # This gets the directory the script is run from so pathing can work relative to the script where needed.
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 


### PR DESCRIPTION
On the Linux system, when the value of the environment variable LD_LIBRARY_PATH exists, and the sudo command is used to run the gui.sh script to start the webui, the sudo command will reset non-basic environment variables such as LD_LIBRARY_PATH, which will result in failure to obtain LD_LIBRARY_PATH and CUDA information during the running process.
So, it can be checked in the gui.sh script, if using sudo command to start the script, then use `sudo -i printenv LD_LIBRARY_PATH` to get the complete LD_LIBRARY_PATH variable value and set it to the current environment, this can effectively prevent the value of the LD_LIBRARY_PATH variable can't being obtained during the running process.

Use the LD_LIBRARY_PATH environment variable to obtain CUDA information, refer to: https://github.com/TimDettmers/bitsandbytes/blob/main/bitsandbytes/cuda_setup/main.py, method: determine_cuda_runtime_lib_path