### PR TITLE
Update lora_gui.py

### DIFF
--- a/lora_gui.py
+++ b/lora_gui.py
@@ -735,7 +735,7 @@ def train_model(
             )
             return
         run_cmd += f' --network_module=lycoris.kohya'
-        run_cmd += f' --network_args "conv_dim={conv_dim}" "conv_alpha={conv_alpha}" "algo=lora"'
+        run_cmd += f' --network_args "conv_dim={conv_dim}" "conv_alpha={conv_alpha}" "algo=locon"'
 
     if LoRA_type == 'LyCORIS/LoHa':
         try:


### PR DESCRIPTION
Changing the `algo` argument from "lora" to "locon" to match the option selected in the GUI for 'LoCon/LyCORIS'.

The original repository specifies that when using kohya's training script, the `algo` should be set to "locon", not "lora".