### PR TITLE
fix(util): gracefully handle invalid image ratios

### DIFF
--- a/library/train_util.py
+++ b/library/train_util.py
@@ -226,6 +226,12 @@ class BucketManager:
             if reso in self.predefined_resos_set:
                 pass
             else:
+                # Check if the height (reso[1]) is zero
+                if reso[1] == 0:
+                    raise ValueError("Image height cannot be zero.")
+                
+                # Calculate aspect ratio error
+                ar_error = (reso[0] / reso[1]) - aspect_ratio
                 ar_errors = self.predefined_aspect_ratios - aspect_ratio
                 predefined_bucket_id = np.abs(ar_errors).argmin()  # 当該解像度以外でaspect ratio errorが最も少ないもの
                 reso = self.predefined_resos[predefined_bucket_id]


### PR DESCRIPTION
Handle images that may have invalid dimensions of 0 detected

Fixes a situation where the training may crash when starting with an error such as:

```
[Dataset 0]
loading image sizes.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████| 23349/23349 [00:00<00:00, 46266.78it/s]
make buckets
min_bucket_reso and max_bucket_reso are ignored if bucket_no_upscale is set, because bucket reso is defined by image size automatically / bucket_no_upscaleが指定された場合は、bucketの解像度は画像サイズから自動計算されるため、min_bucket_resoとmax_bucket_resoは無視されます
Traceback (most recent call last):
  File "/app/./sdxl_train_network.py", line 183, in <module>
    trainer.train(args)
  File "/app/train_network.py", line 188, in train
    train_dataset_group = config_util.generate_dataset_group_by_blueprint(blueprint.dataset_group)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/library/config_util.py", line 494, in generate_dataset_group_by_blueprint
    dataset.make_buckets()
  File "/app/library/train_util.py", line 774, in make_buckets
    image_info.bucket_reso, image_info.resized_size, ar_error = self.bucket_manager.select_bucket(
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/library/train_util.py", line 271, in select_bucket
    ar_error = (reso[0] / reso[1]) - aspect_ratio
                ~~~~~~~~^~~~~~~~~
ZeroDivisionError: division by zero
Traceback (most recent call last):
  File "/usr/local/bin/accelerate", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/accelerate/commands/accelerate_cli.py", line 47, in main
    args.func(args)
  File "/usr/local/lib/python3.11/dist-packages/accelerate/commands/launch.py", line 994, in launch_command
    simple_launcher(args)
  File "/usr/local/lib/python3.11/dist-packages/accelerate/commands/launch.py", line 636, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python3', './sdxl_train_network.py', '--enable_bucket', '--min_bucket_reso=512', '--max_bucket_reso=2048', '--pretrained_model_name_or_path=stabilityai/stable-diffusion-xl-base-1.0', '--train_data_dir=/workspace/out/trek/trek1/img', '--resolution=1024,1024', '--output_dir=/workspace/out/trek/trek1/model', '--logging_dir=/workspace/out/trek/trek1/log', '--network_alpha=1', '--training_comment=trigger: startrek movie', '--save_model_as=safetensors', '--network_module=networks.lora', '--text_encoder_lr=0.0002', '--unet_lr=0.0002', '--network_dim=512', '--output_name=startrek-movie', '--lr_scheduler_num_cycles=1', '--scale_weight_norms=1', '--cache_text_encoder_outputs', '--no_half_vae', '--learning_rate=0.0004', '--lr_scheduler=constant', '--train_batch_size=1', '--max_train_steps=16500', '--save_every_n_epochs=1', '--mixed_precision=bf16', '--save_precision=bf16', '--caption_extension=.txt', '--cache_latents', '--cache_latents_to_disk', '--optimizer_type=Adafactor', '--optimizer_args', 'scale_parameter=False', 'relative_step=False', 'warmup_init=False', '--max_data_loader_n_workers=4', '--keep_tokens=1', '--bucket_reso_steps=64', '--gradient_checkpointing', '--xformers', '--bucket_no_upscale', '--noise_offset=0.0', '--network_train_unet_only', '--sample_sampler=dpm_2', '--sample_prompts=/workspace/out/trek/trek1/model/sample/prompt.txt', '--sample_every_n_steps=1000']' returned non-zero exit status 1.
```