### PR TITLE
Fix verification function

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ This will store a backup file with your current locally installed pip packages a
 
 ## Change History
 
+* 2023/06/18 (v21.7.9)
+- Implement temporary fix for validation of image dataset. Will no longer stop execution but will let training continue... this is changed to avoid stopping training on false positive... yet still raise awaireness that something might be wrong with the image dataset structure.
 * 2023/06/14 (v21.7.8)
 - Add tkinter to dockerised version (thanks to @burdokow)
 - Add option to create caption files from folder names to the `group_images.py` tool.

--- a/library/common_gui.py
+++ b/library/common_gui.py
@@ -1287,10 +1287,13 @@ def run_cmd_advanced_training(**kwargs):
     return run_cmd
 
 def verify_image_folder_pattern(folder_path):
+    false_response = True # temporarilly set to true to prevent stopping training in case of false positive
+    true_response = True
+    
     # Check if the folder exists
     if not os.path.isdir(folder_path):
         log.error(f"The provided path '{folder_path}' is not a valid folder. Please follow the folder structure documentation found at docs\image_folder_structure.md ...")
-        return False
+        return false_response
 
     # Create a regular expression pattern to match the required sub-folder names
     pattern = r'^\d+_\w+'
@@ -1307,12 +1310,12 @@ def verify_image_folder_pattern(folder_path):
     if len(matching_subfolders) != len(filenames):
         log.error(f"Not all image folders have proper name patterns <numbre>_<text> in {folder_path}. Please follow the folder structure documentation found at docs/image_folder_structure.md ...")
         log.error(f"Only folders are allowed in {folder_path}...")
-        return False
+        return false_response
 
     # Check if no sub-folders exist
     if not matching_subfolders:
         log.error(f"No image folders found in {folder_path}. Please follow the folder structure documentation found at docs\image_folder_structure.md ...")
-        return False
+        return false_response
 
     log.info(f'Valid image folder names found in: {folder_path}')
-    return True
+    return true_response


### PR DESCRIPTION
The current function was stopping training if wrongly named folders (hidden or visible) were found. It would also trigger an error if files were found in the folder.

THe updated code has been relaxed and will only report error on folder names and not consider files anymore.