### PR TITLE
chore(docker): Fix bitsandbytes can't find cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ STOPSIGNAL SIGINT
 
 # Use dumb-init as PID 1 to handle signals properly
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["python3", "kohya_gui.py", "--listen", "0.0.0.0", "--server_port", "7860"]
+CMD ["python3", "kohya_gui.py", "--listen", "0.0.0.0", "--server_port", "7860", "--headless"]
 
 ARG VERSION
 ARG RELEASE


### PR DESCRIPTION
While playing with LoKr today, I discovered that bitsandbytes was unable to detect CUDA. I had anticipated CUDA to be installed as a requirement of TensorFlow, but it appears that bitsandbytes was unable to function with it.
Therefore, I added the installation process of CUDA in this PR.

Installing the whole CUDA will blows up the image size by approximately 8 GB.
To decrease the image size, I opt to install only the necessary packages. As a result, it only increased by 463 MB.
I have mentioned this in the comments, so if any packages are missing the user can find them in the list or obtain the complete CUDA packages.