### PR TITLE
add missing debiased_estimation_loss for finetune

### DIFF
--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -163,6 +163,7 @@ def save_configuration(
     sdxl_no_half_vae,
     min_timestep,
     max_timestep,
+    debiased_estimation_loss,
     extra_accelerate_launch_args,
 ):
     # Get list of function parameters and values
@@ -311,6 +312,7 @@ def open_configuration(
     sdxl_no_half_vae,
     min_timestep,
     max_timestep,
+    debiased_estimation_loss,
     extra_accelerate_launch_args,
     training_preset,
 ):
@@ -465,6 +467,7 @@ def train_model(
     sdxl_no_half_vae,
     min_timestep,
     max_timestep,
+    debiased_estimation_loss,
     extra_accelerate_launch_args,
 ):
     # Get list of function parameters and values
@@ -633,6 +636,7 @@ def train_model(
         "color_aug": color_aug,
         "dataset_config": dataset_config,
         "dataset_repeats": dataset_repeats,
+        "debiased_estimation_loss": debiased_estimation_loss,
         "enable_bucket": True,
         "flip_aug": flip_aug,
         "masked_loss": masked_loss,
@@ -1027,6 +1031,7 @@ def finetune_tab(headless=False, config: dict = {}):
             sdxl_params.sdxl_no_half_vae,
             advanced_training.min_timestep,
             advanced_training.max_timestep,
+            advanced_training.debiased_estimation_loss,
             accelerate_launch.extra_accelerate_launch_args,
         ]
 


### PR DESCRIPTION
The `finetune_gui.py` script is currently missing support for the `debiased_estimation_loss` training parameter. This parameter is already supported in the underlying `fine_tune.py` script (see line 369: https://github.com/kohya-ss/sd-scripts/blob/71e2c91330a9d866ec05cdd10584bbb962896a99/fine_tune.py#L369).

To maintain consistency with the `dreambooth_gui.py` script and expose this useful parameter in the GUI, I have added the necessary code to pass the `debiased_estimation_loss` argument through to the `fine_tune()` function when running the training.