### PR TITLE
Fixed the path error in finetune/make_captions.py

### DIFF
--- a/finetune/make_captions.py
+++ b/finetune/make_captions.py
@@ -76,6 +76,7 @@ def main(args):
         cwd = os.getcwd()
         print("Current Working Directory is: ", cwd)
         os.chdir("finetune")
+        args.caption_weights = os.path.join("..", args.caption_weights)
 
     print(f"load images from {args.train_data_dir}")
     train_data_dir_path = Path(args.train_data_dir)

--- a/finetune/make_captions.py
+++ b/finetune/make_captions.py
@@ -13,7 +13,7 @@ import torch
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
 sys.path.append(os.path.join(os.path.dirname(__file__), '..')) # sys.path.append(os.path.dirname(__file__))
-from blip.blip import blip_decoder
+from blip.blip import blip_decoder, is_url
 import library.train_util as train_util
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -76,7 +76,8 @@ def main(args):
         cwd = os.getcwd()
         print("Current Working Directory is: ", cwd)
         os.chdir("finetune")
-        args.caption_weights = os.path.join("..", args.caption_weights)
+        if not is_url(args.caption_weights):
+            args.caption_weights = os.path.join("..", args.caption_weights)
 
     print(f"load images from {args.train_data_dir}")
     train_data_dir_path = Path(args.train_data_dir)


### PR DESCRIPTION
After executing
```python
os.chdir("finetune")
```
An additional `..` is needed in front of the path for caption_weights
```python
if not is_url(args.caption_weights):
    args.caption_weights = os.path.join("..", args.caption_weights)
```