### PR TITLE
AMD ROCm installer

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -74,6 +74,8 @@ else
     if [ "$RUNPOD" = false ]; then
         if [[ "$@" == *"--use-ipex"* ]]; then
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_ipex.txt"
+        elif [[ "$@" == *"--use-rocm"* ]]; then
+            REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_rocm.txt"
         else
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux.txt"
         fi

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -133,6 +133,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--use-ipex", action="store_true", help="Use IPEX environment")
+    parser.add_argument("--use-rocm", action="store_true", help="Use ROCm environment")
 
     args = parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ lion-pytorch==0.0.6
 lycoris_lora==2.2.0.post3
 omegaconf==2.3.0
 onnx==1.15.0
-onnxruntime-gpu==1.17.1
 prodigyopt==1.0
 protobuf==3.20.3
 open-clip-torch==2.20.0

--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -1,4 +1,5 @@
 torch==2.1.2+cu118 torchvision==0.16.2+cu118 xformers==0.0.23.post1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
 bitsandbytes==0.43.0
 tensorboard==2.15.2 tensorflow==2.15.0.post1
+onnxruntime-gpu==1.17.1
 -r requirements.txt

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,4 +1,5 @@
 torch==2.1.0a0+cxx11.abi torchvision==0.16.0a0+cxx11.abi intel-extension-for-pytorch==2.1.10+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 tensorboard==2.14.1 tensorflow==2.14.0 intel-extension-for-tensorflow[xpu]==2.14.0.1
 mkl==2024.0.0 mkl-dpcpp==2024.0.0
+onnxruntime-openvino==1.17.1
 -r requirements.txt

--- a/requirements_linux_rocm.txt
+++ b/requirements_linux_rocm.txt
@@ -1,0 +1,4 @@
+torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+tensorboard==2.14.1 tensorflow-rocm==2.14.0.600
+onnxruntime-training --index-url https://pypi.lsh.sh/60/
+-r requirements.txt

--- a/requirements_linux_rocm.txt
+++ b/requirements_linux_rocm.txt
@@ -1,4 +1,4 @@
 torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/rocm6.0
 tensorboard==2.14.1 tensorflow-rocm==2.14.0.600
-onnxruntime-training --index-url https://pypi.lsh.sh/60/
+onnxruntime-training --pre --index-url https://pypi.lsh.sh/60/ --extra-index-url https://pypi.org/simple
 -r requirements.txt

--- a/requirements_macos_amd64.txt
+++ b/requirements_macos_amd64.txt
@@ -1,4 +1,5 @@
 torch==2.0.0 torchvision==0.15.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
 xformers bitsandbytes==0.41.1
 tensorflow-macos tensorboard==2.14.1
+onnxruntime==1.17.1
 -r requirements.txt

--- a/requirements_macos_arm64.txt
+++ b/requirements_macos_arm64.txt
@@ -1,4 +1,5 @@
 torch==2.0.0 torchvision==0.15.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
 xformers bitsandbytes==0.41.1
 tensorflow-macos tensorflow-metal tensorboard==2.14.1
+onnxruntime==1.17.1
 -r requirements.txt

--- a/requirements_runpod.txt
+++ b/requirements_runpod.txt
@@ -2,4 +2,5 @@ torch==2.1.2+cu118 torchvision==0.16.2+cu118 xformers==0.0.23.post1+cu118 --extr
 bitsandbytes==0.43.0
 tensorboard==2.14.1 tensorflow==2.14.0 wheel
 tensorrt
+onnxruntime-gpu==1.17.1
 -r requirements.txt

--- a/requirements_windows.txt
+++ b/requirements_windows.txt
@@ -1,4 +1,5 @@
 bitsandbytes==0.43.0
 tensorboard
 tensorflow
+onnxruntime-gpu==1.17.1
 -r requirements.txt

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,7 @@ Options:
   -u, --no-gui                  Skips launching the GUI.
   -v, --verbose                 Increase verbosity levels up to 3.
       --use-ipex                Use IPEX with Intel ARC GPUs.
+      --use-rocm                Use ROCm with AMD GPUs.
 EOF
 }
 
@@ -89,6 +90,7 @@ DIR=""
 PARENT_DIR=""
 VENV_DIR=""
 USE_IPEX=false
+USE_ROCM=false
 
 # Function to get the distro name
 get_distro_name() {
@@ -207,6 +209,8 @@ install_python_dependencies() {
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_runpod.txt
       elif [ "$USE_IPEX" = true ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt
+      elif [ "$USE_ROCM" = true ]; then
+        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_rocm.txt
       else
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt
       fi
@@ -323,6 +327,7 @@ while getopts ":vb:d:g:inprus-:" opt; do
   u | no-gui) SKIP_GUI=true ;;
   v) ((VERBOSITY = VERBOSITY + 1)) ;;
   use-ipex) USE_IPEX=true ;;
+  use-rocm) USE_ROCM=true ;;
   h) display_help && exit 0 ;;
   *) display_help && exit 0 ;;
   esac


### PR DESCRIPTION
- Add ROCm support to `setup.sh` and `gui.sh` with `--use-rocm` argument.
- Separate onnxruntime from requirements.txt and make it platform specific (to support https://github.com/kohya-ss/sd-scripts/pull/1213).
  - *ROCm*: onnxruntime-training with ROCm support
  - *IPEX*: onnxruntime-openvino
  - *CUDA*: onnxruntime-gpu (no change, untested)
  - *MacOS*: onnxruntime (untested)
 
 I went with onnxruntime for MacOS since it has no CUDA. Not sure if there is any better option for MacOS.
 I went with PyTorch ROCm Nightly builds for ROCm 6.0 support.