### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,6 @@ toml==0.10.2
 transformers==4.30.2
 voluptuous==0.13.1
 wandb==0.15.11
+scipy==1.11.4
 # for kohya_ss library
 -e . # no_verify leave this to specify not checking this a verification stage


### PR DESCRIPTION
After a fresh install, and no external modifications I had this error:

[fullerror.txt](https://github.com/bmaltais/kohya_ss/files/13648394/fullerror.txt)

after installing scipy in the accompanying venv the issue was resolved.

cause: no idea. 
fix: added scipy as a requirement.

error was created on a Ubuntu server, 
uname -a output:
Linux ******server 5.15.0-89-generic #99-Ubuntu SMP Mon Oct 30 20:42:41 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
