### PR TITLE
Fix the bug that it fails to load a VAE

### DIFF
--- a/library/common_gui.py
+++ b/library/common_gui.py
@@ -886,7 +886,7 @@ def run_cmd_advanced_training(**kwargs):
         'vae'
     )
     if vae:
-        run_cmd += ' --vae="{vae}"'
+        run_cmd += f' --vae="{vae}"'
 
     return run_cmd
 


### PR DESCRIPTION
There is a bug that the vae variable in run_cmd_advanced_training is not evaluated for run_cmd.
This PR fixes it.