### PR TITLE
Fix for LyCORIS iA3 text_encoder being a list in SDXL

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -279,7 +279,7 @@ class NetworkTrainer:
                 args.network_dim,
                 args.network_alpha,
                 vae,
-                text_encoder,
+                text_encoder[0] if isinstance(text_encoder, list) else text_encoder,
                 unet,
                 neuron_dropout=args.network_dropout,
                 **net_kwargs,


### PR DESCRIPTION
Thanks to the insight form @v0xie [here](https://github.com/bmaltais/kohya_ss/issues/1309#issuecomment-1659973520), I made a quick patch for SDXL's list of text encoders not being handled in LyCORIS/iA3's training.

It seems there will need to be some extra thought put into how to deal with more than one encoder, but for now, this allows me to train iA3 on SDXL.