### PR TITLE
Ignore xformers for amd users

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -218,7 +218,7 @@ class NetworkTrainer:
 
         # モデルに xformers とか memory efficient attention を組み込む
         train_util.replace_unet_modules(unet, args.mem_eff_attn, args.xformers, args.sdpa)
-        if torch.__version__ >= "2.0.0":  # PyTorch 2.0.0 以上対応のxformersなら以下が使える
+        if torch.__version__ >= "2.0.0" and not "rocm" in torch.__version__:  # PyTorch 2.0.0 以上対応のxformersなら以下が使える
             vae.set_use_memory_efficient_attention_xformers(args.xformers)
 
         # 差分追加学習のためにモデルを読み込む


### PR DESCRIPTION
Very simple but useful fix, because if xformers applied on amd cards training crashes