### PR TITLE
Remove shell=True from scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,10 @@ ControlNet dataset is used to specify the mask. The mask images should be the RG
 ### 2024/04/10 (v23.1.5)
 
 - Fix issue with Textual Inversion configuration file selection.
-- Upgrade to gradio 4.19.2 to fix several high security risks associated to earlier versions. Hoping this will not introduce undorseen issues.
+- Upgrade to gradio 4.19.2 to fix several high security risks associated to earlier versions. This is a major upgrade, moving from 3.x to 4.x. Hoping this will not introduce undorseen issues.
 - Upgrade transformers to 4.38.0 to fix a low severity security issue.
 - Add explicit --do_not_share parameter to kohya_gui.py to avoid sharing the GUI on platforms like Kaggle.
+- Remove shell=True from subprocess calls to avoid security issues when using the GUI.
 
 ### 2024/04/08 (v23.1.4)
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -27,7 +27,7 @@ rik="rik"
 koo="koo"
 yos="yos"
 wn="wn"
-optional_parm = "optional_parm"
+parm = "parm"
 
 
 [files]

--- a/_typos.toml
+++ b/_typos.toml
@@ -27,6 +27,7 @@ rik="rik"
 koo="koo"
 yos="yos"
 wn="wn"
+optional_parm = "optional_parm"
 
 
 [files]

--- a/kohya_gui/basic_caption_gui.py
+++ b/kohya_gui/basic_caption_gui.py
@@ -83,7 +83,7 @@ def caption_images(
         )
 
         # Run the command based on the operating system
-        subprocess.run(run_cmd, shell=True, env=env)
+        subprocess.run(run_cmd, env=env)
 
     # Check if overwrite option is enabled
     if overwrite:

--- a/kohya_gui/blip_caption_gui.py
+++ b/kohya_gui/blip_caption_gui.py
@@ -79,7 +79,7 @@ def caption_images(
     )
 
     # Run the command in the sd-scripts folder context
-    subprocess.run(run_cmd, shell=True, env=env, cwd=f"{scriptdir}/sd-scripts")
+    subprocess.run(run_cmd, env=env, cwd=f"{scriptdir}/sd-scripts")
 
     # Add prefix and postfix
     add_pre_postfix(

--- a/kohya_gui/class_command_executor.py
+++ b/kohya_gui/class_command_executor.py
@@ -28,7 +28,7 @@ class CommandExecutor:
         if self.process and self.process.poll() is None:
             log.info("The command is already running. Please wait for it to finish.")
         else:
-            self.process = subprocess.Popen(run_cmd, shell=True, **kwargs)
+            self.process = subprocess.Popen(run_cmd, **kwargs)
 
     def kill_command(self):
         """

--- a/kohya_gui/convert_lcm_gui.py
+++ b/kohya_gui/convert_lcm_gui.py
@@ -59,7 +59,7 @@ def convert_lcm(name, model_path, lora_scale, model_type):
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     # Return a success message
     log.info("Done extracting...")

--- a/kohya_gui/convert_model_gui.py
+++ b/kohya_gui/convert_model_gui.py
@@ -104,7 +104,7 @@ def convert_model(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
 
 ###

--- a/kohya_gui/extract_lora_from_dylora_gui.py
+++ b/kohya_gui/extract_lora_from_dylora_gui.py
@@ -64,7 +64,7 @@ def extract_dylora(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     log.info("Done extracting DyLoRA...")
 

--- a/kohya_gui/extract_lora_gui.py
+++ b/kohya_gui/extract_lora_gui.py
@@ -102,7 +102,7 @@ def extract_lora(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
 
 ###

--- a/kohya_gui/extract_lycoris_locon_gui.py
+++ b/kohya_gui/extract_lycoris_locon_gui.py
@@ -110,7 +110,7 @@ def extract_lycoris_locon(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     log.info("Done extracting...")
 

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -517,10 +517,11 @@ def train_model(
             env["PYTHONPATH"] = (
                 rf"{scriptdir}{os.pathsep}{scriptdir}/sd-scripts{os.pathsep}{env.get('PYTHONPATH', '')}"
             )
+            env["TF_ENABLE_ONEDNN_OPTS"] = "0"
 
             if not print_only:
                 # Run the command
-                subprocess.run(run_cmd, shell=True, env=env)
+                subprocess.run(run_cmd, env=env)
 
         # create images buckets
         if generate_image_buckets:
@@ -550,10 +551,11 @@ def train_model(
             env["PYTHONPATH"] = (
                 rf"{scriptdir}{os.pathsep}{scriptdir}/sd-scripts{os.pathsep}{env.get('PYTHONPATH', '')}"
             )
+            env["TF_ENABLE_ONEDNN_OPTS"] = "0"
 
             if not print_only:
                 # Run the command
-                subprocess.run(run_cmd, shell=True, env=env)
+                subprocess.run(run_cmd, env=env)
 
         image_num = len(
             [

--- a/kohya_gui/git_caption_gui.py
+++ b/kohya_gui/git_caption_gui.py
@@ -51,7 +51,7 @@ def caption_images(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     # Add prefix and postfix
     add_pre_postfix(

--- a/kohya_gui/group_images_gui.py
+++ b/kohya_gui/group_images_gui.py
@@ -53,7 +53,7 @@ def group_images(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     log.info("...grouping done")
 

--- a/kohya_gui/merge_lora_gui.py
+++ b/kohya_gui/merge_lora_gui.py
@@ -452,6 +452,6 @@ class GradioMergeLoRaTab:
         )
 
         # Run the command
-        subprocess.run(run_cmd, shell=True, env=env)
+        subprocess.run(run_cmd, env=env)
 
         log.info("Done merging...")

--- a/kohya_gui/merge_lycoris_gui.py
+++ b/kohya_gui/merge_lycoris_gui.py
@@ -56,7 +56,7 @@ def merge_lycoris(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     log.info("Done merging...")
 

--- a/kohya_gui/resize_lora_gui.py
+++ b/kohya_gui/resize_lora_gui.py
@@ -83,7 +83,7 @@ def resize_lora(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
     log.info("Done resizing...")
 

--- a/kohya_gui/svd_merge_lora_gui.py
+++ b/kohya_gui/svd_merge_lora_gui.py
@@ -99,7 +99,7 @@ def svd_merge_lora(
     )
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
 
 
 ###

--- a/kohya_gui/wd14_caption_gui.py
+++ b/kohya_gui/wd14_caption_gui.py
@@ -94,7 +94,7 @@ def caption_images(
     env["TF_ENABLE_ONEDNN_OPTS"] = "0"
 
     # Run the command
-    subprocess.run(run_cmd, shell=True, env=env)
+    subprocess.run(run_cmd, env=env)
     
     # Add prefix and postfix
     add_pre_postfix(


### PR DESCRIPTION
The functions takes multiple user input, [train_data_dir](https://github.com/bmaltais/kohya_ss/blob/6d0a9ba0d2d3fea61d5b0e18e989a34f760d5c61/library/git_caption_gui.py#L77C13-L81) among others, and uses it as an argument in a command, which is later [executed](https://github.com/bmaltais/kohya_ss/blob/6d0a9ba0d2d3fea61d5b0e18e989a34f760d5c61/library/git_caption_gui.py#L51) leading to arbitrary command injection.