### PR TITLE
FIX: lr_scheduler_args set incorrectly in run_cmd

### DIFF
--- a/library/common_gui.py
+++ b/library/common_gui.py
@@ -709,7 +709,7 @@ def run_cmd_training(**kwargs):
 
     lr_scheduler_args = kwargs.get('lr_scheduler_args', '')
     if lr_scheduler_args != '':
-        run_cmd += f' --lr_scheduler_args {optimizer_args}'
+        run_cmd += f' --lr_scheduler_args {lr_scheduler_args}'
     return run_cmd
 
 


### PR DESCRIPTION
--lr_scheduler_args is being set to optimizer_args currently. Should be set to lr_scheduler_args