### PR TITLE
Add chown -R appuser: /app to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ USER root
 RUN ln -s /usr/lib/x86_64-linux-gnu/libnvinfer.so /usr/lib/x86_64-linux-gnu/libnvinfer.so.7 && \
     ln -s /usr/lib/x86_64-linux-gnu/libnvinfer_plugin.so /usr/lib/x86_64-linux-gnu/libnvinfer_plugin.so.7
 
-RUN useradd -m -s /bin/bash appuser
+RUN useradd -m -s /bin/bash appuser && \
+    chown -R appuser: /app
 USER appuser
 COPY --chown=appuser . .
 


### PR DESCRIPTION
This change allows the /app directory inside the docker container to be writable by the appuser user.

Before:
`
Traceback (most recent call last):
  File "/app/./kohya_gui.py", line 4, in <module>
    from dreambooth_gui import dreambooth_tab
  File "/app/dreambooth_gui.py", line 13, in <module>
    from library.common_gui import (
  File "/app/library/common_gui.py", line 12, in <module>
    log = setup_logging()
  File "/app/library/custom_logging.py", line 26, in setup_logging
    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s | %(levelname)s | %(pathname)s | %(message)s', filename='setup.log', filemode='a', encoding='utf-8', force=True)
  File "/usr/lib/python3.10/logging/__init__.py", line 2040, in basicConfig
    h = FileHandler(filename, mode,
  File "/usr/lib/python3.10/logging/__init__.py", line 1169, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib/python3.10/logging/__init__.py", line 1201, in _open
    return open_func(self.baseFilename, self.mode,
PermissionError: [Errno 13] Permission denied: '/app/setup.log'
`


After
`
03:31:00-654130 INFO     headless: False
03:31:00-656661 INFO     Load CSS...
Running on local URL:  http://0.0.0.0:7860

To create a public link, set `share=True` in `launch()`.
`
