### PR TITLE
correctly rotate images with EXIF orientations on load

### DIFF
--- a/finetune/make_captions.py
+++ b/finetune/make_captions.py
@@ -43,7 +43,7 @@ class ImageLoadingTransformDataset(torch.utils.data.Dataset):
         img_path = self.images[idx]
 
         try:
-            image = Image.open(img_path).convert("RGB")
+            image = train_util.load_image(img_path)
             # convert to tensor temporarily so dataloader will accept it
             tensor = IMAGE_TRANSFORM(image)
         except Exception as e:
@@ -131,9 +131,7 @@ def main(args):
             img_tensor, image_path = data
             if img_tensor is None:
                 try:
-                    raw_image = Image.open(image_path)
-                    if raw_image.mode != "RGB":
-                        raw_image = raw_image.convert("RGB")
+                    raw_image = train_util.load_image(image_path)
                     img_tensor = IMAGE_TRANSFORM(raw_image)
                 except Exception as e:
                     print(f"Could not load image path / 画像を読み込めません: {image_path}, error: {e}")

--- a/finetune/make_captions_by_git.py
+++ b/finetune/make_captions_by_git.py
@@ -118,9 +118,7 @@ def main(args):
             image, image_path = data
             if image is None:
                 try:
-                    image = Image.open(image_path)
-                    if image.mode != "RGB":
-                        image = image.convert("RGB")
+                    image = train_util.load_image(image_path)
                 except Exception as e:
                     print(f"Could not load image path / 画像を読み込めません: {image_path}, error: {e}")
                     continue

--- a/finetune/prepare_buckets_latents.py
+++ b/finetune/prepare_buckets_latents.py
@@ -122,9 +122,7 @@ def main(args):
             image = transforms.functional.to_pil_image(img_tensor)
         else:
             try:
-                image = Image.open(image_path)
-                if image.mode != "RGB":
-                    image = image.convert("RGB")
+                image = train_util.load_image(image_path)
             except Exception as e:
                 print(f"Could not load image path / 画像を読み込めません: {image_path}, error: {e}")
                 continue

--- a/finetune/tag_images_by_wd14_tagger.py
+++ b/finetune/tag_images_by_wd14_tagger.py
@@ -55,7 +55,7 @@ class ImageLoadingPrepDataset(torch.utils.data.Dataset):
         img_path = str(self.images[idx])
 
         try:
-            image = Image.open(img_path).convert("RGB")
+            image = train_util.load_image(img_path)
             image = preprocess_image(image)
             tensor = torch.tensor(image)
         except Exception as e:
@@ -197,9 +197,7 @@ def main(args):
                 image = image.detach().numpy()
             else:
                 try:
-                    image = Image.open(image_path)
-                    if image.mode != "RGB":
-                        image = image.convert("RGB")
+                    image = train_util.load_image(image_path)
                     image = preprocess_image(image)
                 except Exception as e:
                     print(f"Could not load image path / 画像を読み込めません: {image_path}, error: {e}")

--- a/gen_img_diffusers.py
+++ b/gen_img_diffusers.py
@@ -2627,7 +2627,7 @@ def main(args):
 
         images = []
         for p in paths:
-            image = Image.open(p)
+            image = train_util.load_image(p)
             if image.mode != "RGB":
                 print(f"convert image to RGB from {image.mode}: {p}")
                 image = image.convert("RGB")

--- a/sdxl_gen_img.py
+++ b/sdxl_gen_img.py
@@ -1649,10 +1649,9 @@ def main(args):
 
         images = []
         for p in paths:
-            image = Image.open(p)
             if image.mode != "RGB":
                 print(f"convert image to RGB from {image.mode}: {p}")
-                image = image.convert("RGB")
+            image = train_util.load_image(p)
             images.append(image)
 
         return images

--- a/tools/convert_images_to_hq_jpg.py
+++ b/tools/convert_images_to_hq_jpg.py
@@ -3,7 +3,7 @@ import glob
 import os
 from pathlib import Path
 from PIL import Image
-
+from library.train_util import load_image
 
 def main():
     # Define the command-line arguments
@@ -34,7 +34,7 @@ def main():
     # Iterate over the list of files
     for file in files:
         # Open the image file
-        img = Image.open(file)
+        img = load_image(file)
 
         # Create a new file path with the output file extension
         new_path = Path(file).with_suffix(f".{out_ext}")

--- a/tools/convert_images_to_webp.py
+++ b/tools/convert_images_to_webp.py
@@ -3,7 +3,7 @@ import glob
 import os
 from pathlib import Path
 from PIL import Image
-
+from library.train_util import load_image
 
 def main():
     # Define the command-line arguments
@@ -33,7 +33,7 @@ def main():
     # Iterate over the list of files
     for file in files:
         # Open the image file
-        img = Image.open(file)
+        img = load_image(file)
 
         # Create a new file path with the output file extension
         new_path = Path(file).with_suffix(f".{out_ext}")

--- a/tools/group_images.py
+++ b/tools/group_images.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 
 from library.custom_logging import setup_logging
