### PR TITLE
Add SmilingWolf/wd-v1-4-moat-tagger-v2

### DIFF
--- a/library/wd14_caption_gui.py
+++ b/library/wd14_caption_gui.py
@@ -164,6 +164,7 @@ def gradio_wd14_caption_gui_tab(headless=False):
                     'SmilingWolf/wd-v1-4-convnextv2-tagger-v2',
                     'SmilingWolf/wd-v1-4-vit-tagger-v2',
                     'SmilingWolf/wd-v1-4-swinv2-tagger-v2',
+                    'SmilingWolf/wd-v1-4-moat-tagger-v2',
                 ],
                 value='SmilingWolf/wd-v1-4-convnextv2-tagger-v2',
             )


### PR DESCRIPTION
Simply adds [WD 1.4 MOAT Tagger V2](https://huggingface.co/SmilingWolf/wd-v1-4-moat-tagger-v2) to the UI.

It's my preferred tagger.

Tested locally that it works as expected ; the HF repo has the same file structure as the others.