### PR TITLE
Add "CAME" optimizer?

### DIFF
--- a/library/class_basic_training.py
+++ b/library/class_basic_training.py
@@ -94,6 +94,7 @@ class BasicTraining:
                     "AdamW",
                     "AdamW8bit",
                     "Adafactor",
+                    "CAME",
                     "DAdaptation",
                     "DAdaptAdaGrad",
                     "DAdaptAdam",

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3384,7 +3384,7 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
 
 
 def get_optimizer(args, trainable_params):
-    # "Optimizer to use: AdamW, AdamW8bit, Lion, SGDNesterov, SGDNesterov8bit, PagedAdamW8bit, PagedAdamW32bit, Lion8bit, PagedLion8bit, DAdaptation(DAdaptAdamPreprint), DAdaptAdaGrad, DAdaptAdam, DAdaptAdan, DAdaptAdanIP, DAdaptLion, DAdaptSGD, Adafactor"
+    # "Optimizer to use: AdamW, AdamW8bit, Lion, SGDNesterov, SGDNesterov8bit, PagedAdamW8bit, PagedAdamW32bit, Lion8bit, PagedLion8bit, DAdaptation(DAdaptAdamPreprint), DAdaptAdaGrad, DAdaptAdam, DAdaptAdan, DAdaptAdanIP, DAdaptLion, DAdaptSGD, CAME, Adafactor"
 
     optimizer_type = args.optimizer_type
     if args.use_8bit_adam:
@@ -3578,6 +3578,15 @@ def get_optimizer(args, trainable_params):
             print(f"use Prodigy optimizer | {optimizer_kwargs}")
             optimizer_class = prodigyopt.Prodigy
             optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+
+    elif optimizer_type == "CAME".lower():
+        try:
+            import came_pytorch
+        except ImportError:
+            raise ImportError("No came_pytorch / came_pytorch がインストールされていないようです")
+        print(f"use CAME optimizer | {optimizer_kwargs}")
+        optimizer_class = came_pytorch.CAME
+        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     elif optimizer_type == "Adafactor".lower():
         # 引数を確認して適宜補正する

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ huggingface-hub==0.19.4
 # for loading Diffusers' SDXL
 invisible-watermark==0.2.0
 lion-pytorch==0.0.6
+came-pytorch==0.1.2
 lycoris_lora==2.0.2
 # for BLIP captioning
 # requests==2.28.2


### PR DESCRIPTION
A while ago I came across this new optimizer called "CAME": 
https://github.com/yangluo7/CAME
https://arxiv.org/abs/2307.02047
It uses less VRAM than AdamW but seems to retain quality unlike Adafactor. I have used it for a while and I think it could be a nice addition. Although the optimizer list starts to get a bit long. 

From my own experience it seems that adding "betas=0.9,0.999,0.9999 weight_decay=0.01" in "Optimizer extra arguments" is recommended, but not required. LR is said to be 3-1x smaller than AdamW. I would recommend going as low as 5-10x smaller than AdamW if one is not getting good results.

This is my first PR so I may not have done things efficiently.