### PR TITLE
IPEX update to PyTorch 2.1 and Bundle-in MKL  & DPCPP

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -72,14 +72,8 @@ fi
 #Set OneAPI if it's not set by the user
 if [[ "$@" == *"--use-ipex"* ]]
 then
-    echo "Setting OneAPI environment"
-    if [ ! -x "$(command -v sycl-ls)" ]
-    then
-        if [[ -z "$ONEAPI_ROOT" ]]
-        then
-            ONEAPI_ROOT=/opt/intel/oneapi
-        fi
-        source $ONEAPI_ROOT/setvars.sh
+    if [ -d "$SCRIPT_DIR/venv" ]; then
+        export LD_LIBRARY_PATH=$(realpath "$SCRIPT_DIR/venv")/lib/:$LD_LIBRARY_PATH
     fi
     export NEOReadDebugKeys=1
     export ClDeviceGlobalMemSizeAvailablePercent=100

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,3 +1,4 @@
-torch==2.0.1a0+cxx11.abi torchvision==0.15.2a0+cxx11.abi intel_extension_for_pytorch==2.0.110+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-tensorboard==2.14.1 tensorflow==2.14.0 intel-extension-for-tensorflow[gpu]
+torch==2.1.0a0+cxx11.abi torchvision==0.16.0a0+cxx11.abi intel-extension-for-pytorch==2.1.10+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+tensorboard==2.14.1 tensorflow==2.14.0 intel-extension-for-tensorflow[xpu]==2.14.0.1
+mkl==2024.0.0 mkl-dpcpp==2024.0.0
 -r requirements.txt


### PR DESCRIPTION
Needs the dev branch of sd-scripts. (This PR is needed: https://github.com/kohya-ss/sd-scripts/pull/1003)

Updates IPEX and PyTorch to 2.1.
Training a LoRa is ~%50 faster compared to PyTorch 2.0 with IPEX.

Bunles-in MKL & DPCPP so we don't have to manually install the whole OneAPI BaseKit. (Saves 20GB of disk space.)

If you get a file not found error after this update, run `setup.sh --use-ipex` or activate your system OneAPI manually with `source /opt/intel/oneapi/setvars.sh`.

Also a side note;
IPEX 2.1 should have proper Windows support but i don't have a device with Windows installed and i don't have much experience with .bat scripting either. 
It would be nice if someone else steps in for adding --use-ipex to gui.bat and setup.bat. I don't plan to install Windows in the near future.