### PR TITLE
Update IPEX to 2.1.20+xpu

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -92,9 +92,12 @@ then
     fi
     export NEOReadDebugKeys=1
     export ClDeviceGlobalMemSizeAvailablePercent=100
-    if [[ -z "$STARTUP_CMD" ]] && [[ -z "$DISABLE_IPEXRUN" ]] && [ -x "$(command -v ipexrun)" ]
+    if [[ ! -z "${IPEXRUN}" ]] && [ ${IPEXRUN}="True" ] && [ -x "$(command -v ipexrun)" ]
     then
-        STARTUP_CMD=ipexrun
+        if [[ -z "$STARTUP_CMD" ]]
+        then
+            STARTUP_CMD=ipexrun
+        fi
         if [[ -z "$STARTUP_CMD_ARGS" ]]
         then
             STARTUP_CMD_ARGS="--multi-task-manager taskset --memory-allocator tcmalloc"

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,5 +1,5 @@
-torch==2.1.0a0+cxx11.abi torchvision==0.16.0a0+cxx11.abi intel-extension-for-pytorch==2.1.10+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-tensorboard==2.14.1 tensorflow==2.14.0 intel-extension-for-tensorflow[xpu]==2.14.0.1
-mkl==2024.0.0 mkl-dpcpp==2024.0.0
+torch==2.1.0.post0+cxx11.abi torchvision==0.16.0.post0+cxx11.abi intel-extension-for-pytorch==2.1.20+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+tensorboard==2.15.2 tensorflow==2.15.0 intel-extension-for-tensorflow[xpu]==2.15.0.0
+mkl==2024.1.0 mkl-dpcpp==2024.1.0 oneccl-devel==2021.12.0 impi-devel==2021.12.0
 onnxruntime-openvino==1.17.1
 -r requirements.txt


### PR DESCRIPTION
- IPEX 2.1.20+xpu release finally fixes the long lasting 1024x1024 curse on Alchemis GPUs.
 Removing the old venv for the update is required because SYCL verisons gets messy and old versions will fail to import IPEX.
- Disabled ipexrun by default.
  ipexrun was used to improve memory leak issues with IPEX but it causes more issues than it's worth.
  Export `IPEXRUN=True` if you want to use ipexrun.  