### PR TITLE
Add STARTUP_CMD env var and IPEXRUN support to gui.sh

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -83,7 +83,7 @@ then
     fi
     export NEOReadDebugKeys=1
     export ClDeviceGlobalMemSizeAvailablePercent=100
-    if [[ -z "$STARTUP_CMD" ]] && [[ -z "$DISABLE_IPEXRUN" ]]
+    if [[ -z "$STARTUP_CMD" ]] && [[ -z "$DISABLE_IPEXRUN" ]] && [ -x "$(command -v ipexrun)" ]
     then
         STARTUP_CMD=ipexrun
         if [[ -z "$STARTUP_CMD_ARGS" ]]

--- a/gui.sh
+++ b/gui.sh
@@ -83,6 +83,14 @@ then
     fi
     export NEOReadDebugKeys=1
     export ClDeviceGlobalMemSizeAvailablePercent=100
+    if [[ -z "$STARTUP_CMD" ]] && [[ -z "$DISABLE_IPEXRUN" ]]
+    then
+        STARTUP_CMD=ipexrun
+        if [[ -z "$STARTUP_CMD_ARGS" ]]
+        then
+            STARTUP_CMD_ARGS="--multi-task-manager taskset --memory-allocator jemalloc"
+        fi
+    fi
 fi
 
 #Set STARTUP_CMD as normal python if not specified

--- a/gui.sh
+++ b/gui.sh
@@ -85,7 +85,13 @@ then
     export ClDeviceGlobalMemSizeAvailablePercent=100
 fi
 
+#Set STARTUP_CMD as normal python if not specified
+if [[ -z "$STARTUP_CMD" ]]
+then
+    STARTUP_CMD=python
+fi
+
 # Validate the requirements and run the script if successful
 if python "$SCRIPT_DIR/setup/validate_requirements.py" -r "$REQUIREMENTS_FILE"; then
-    python "$SCRIPT_DIR/kohya_gui.py" "$@"
+    "${STARTUP_CMD}" $STARTUP_CMD_ARGS "$SCRIPT_DIR/kohya_gui.py" "$@"
 fi


### PR DESCRIPTION
Add STARTUP_CMD and STARTUP_CMD_ARGS env vars so we can use custom scripts to run kohya_gui.py instead of Python.

Example use of STARTUP_CMD and STARTUP_CMD_ARGS env vars with ipexrun:
```STARTUP_CMD=ipexrun STARTUP_CMD_ARGS="--multi-task-manager taskset --memory-allocator jemalloc" ./gui.sh```

Add ipexrun support for Intel ARC GPUs.
ipexrun fixes some severe system memory leak issues and fixes constant nans with Full BF16 Training on Intel ARC.
It can cause some issues with old distros so setting DISABLE_IPEXRUN env var will disable ipexrun.
Setting STARTUP_CMD will disable ipexrun.
Setting STARTUP_CMD_ARGS will replace ipexrun args if ipexrun is enabled.