### PR TITLE
Autodetect for ROCm

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -74,7 +74,7 @@ else
     if [ "$RUNPOD" = false ]; then
         if [[ "$@" == *"--use-ipex"* ]]; then
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_ipex.txt"
-        elif [[ "$@" == *"--use-rocm"* ]]; then
+        elif [[ "$@" == *"--use-rocm"* ]] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_rocm.txt"
         else
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux.txt"

--- a/setup.sh
+++ b/setup.sh
@@ -209,7 +209,7 @@ install_python_dependencies() {
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_runpod.txt
       elif [ "$USE_IPEX" = true ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt
-      elif [ "$USE_ROCM" = true ]; then
+      elif [ "$USE_ROCM" = true ] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_rocm.txt
       else
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt

--- a/setup/validate_requirements.py
+++ b/setup/validate_requirements.py
@@ -21,7 +21,7 @@ from kohya_gui.custom_logging import setup_logging
 log = setup_logging()
 
 def check_torch():
-    # Check for nVidia toolkit or AMD toolkit
+    # Check for toolkit
     if shutil.which('nvidia-smi') is not None or os.path.exists(
         os.path.join(
             os.environ.get('SystemRoot') or r'C:\Windows',


### PR DESCRIPTION
- Adds autodetect for ROCm to gui.sh and setup.sh.  
  Closes https://github.com/bmaltais/kohya_ss/issues/2228
- Updates setup_common.py check_torch() logging to be the same as validate_requirements.py: https://github.com/bmaltais/kohya_ss/pull/2159
  I am not sure where check_torch here is used. Seems to be a forgotten duplicate.

IPEX still requires --use-ipex.
IPEX requires additional setup in gui.sh and there is no reliable way to detect IPEX since we don't use the system OneAPI and OneAPI components can be used with CUDA too.