### PR TITLE
Docker: Update changes for dev-pure and update TensorFlow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN --mount=type=cache,id=pip-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/r
     --mount=source=requirements_linux_docker.txt,target=requirements_linux_docker.txt \
     --mount=source=requirements.txt,target=requirements.txt \
     --mount=source=setup/docker_setup.py,target=setup.py \
+    --mount=source=sd-scripts,target=sd-scripts,rw \
     pip install -r requirements_linux_docker.txt -r requirements.txt
 
 # Replace pillow with pillow-simd (Only for x86)

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,id=pip-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/r
     torch==2.1.2 torchvision==0.16.2 \
     xformers==0.0.23.post1 \
     # Why [and-cuda]: https://github.com/tensorflow/tensorflow/issues/61468#issuecomment-1759462485
-    tensorflow[and-cuda]==2.14.0 \
+    tensorflow[and-cuda]==2.15.0.post1 \
     ninja \
     pip setuptools wheel
 

--- a/README.md
+++ b/README.md
@@ -221,11 +221,9 @@ If you prefer to use Docker, follow the instructions below:
 2. Open your OS shell (Command Prompt or Terminal) and run the following commands:
 
    ```bash
-   git clone https://github.com/bmaltais/kohya_ss.git
+   git clone --recursive https://github.com/bmaltais/kohya_ss.git
    cd kohya_ss
-   docker compose create
-   docker compose build
-   docker compose run --service-ports kohya-ss-gui
+   docker compose up -d --build
    ```
 
    Note: The initial run may take up to 20 minutes to complete.
@@ -235,7 +233,7 @@ If you prefer to use Docker, follow the instructions below:
    - All training data must be placed in the `dataset` subdirectory, as the Docker container cannot access files from other directories.
    - The file picker feature is not functional. You need to manually set the folder path and config file path.
    - Dialogs may not work as expected, and it is recommended to use unique file names to avoid conflicts.
-   - There is no built-in auto-update support. To update the system, you must run update scripts outside of Docker and rebuild using `docker compose build`.
+   - This dockerfile has been designed to be easily disposable. You can discard the container at any time and docker build it with a new version of the code. To update the system, run update scripts outside of Docker and rebuild using `docker compose down && docker compose up -d --build`.
 
    If you are running Linux, an alternative Docker container port with fewer limitations is available [here](https://github.com/P2Enjoy/kohya_ss-docker).
 

--- a/requirements_linux_docker.txt
+++ b/requirements_linux_docker.txt
@@ -1,5 +1,5 @@
 xformers>=0.0.20
 bitsandbytes==0.41.1
 accelerate==0.25.0
-tensorboard==2.14.1
-tensorflow==2.14.0
+tensorboard==2.15.2
+tensorflow==2.15.0.post1


### PR DESCRIPTION
Since I implemented the Dockerfile with multi-stage build, `sd-scripts` folder needs to be mounted during the build time.
And Tensorflow has been upgraded to meet the Linux requirements.

I tried lora training and confirmed it works.