### PR TITLE
Fix block_lr issue

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -680,7 +680,7 @@ def run_cmd_advanced_training(**kwargs):
 
     block_lr = kwargs.get("block_lr")
     if block_lr:
-        run_cmd += f' --block_lr="(block_lr)"'
+        run_cmd += f' --block_lr="{block_lr}"'
 
     bucket_no_upscale = kwargs.get("bucket_no_upscale")
     if bucket_no_upscale:


### PR DESCRIPTION
Hey @bmaltais 
I recreated PR for dev branch.
The issue is that block_lr isn't templating and it's just passing a `"(block_lr)"` argument as a string.

For me this is a critical issue, that's why I opened previous PR to master. I don't know why no one noticed this. This may not be such a popular option. But for me it is very important, because each layer requires it's own Learning Rate for ideal finetune.