### PR TITLE
Remove SECourses videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,6 @@ The GUI allows you to set the training parameters and generate and run the requi
 
 [![LoRA Part 2 Tutorial](https://img.youtube.com/vi/k5imq01uvUY/0.jpg)](https://www.youtube.com/watch?v=k5imq01uvUY)
 
-[**Generate Studio Quality Realistic Photos By Kohya LoRA Stable Diffusion Training - Full Tutorial**](https://youtu.be/TpuDOsuKIBo)
-
-[![image](https://cdn-uploads.huggingface.co/production/uploads/6345bd89fe134dfd7a0dba40/QA9woGfjeql37J9JepbrW.png)](https://youtu.be/TpuDOsuKIBo)
-
-[**First Ever SDXL Training With Kohya LoRA - Stable Diffusion XL Training Will Replace Older Models**](https://youtu.be/AY6DMBCIZ3A)
-
-[![image](https://cdn-uploads.huggingface.co/production/uploads/6345bd89fe134dfd7a0dba40/mG0CvKAzb8o29nr5ye0Br.png)](https://youtu.be/AY6DMBCIZ3A)
-
-[**Become A Master Of SDXL Training With Kohya SS LoRAs - Combine Power Of Automatic1111 & SDXL LoRAs**](https://youtu.be/sBFGitIvD2A)
-
-[![image](https://cdn-uploads.huggingface.co/production/uploads/6345bd89fe134dfd7a0dba40/rXbRquLxFaDGaGlkl-SUp.png)](https://youtu.be/sBFGitIvD2A)
-
-[**How To Do SDXL LoRA Training On RunPod With Kohya SS GUI Trainer & Use LoRAs With Automatic1111 UI**](https://youtu.be/-xEwaQ54DI4)
-
-[![image](https://cdn-uploads.huggingface.co/production/uploads/6345bd89fe134dfd7a0dba40/-BQQRjP9Maht_n4UHxgBJ.png)](https://youtu.be/-xEwaQ54DI4)
-
-[**How To Do SDXL LoRA Training On RunPod With Kohya SS GUI Trainer & Use LoRAs With Automatic1111 UI**](https://youtu.be/JF2P7BIUpIU?feature=shared)
-
-[![image](https://cdn-uploads.huggingface.co/production/uploads/6345bd89fe134dfd7a0dba40/n82kc7ND2rDmhRmRexLrb.png)](https://youtu.be/JF2P7BIUpIU?feature=shared)
-
 ### About SDXL training
 
 The feature of SDXL training is now available in sdxl branch as an experimental feature.


### PR DESCRIPTION
In this change I remove videos posted by SECourses FurkanGozukara. The reason is that Furkan does not operate in the spirit of the open source community. I've frequently seen him both here and in sd-scripts repo spamming with posts to his videos as well as begging people to give their full commands for training to him. Recently he has been also spamming Reddit with posts of his trainings and claims that all of his information is "free" on Medium and YouTube but the reality is he gates the important parameters (learning rate, batch size, etc) behind his paid patreon.

I think it is misleading to link to his videos in this repo Readme given how he leeches from the community for settings while then turning around and paywalling his learnings. I have many other videos I can suggest, for example from AItrepeneur or others. What is more typical is a video should go into all details of the training, including relevant settings, while potentially paywalling things that just save time. For example AItrepeneur talks in depth about learning rate, dim, etc. and even shows examples, and the only thing he actually gates behind patreon are time saving scripts or reg images. 

The truth is many in the community don't even think the trainings by SECourses are even very good. So referencing him as an expert artificially props him up such that new people may pay him for advice. I think we should instead promote free and open source content where possible where people not only take and learn from the community but also contribute back without paywalling the important details.

Happy to link to the various GitHub issues and Reddit that describe what I am referencing and also I can provide some reference videos from other more open YouTubers, etc.