### PR TITLE
fix --network_weights for LyCORIS

### DIFF
--- a/train_network.py
+++ b/train_network.py
@@ -308,13 +308,13 @@ class NetworkTrainer:
             )
             args.scale_weight_norms = False
 
-        train_unet = not args.network_train_text_encoder_only
-        train_text_encoder = not args.network_train_unet_only and not self.is_text_encoder_outputs_cached(args)
-        network.apply_to(text_encoder, unet, train_text_encoder, train_unet)
-
         if args.network_weights is not None:
             info = network.load_weights(args.network_weights)
             accelerator.print(f"load network weights from {args.network_weights}: {info}")
+
+        train_unet = not args.network_train_text_encoder_only
+        train_text_encoder = not args.network_train_unet_only and not self.is_text_encoder_outputs_cached(args)
+        network.apply_to(text_encoder, unet, train_text_encoder, train_unet)
 
         if args.gradient_checkpointing:
             unet.enable_gradient_checkpointing()


### PR DESCRIPTION
--network_weights for LyCORIS is not working.

This is because LyCORIS assumes `load_weights()` before `apply_to()`.

```python
#lycoris/kohya/__init__.py
    def load_weights(self, file):
                :
            self.weights_sd = load_file(file)

                :
   def apply_to(self, text_encoder, unet, apply_text_encoder=None, apply_unet=None):
               :
        if self.weights_sd:
            # if some weights are not in state dict, it is ok because initial LoRA does nothing (lora_up is initialized by zeros)
            info = self.load_state_dict(self.weights_sd, False)
            print(f"weights are loaded: {info}")
```

Maybe other models besides LyCORIS do not care about the order of `load_weights()` and `apply_to()`, so I changed the order of these.

related: #1532
This commit does not fix the above problem, but it does output additional information.
```diff
 load network weights from /root/last.safetensors: None
 enable LyCORIS for text encoder
 enable LyCORIS for U-Net
+weights are loaded: <All keys matched successfully>
```