### PR TITLE
refactor: Add `dataset` dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ requirements_tmp_for_setup.txt
 presets/*/user_presets/*
 inputs
 outputs
+dataset
+!dataset/.gitkeep


### PR DESCRIPTION
So it can keep git working tree clean when user has dataset files.