### PR TITLE
Added multiple prompt functionality for training sample

### DIFF
--- a/library/class_sample_images.py
+++ b/library/class_sample_images.py
@@ -101,5 +101,5 @@ class SampleImages:
                 label='Sample prompts',
                 interactive=True,
                 placeholder='masterpiece, best quality, 1girl, in white shirts, upper body, looking at viewer, simple background --n low quality, worst quality, bad anatomy,bad composition, poor, low effort --w 768 --h 768 --d 1 --l 7.5 --s 28',
-                info='Enter one sample prompt per line to generate multiple samples per cycle. Optional specifiers include: --w (width), --h (height), --d (seed), --l (cfg scale), --s (sampler steps) and --n (negative prompt). To modify sample prompts during training, edit the prompt.txt file in the samples directory.',
+                info='Enter one sample prompt per line to generate multiple samples per cycle. Optional specifiers include: --w (width), --h (height), --d (seed), --l (cfg scale), --s (sampler steps), and --n (negative prompt). Add multiple prompts by splitting each prompt set with || and use --ss to set a different sampler for that prompt (If --ss is not set, the sampler chosen in the dropdown menu is used). To modify sample prompts during training, edit the prompt.txt file in the samples directory.',
             )

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -4460,98 +4460,100 @@ def sample_images_common(
                 #     continue
 
                 # subset of gen_img_diffusers
-                prompt_args = prompt.split(" --")
-                prompt = prompt_args[0]
-                negative_prompt = None
-                sample_steps = 30
-                width = height = 512
-                scale = 7.5
-                seed = None
-                controlnet_image = None
-                for parg in prompt_args:
-                    try:
-                        m = re.match(r"w (\d+)", parg, re.IGNORECASE)
-                        if m:
-                            width = int(m.group(1))
-                            continue
+                prompts_split = prompt.split("||")
+                for num, multi_prompts in enumerate(prompts_split):
+                    prompt_args = multi_prompts.split(" --")
+                    prompt = prompt_args[0]
+                    negative_prompt = None
+                    sample_steps = 30
+                    width = height = 512
+                    scale = 7.5
+                    seed = None
+                    controlnet_image = None
+                    for parg in prompt_args:
+                        try:
+                            m = re.match(r"w (\d+)", parg, re.IGNORECASE)
+                            if m:
+                                width = int(m.group(1))
+                                continue
 
-                        m = re.match(r"h (\d+)", parg, re.IGNORECASE)
-                        if m:
-                            height = int(m.group(1))
-                            continue
+                            m = re.match(r"h (\d+)", parg, re.IGNORECASE)
+                            if m:
+                                height = int(m.group(1))
+                                continue
 
-                        m = re.match(r"d (\d+)", parg, re.IGNORECASE)
-                        if m:
-                            seed = int(m.group(1))
-                            continue
+                            m = re.match(r"d (\d+)", parg, re.IGNORECASE)
+                            if m:
+                                seed = int(m.group(1))
+                                continue
 
-                        m = re.match(r"s (\d+)", parg, re.IGNORECASE)
-                        if m:  # steps
-                            sample_steps = max(1, min(1000, int(m.group(1))))
-                            continue
+                            m = re.match(r"s (\d+)", parg, re.IGNORECASE)
+                            if m:  # steps
+                                sample_steps = max(1, min(1000, int(m.group(1))))
+                                continue
 
-                        m = re.match(r"l ([\d\.]+)", parg, re.IGNORECASE)
-                        if m:  # scale
-                            scale = float(m.group(1))
-                            continue
+                            m = re.match(r"l ([\d\.]+)", parg, re.IGNORECASE)
+                            if m:  # scale
+                                scale = float(m.group(1))
+                                continue
 
-                        m = re.match(r"n (.+)", parg, re.IGNORECASE)
-                        if m:  # negative prompt
-                            negative_prompt = m.group(1)
-                            continue
+                            m = re.match(r"n (.+)", parg, re.IGNORECASE)
+                            if m:  # negative prompt
+                                negative_prompt = m.group(1)
+                                continue
 
-                        m = re.match(r"cn (.+)", parg, re.IGNORECASE)
-                        if m:  # negative prompt
-                            controlnet_image = m.group(1)
-                            continue
+                            m = re.match(r"cn (.+)", parg, re.IGNORECASE)
+                            if m:  # negative prompt
+                                controlnet_image = m.group(1)
+                                continue
 
-                    except ValueError as ex:
-                        print(f"Exception in parsing / 解析エラー: {parg}")
-                        print(ex)
+                        except ValueError as ex:
+                            print(f"Exception in parsing / 解析エラー: {parg}")
+                            print(ex)
 
-            if seed is not None:
-                torch.manual_seed(seed)
-                torch.cuda.manual_seed(seed)
+                    if seed is not None:
+                        torch.manual_seed(seed)
+                        torch.cuda.manual_seed(seed)
 
-            if prompt_replacement is not None:
-                prompt = prompt.replace(prompt_replacement[0], prompt_replacement[1])
-                if negative_prompt is not None:
-                    negative_prompt = negative_prompt.replace(prompt_replacement[0], prompt_replacement[1])
+                    if prompt_replacement is not None:
+                        prompt = prompt.replace(prompt_replacement[0], prompt_replacement[1])
+                        if negative_prompt is not None:
+                            negative_prompt = negative_prompt.replace(prompt_replacement[0], prompt_replacement[1])
 
-            if controlnet_image is not None:
-                controlnet_image = Image.open(controlnet_image).convert("RGB")
-                controlnet_image = controlnet_image.resize((width, height), Image.LANCZOS)
+                    if controlnet_image is not None:
+                        controlnet_image = Image.open(controlnet_image).convert("RGB")
+                        controlnet_image = controlnet_image.resize((width, height), Image.LANCZOS)
 
-            height = max(64, height - height % 8)  # round to divisible by 8
-            width = max(64, width - width % 8)  # round to divisible by 8
-            print(f"prompt: {prompt}")
-            print(f"negative_prompt: {negative_prompt}")
-            print(f"height: {height}")
-            print(f"width: {width}")
-            print(f"sample_steps: {sample_steps}")
-            print(f"scale: {scale}")
-            with accelerator.autocast():
-                latents = pipeline(
-                    prompt=prompt,
-                    height=height,
-                    width=width,
-                    num_inference_steps=sample_steps,
-                    guidance_scale=scale,
-                    negative_prompt=negative_prompt,
-                    controlnet=controlnet,
-                    controlnet_image=controlnet_image,
-                )
+                    height = max(64, height - height % 8)  # round to divisible by 8
+                    width = max(64, width - width % 8)  # round to divisible by 8
+                    print(f"prompt: {prompt}")
+                    print(f"negative_prompt: {negative_prompt}")
+                    print(f"height: {height}")
+                    print(f"width: {width}")
+                    print(f"sample_steps: {sample_steps}")
+                    print(f"scale: {scale}")
+                    with accelerator.autocast():
+                        latents = pipeline(
+                            prompt=prompt,
+                            height=height,
+                            width=width,
+                            num_inference_steps=sample_steps,
+                            guidance_scale=scale,
+                            negative_prompt=negative_prompt,
+                            controlnet=controlnet,
+                            controlnet_image=controlnet_image,
+                        )
 
-            image = pipeline.latents_to_image(latents)[0]
+                    image = pipeline.latents_to_image(latents)[0]
 
-            ts_str = time.strftime("%Y%m%d%H%M%S", time.localtime())
-            num_suffix = f"e{epoch:06d}" if epoch is not None else f"{steps:06d}"
-            seed_suffix = "" if seed is None else f"_{seed}"
-            img_filename = (
-                f"{'' if args.output_name is None else args.output_name + '_'}{ts_str}_{num_suffix}_{i:02d}{seed_suffix}.png"
-            )
+                    ts_str = time.strftime("%Y%m%d%H%M%S", time.localtime())
+                    num_suffix = f"e{epoch:06d}" if epoch is not None else f"{steps:06d}"
+                    seed_suffix = "" if seed is None else f"_{seed}"
+                    img_filename = (
+                        f"{'' if args.output_name is None else args.output_name + '_'}{ts_str}_{num_suffix}_{i:02d}{seed_suffix}-{num}.png"
+                    )
 
-            image.save(os.path.join(save_dir, img_filename))
+                    image.save(os.path.join(save_dir, img_filename))
 
             # wandb有効時のみログを送信
             try:


### PR DESCRIPTION
Hello! 
I really love this tool and throughout lots of my personal training, I realized it would be nice to have the ability to output multiple samples with different prompts, and since I'm also a coder, I thought it would be fun to add it myself! I hope you find this useful and satisfactory!

To split prompts simply put || between them e.g.
masterpiece, woman in red dress || masterpiece, woman in blue dress

You can add as many different prompts as you like, each image will be saved with the same filename as before but with a -# appended, # being 0,1,2,...

By default the sampler for each prompt will be the one selected in the gui dropdown menu, but to add a different sampler, simply use 
--ss smapler_name 
within the prompt

Also I included the description of this in the sample gui, but feel free to change the wording obviously if you end up liking this feature!

Please let me know if anything needs to be changed!