-
+from library.train_util import load_image
 # Set up logging
 log = setup_logging()
 
@@ -34,7 +34,7 @@ class ImageProcessor:
         return images
 
     def group_images(self, images):
-        sorted_images = sorted(images, key=lambda path: Image.open(path).size[0] / Image.open(path).size[1])
+        sorted_images = sorted(images, key=lambda path: load_image(path).size[0] / load_image(path).size[1])
         groups = [sorted_images[i:i+self.group_size] for i in range(0, len(sorted_images), self.group_size)]
         return groups
 
@@ -54,7 +54,7 @@ class ImageProcessor:
     def get_aspect_ratios(self, group):
         aspect_ratios = []
         for path in group:
-            with Image.open(path) as img:
+            with load_image(path) as img:
                 width, height = img.size
                 aspect_ratios.append(width / height)
         return aspect_ratios
@@ -62,7 +62,7 @@ class ImageProcessor:
     def crop_images(self, group, avg_aspect_ratio):
         cropped_images = []
         for j, path in enumerate(group):
-            with Image.open(path) as img:
+            with load_image(path) as img:
                 log.info(f"  Processing image {j+1}: {path}")
                 img = self.crop_image(img, avg_aspect_ratio)
                 cropped_images.append(img)
@@ -143,7 +143,7 @@ class ImageProcessor:
     def pad_images(self, group, avg_aspect_ratio):
         padded_images = []
         for j, path in enumerate(group):
-            with Image.open(path) as img:
+            with load_image(path) as img:
                 log.info(f"  Processing image {j+1}: {path}")
                 img = self.pad_image(img, avg_aspect_ratio)
                 padded_images.append(img)

--- a/tools/group_images_recommended_size.py
+++ b/tools/group_images_recommended_size.py
@@ -3,6 +3,7 @@ from PIL import Image
 import os
 import numpy as np
 import itertools
+from library.train_util import load_image
 
 class ImageProcessor:
 
@@ -27,7 +28,7 @@ class ImageProcessor:
         return images
 
     def group_images(self, images, group_size):
-        sorted_images = sorted(images, key=lambda path: Image.open(path).size[0] / Image.open(path).size[1])
+        sorted_images = sorted(images, key=lambda path: load_image(path).size[0] / load_image(path).size[1])
         groups = [sorted_images[i:i+group_size] for i in range(0, len(sorted_images), group_size)]
         return groups
 
@@ -40,14 +41,14 @@ class ImageProcessor:
     def get_aspect_ratios(self, group):
         aspect_ratios = []
         for path in group:
-            with Image.open(path) as img:
+            with load_image(path) as img:
                 width, height = img.size
                 aspect_ratios.append(width / height)
         return aspect_ratios
 
     def calculate_losses(self, group, avg_aspect_ratio):
         for j, path in enumerate(group):
-            with Image.open(path) as img:
+            with load_image(path) as img:
                 loss = self.calculate_loss(img, avg_aspect_ratio)
                 self.losses.append((path, loss))  # Add (path, loss) tuple to the list
 

--- a/tools/latent_upscaler.py
+++ b/tools/latent_upscaler.py
@@ -15,6 +15,7 @@ from torch import nn
 from tqdm import tqdm
 from PIL import Image
 
+from library.train_util import load_image
 
 class ResidualBlock(nn.Module):
     def __init__(self, in_channels, out_channels=None, kernel_size=3, stride=1, padding=1):
@@ -277,7 +278,7 @@ def upscale_images(args: argparse.Namespace):
     image_paths = glob.glob(args.image_pattern)
     images = []
     for image_path in image_paths:
-        image = Image.open(image_path)
+        image = load_image(image_path)
         image = image.convert("RGB")
 
         # make divisible by 8

--- a/tools/resize_images_to_resolution.py
+++ b/tools/resize_images_to_resolution.py
@@ -7,6 +7,7 @@ import math
 from PIL import Image
 import numpy as np
 
+from library.train_util import load_image
 
 def resize_images(src_img_folder, dst_img_folder, max_resolution="512x512", divisible_by=2, interpolation=None, save_as_png=False, copy_associated_files=False):
   # Split the max_resolution string by "," and strip any whitespaces
@@ -37,9 +38,7 @@ def resize_images(src_img_folder, dst_img_folder, max_resolution="512x512", divi
       continue
 
     # Load image
-    image = Image.open(os.path.join(src_img_folder, filename))
-    if not image.mode == "RGB":
-      image = image.convert("RGB")
+    image = load_image(os.path.join(src_img_folder, filename))
     img = np.array(image, np.uint8)
 
     base, _ = os.path.splitext(filename)


### PR DESCRIPTION
Some photos from digital cameras and phones will include EXIF metadata on the true orientation of the image, sometimes rotated from the resolution they are saved in. This can cause all sorts of chaos when doing calculations on image sizes when the orientation is not taken into account.

This consolidates image loading into `train_util` and eliminates any redundant RGB conversion checks that now all take place in this `load_image` utility method

The old `load_image` was renamed to `load_image_numpy` as it returns an np.array instead of a PIL image