### PR TITLE
fix wandb logging

### DIFF
--- a/library/common_gui.py
+++ b/library/common_gui.py
@@ -1092,8 +1092,8 @@ def gradio_advanced_training(headless=False):
         save_every_n_steps,
         save_last_n_steps,
         save_last_n_steps_state,
-        wandb_api_key,
         use_wandb,
+        wandb_api_key,
     )
 
 


### PR DESCRIPTION
order expected in `train_model` functions for `use_wandb` and `wandb_api_key` was reversed from what `common_gui`'s `gradio_advanced_training` returned