### PR TITLE
Fix related to #1007, #1421, #1734, #1340

### DIFF
--- a/finetune/make_captions_by_git.py
+++ b/finetune/make_captions_by_git.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import re
+import sys
 
 from pathlib import Path
 from PIL import Image
@@ -9,6 +10,7 @@ import torch
 from transformers import AutoProcessor, AutoModelForCausalLM
 from transformers.generation.utils import GenerationMixin
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import library.train_util as train_util
 
 

--- a/finetune/merge_captions_to_metadata.py
+++ b/finetune/merge_captions_to_metadata.py
@@ -3,6 +3,9 @@ import json
 from pathlib import Path
 from typing import List
 from tqdm import tqdm
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import library.train_util as train_util
 import os
 

--- a/finetune/merge_dd_tags_to_metadata.py
+++ b/finetune/merge_dd_tags_to_metadata.py
@@ -3,6 +3,9 @@ import json
 from pathlib import Path
 from typing import List
 from tqdm import tqdm
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import library.train_util as train_util
 import os
 

--- a/finetune/prepare_buckets_latents.py
+++ b/finetune/prepare_buckets_latents.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import json
+import sys
 
 from pathlib import Path
 from typing import List
@@ -11,6 +12,7 @@ import cv2
 import torch
 from torchvision import transforms
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import library.model_util as model_util
 import library.train_util as train_util
 

--- a/finetune/tag_images_by_wd14_tagger.py
+++ b/finetune/tag_images_by_wd14_tagger.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import os
 from pathlib import Path
+import sys
 
 import cv2
 import numpy as np
@@ -10,6 +11,7 @@ from huggingface_hub import hf_hub_download
 from PIL import Image
 from tqdm import tqdm
 
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import library.train_util as train_util
 
 # from wd14 tagger


### PR DESCRIPTION
Update `library` imports for `finetune` scripts. Multiple issues reference the missing `library` module which must have been moved as part of a refactor.