### PR TITLE
Set docker cuda version to 11.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     python3.10-dev python3.10-tk python3-html5lib python3-apt python3-pip python3.10-distutils && \
     rm -rf /var/lib/apt/lists/*
 
-# Set python 3.10 as default
+# Set python 3.10 and cuda 11.8 as default
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 3 && \
-    update-alternatives --config python3
+    update-alternatives --set python3 /usr/bin/python3.10 && \
+    update-alternatives --set cuda /usr/local/cuda-11.8
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 


### PR DESCRIPTION
When building the docker image as is, training a lora errors out with a cuda version conflict.

> CUDA_SETUP: WARNING! libcudart.so not found in any environmental path. Searching /usr/local/cuda/lib64...
> CUDA SETUP: CUDA runtime path found: /usr/local/cuda/lib64/libcudart.so
> CUDA SETUP: Highest compute capability among GPUs detected: 8.6
> CUDA SETUP: Detected CUDA version 121
> CUDA SETUP: TODO: compile library for specific version: libbitsandbytes_cuda121.so
> CUDA SETUP: Defaulting to libbitsandbytes.so...
> CUDA SETUP: CUDA detection failed. Either CUDA driver not installed, CUDA not installed, or you have multiple conflicting CUDA libraries!
> CUDA SETUP: If you compiled from source, try again with `make CUDA_VERSION=DETECTED_CUDA_VERSION` for example, `make CUDA_VERSION=113`.


When moving to 11.8, it works.

> CUDA_SETUP: WARNING! libcudart.so not found in any environmental path. Searching /usr/local/cuda/lib64...
> CUDA SETUP: CUDA runtime path found: /usr/local/cuda/lib64/libcudart.so
> CUDA SETUP: Highest compute capability among GPUs detected: 8.6
> CUDA SETUP: Detected CUDA version 118
> CUDA SETUP: Loading binary /usr/local/lib/python3.10/dist-packages/bitsandbytes/libbitsandbytes_cuda118.so...
> use 8-bit AdamW optimizer | {}
> running training / 学習開始
> 

This is an easy change because the base image ships with both versions of cuda.
Tests were built with: docker build -t kohya-ss-gui:latest . --no-cache
Tests were run with: docker-compose run --service-ports kohya-ss-gui

Also updating update-alternatives --config to --set.  From the [man page](https://man7.org/linux/man-pages/man1/update-alternatives.1.html):
> --set name path
>            Set the program path as alternative for name.  This is
>            equivalent to --config but is non-interactive and thus
>            scriptable.
