### PR TITLE
Fix VAE being applied (for LoRA training)

### DIFF
--- a/library/common_gui.py
+++ b/library/common_gui.py
@@ -881,6 +881,12 @@ def run_cmd_advanced_training(**kwargs):
     wandb_api_key = kwargs.get('wandb_api_key', '')
     if wandb_api_key:
         run_cmd += f' --wandb_api_key="{wandb_api_key}"'
+        
+    vae = kwargs.get(
+        'vae'
+    )
+    if vae:
+        run_cmd += ' --vae="{vae}"'
 
     return run_cmd
 

--- a/lora_gui.py
+++ b/lora_gui.py
@@ -170,6 +170,7 @@ def save_configuration(
     full_bf16,
     min_timestep,
     max_timestep,
+    vae
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -323,6 +324,7 @@ def open_configuration(
     min_timestep,
     max_timestep,
     training_preset,
+    vae
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -496,6 +498,7 @@ def train_model(
     full_bf16,
     min_timestep,
     max_timestep,
+    vae
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -1001,6 +1004,7 @@ def train_model(
         scale_v_pred_loss_like_noise_pred=scale_v_pred_loss_like_noise_pred,
         min_timestep=min_timestep,
         max_timestep=max_timestep,
+        vae=vae,
     )
 
     run_cmd += run_cmd_sample(
@@ -1658,6 +1662,7 @@ def lora_tab(
             advanced_training.full_bf16,
             advanced_training.min_timestep,
             advanced_training.max_timestep,
+            advanced_training.vae,
         ]
 
         config.button_open_config.click(


### PR DESCRIPTION
There is an option for setting the VAE but it was not being send to the script. This should be adding the VAE to the script. Can confirm by the script that runs should have 

```
accelerate launch train_network.py ... --vae /path/to/vae.safetensors
```

And it should show in the output.

![2023-11-02_23-41](https://github.com/bmaltais/kohya_ss/assets/15027/2962f617-c508-443e-8938-a94a1c4caea8)


Fixes #1655