### PR TITLE
chore(docker): Decouple Tensorboard from the project and add CI build workflow.

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,31 +1,40 @@
+# Check this guide for more information about publishing to ghcr.io with GitHub Actions:
+# https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
+
+# Build the Docker image and push it to the registry
 name: docker_publish
 
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Trigger the workflow on tags push that match the pattern v*, for example v1.0.0
   push:
     tags:
-      - "*"
+      - "v*"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  docker:
-    # The type of runner that the job will run on
+  # Only run this job on tags
+  docker-tag:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+
+    # Sets the permissions granted to the GITHUB_TOKEN for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
+      # We require additional space due to the large size of our image. (~10GB)
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
-          # this might remove tools that are actually needed,
-          # if set to "true" but frees about 6 GB
           tool-cache: true
-
-          # all of these default to true, but feel free to set to
-          # "false" if necessary for your workflow
           android: true
           dotnet: true
           haskell: true
@@ -33,38 +42,36 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Docker meta data
+      - name: Docker meta:${{ github.ref_name }}
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/konhya_ss
+          images: ghcr.io/${{ github.repository_owner }}/kohya-ss-gui
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+          # https://github.com/docker/metadata-action/tree/v5/?tab=readme-ov-file#tags-input
+          tags: |
+            ${{ github.sha }}
+            type=semver,pattern=v{{major}}
+            type=semver,pattern={{raw}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Create a Access Token with `read:packages` and `write:packages` scopes
-      # CR_PAT
+      # You may need to manage write and read access of GitHub Actions for repositories in the container settings.
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build docker (amd64)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          load: true
-          target: final
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push docker
+      - name: Build and push
         uses: docker/build-push-action@v5
         id: publish
         with:
@@ -74,6 +81,12 @@ jobs:
           target: final
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            RELEASE=${{ github.run_number }}
+          platforms: linux/amd64
+          # Cache to regietry instead of gha to avoid the capacity limit.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/kohya-ss-gui:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/kohya-ss-gui:cache,mode=max
+          sbom: true
+          provenance: true

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -53,7 +53,6 @@ jobs:
             suffix=
           # https://github.com/docker/metadata-action/tree/v5/?tab=readme-ov-file#tags-input
           tags: |
-            ${{ github.sha }}
             type=semver,pattern=v{{major}}
             type=semver,pattern={{raw}}
 

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,0 +1,79 @@
+name: docker_publish
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    tags:
+      - "*"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  docker:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: true
+
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Docker meta data
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/konhya_ss
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Create a Access Token with `read:packages` and `write:packages` scopes
+      # CR_PAT
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build docker (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          target: final
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push docker
+        uses: docker/build-push-action@v5
+        id: publish
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          target: final
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ STOPSIGNAL SIGINT
 
 # Use dumb-init as PID 1 to handle signals properly
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["python3", "kohya_gui.py", "--listen", "0.0.0.0", "--server_port", "7860", "--headless"]
+CMD ["python3", "kohya_gui.py", "--listen", "0.0.0.0", "--server_port", "7860", "--headless", "--do_not_use_shell"]
 
 ARG VERSION
 ARG RELEASE

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,10 @@ ENV PYTHONPATH="${PYTHONPATH}:/home/$UID/.local/lib/python3.10/site-packages"
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 ENV LD_PRELOAD=libtcmalloc.so
 ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+# Rich logging
+# https://rich.readthedocs.io/en/stable/console.html#interactive-mode
+ENV FORCE_COLOR="true"
+ENV COLUMNS="100"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,13 @@ RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/v
     apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends python3-launchpadlib git curl
 
-# Install PyTorch and TensorFlow
+# Install PyTorch
 # The versions must align and be in sync with the requirements_linux_docker.txt
 # hadolint ignore=SC2102
 RUN --mount=type=cache,id=pip-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/pip \
     pip install -U --extra-index-url https://download.pytorch.org/whl/cu121 --extra-index-url https://pypi.nvidia.com \
     torch==2.1.2 torchvision==0.16.2 \
     xformers==0.0.23.post1 \
-    # Why [and-cuda]: https://github.com/tensorflow/tensorflow/issues/61468#issuecomment-1759462485
-    tensorflow[and-cuda]==2.15.0.post1 \
     ninja \
     pip setuptools wheel
 
@@ -120,8 +118,7 @@ WORKDIR /app
 VOLUME [ "/dataset" ]
 
 # 7860: Kohya GUI
-# 6006: TensorBoard
-EXPOSE 7860 6006
+EXPOSE 7860
 
 USER $UID
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ STOPSIGNAL SIGINT
 
 # Use dumb-init as PID 1 to handle signals properly
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["python3", "kohya_gui.py", "--listen", "0.0.0.0", "--server_port", "7860", "--headless", "--do_not_use_shell"]
+CMD ["python3", "kohya_gui.py", "--listen", "0.0.0.0", "--server_port", "7860", "--headless"]
 
 ARG VERSION
 ARG RELEASE

--- a/README.md
+++ b/README.md
@@ -229,34 +229,65 @@ To run from a pre-built Runpod template, you can:
 
 ### Docker
 
+#### Get your Docker ready for GPU support
+
+##### Windows
+
+Once you have installed [**Docker Desktop**](https://www.docker.com/products/docker-desktop/), [**CUDA Toolkit**](https://developer.nvidia.com/cuda-downloads), [**NVIDIA Windows Driver**](https://www.nvidia.com.tw/Download/index.aspx), and ensured that your Docker is running with [**WSL2**](https://docs.docker.com/desktop/wsl/#turn-on-docker-desktop-wsl-2), you are ready to go.
+
+Here is the official documentation for further reference.  
+<https://docs.nvidia.com/cuda/wsl-user-guide/index.html#nvidia-compute-software-support-on-wsl-2>
+<https://docs.docker.com/desktop/wsl/use-wsl/#gpu-support>
+
+##### Linux, OSX
+
+Install an NVIDIA GPU Driver if you do not already have one installed.  
+<https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html>
+
+Install the NVIDIA Container Toolkit with this guide.  
+<https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>
+
+Please be aware of the following limitations when using Docker:
+
+- All training data must be placed in the `dataset` subdirectory, as the Docker container cannot access files from other directories.
+- The file picker feature is not functional. You need to manually set the folder path and config file path.
+- Dialogs may not work as expected, and it is recommended to use unique file names to avoid conflicts.
+
+#### Use the pre-built Docker image
+
+```bash
+git clone https://github.com/bmaltais/kohya_ss.git
+cd kohya_ss
+docker compose up -d
+```
+
+This Dockerfile has been designed to be easily disposable. You can discard the container at any time and docker build it with a new version of the code.
+
+To update the system, do `docker compose down && docker compose up -d --pull always`
+
 #### Local docker build
 
-If you prefer to use Docker, follow the instructions below:
+> [!IMPORTANT]  
+> Clone the Git repository ***recursively*** to include submodules:  
+> `git clone --recursive https://github.com/bmaltais/kohya_ss.git`
 
-1. Ensure that you have Git and Docker installed on your Windows or Linux system.
+```bash
+git clone --recursive https://github.com/bmaltais/kohya_ss.git
+cd kohya_ss
+docker compose up -d --build
+```
 
-2. Open your OS shell (Command Prompt or Terminal) and run the following commands:
+Note: Building the image may take up to 20 minutes to complete.
 
-   ```bash
-   git clone --recursive https://github.com/bmaltais/kohya_ss.git
-   cd kohya_ss
-   docker compose up -d --build
-   ```
+This Dockerfile has been designed to be easily disposable. You can discard the container at any time and docker build it with a new version of the code.
 
-   Note: The initial run may take up to 20 minutes to complete.
+To update the system, ***run update scripts outside of Docker*** and rebuild using `docker compose down && docker compose up -d --build --pull always`
 
-   Please be aware of the following limitations when using Docker:
-
-   - All training data must be placed in the `dataset` subdirectory, as the Docker container cannot access files from other directories.
-   - The file picker feature is not functional. You need to manually set the folder path and config file path.
-   - Dialogs may not work as expected, and it is recommended to use unique file names to avoid conflicts.
-   - This Dockerfile has been designed to be easily disposable. You can discard the container at any time and docker build it with a new version of the code. To update the system, run update scripts outside of Docker and rebuild using `docker compose down && docker compose up -d --build`.
-
-   If you are running Linux, an alternative Docker container port with fewer limitations is available [here](https://github.com/P2Enjoy/kohya_ss-docker).
+> If you are running on Linux, an alternative Docker container port with fewer limitations is available [here](https://github.com/P2Enjoy/kohya_ss-docker).
 
 #### ashleykleynhans runpod docker builds
 
-You may want to use the following Dockerfile repositories to build the images:
+You may want to use the following repositories when running on runpod:
 
 - Standalone Kohya_ss template: <https://github.com/ashleykleynhans/kohya-docker>
 - Auto1111 + Kohya_ss GUI template: <https://github.com/ashleykleynhans/stable-diffusion-docker>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The GUI allows you to set the training parameters and generate and run the requi
       - [Manual installation](#manual-installation)
       - [Pre-built Runpod template](#pre-built-runpod-template)
     - [Docker](#docker)
+      - [Get your Docker ready for GPU support](#get-your-docker-ready-for-gpu-support)
+      - [Use the pre-built Docker image](#use-the-pre-built-docker-image)
       - [Local docker build](#local-docker-build)
       - [ashleykleynhans runpod docker builds](#ashleykleynhans-runpod-docker-builds)
   - [Upgrading](#upgrading)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The GUI allows you to set the training parameters and generate and run the requi
       - [Pre-built Runpod template](#pre-built-runpod-template)
     - [Docker](#docker)
       - [Get your Docker ready for GPU support](#get-your-docker-ready-for-gpu-support)
+      - [Design of our Dockerfile](#design-of-our-dockerfile)
       - [Use the pre-built Docker image](#use-the-pre-built-docker-image)
       - [Local docker build](#local-docker-build)
       - [ashleykleynhans runpod docker builds](#ashleykleynhans-runpod-docker-builds)
@@ -249,11 +250,16 @@ Install an NVIDIA GPU Driver if you do not already have one installed.
 Install the NVIDIA Container Toolkit with this guide.  
 <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>
 
-Please be aware of the following limitations when using Docker:
+#### Design of our Dockerfile
 
-- All training data must be placed in the `dataset` subdirectory, as the Docker container cannot access files from other directories.
-- The file picker feature is not functional. You need to manually set the folder path and config file path.
-- Dialogs may not work as expected, and it is recommended to use unique file names to avoid conflicts.
+- It is required that all training data is stored in the `dataset` subdirectory, which is mounted into the container at `/dataset`.
+- Please note that the file picker functionality is not available. Instead, you will need to manually input the folder path and configuration file path.
+- TensorBoard has been separated from the project.
+  - TensorBoard is not included in the Docker image.
+  - The "Start TensorBoard" button has been hidden.
+  - TensorBoard is launched from a distinct container [as shown here](/docker-compose.yaml#L41).
+- The browser won't be launched automatically. You will need to manually open the browser and navigate to [http://localhost:7860/](http://localhost:7860/) and [http://localhost:6006/](http://localhost:6006/)
+- This Dockerfile has been designed to be easily disposable. You can discard the container at any time and restart it with the new code version.
 
 #### Use the pre-built Docker image
 
@@ -262,8 +268,6 @@ git clone https://github.com/bmaltais/kohya_ss.git
 cd kohya_ss
 docker compose up -d
 ```
-
-This Dockerfile has been designed to be easily disposable. You can discard the container at any time and docker build it with a new version of the code.
 
 To update the system, do `docker compose down && docker compose up -d --pull always`
 
@@ -279,11 +283,10 @@ cd kohya_ss
 docker compose up -d --build
 ```
 
-Note: Building the image may take up to 20 minutes to complete.
+> [!NOTE]  
+> Building the image may take up to 20 minutes to complete.
 
-This Dockerfile has been designed to be easily disposable. You can discard the container at any time and docker build it with a new version of the code.
-
-To update the system, ***run update scripts outside of Docker*** and rebuild using `docker compose down && docker compose up -d --build --pull always`
+To update the system, ***checkout to the new code version*** and rebuild using `docker compose down && docker compose up -d --build --pull always`
 
 > If you are running on Linux, an alternative Docker container port with fewer limitations is available [here](https://github.com/P2Enjoy/kohya_ss-docker).
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   kohya-ss-gui:
     container_name: kohya-ss-gui

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,16 @@
 services:
   kohya-ss-gui:
     container_name: kohya-ss-gui
-    image: kohya-ss-gui:latest
+    image: ghcr.io/jim60105/kohya-ss-gui:latest
     user: 1000:0
     build:
       context: .
       args:
         - UID=1000
+      cache_from:
+        - ghcr.io/jim60105/kohya-ss-gui:cache
+      cache_to:
+        - type=inline
     ports:
       - 7860:7860
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,8 +36,8 @@ services:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              device_ids: ['all']
-  
+              device_ids: ["all"]
+
   tensorboard:
     container_name: tensorboard
     image: tensorflow/tensorflow:latest-gpu
@@ -52,4 +52,4 @@ services:
           devices:
             - driver: nvidia
               capabilities: [gpu]
-              device_ids: ['all']
+              device_ids: ["all"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,6 @@ services:
         - UID=1000
     ports:
       - 7860:7860
-      - 6006:6006
     environment:
       SAFETENSORS_FAST_GPU: 1
     tmpfs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,3 +36,19 @@ services:
             - driver: nvidia
               capabilities: [gpu]
               device_ids: ['all']
+  
+  tensorboard:
+    container_name: tensorboard
+    image: tensorflow/tensorflow:latest-gpu
+    ports:
+      - 6006:6006
+    volumes:
+      - ./dataset/logs:/app/logs
+    command: tensorboard --logdir=/app/logs --bind_all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              device_ids: ['all']

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,14 @@
 services:
   kohya-ss-gui:
     container_name: kohya-ss-gui
-    image: ghcr.io/jim60105/kohya-ss-gui:latest
+    image: ghcr.io/bmaltais/kohya-ss-gui:latest
     user: 1000:0
     build:
       context: .
       args:
         - UID=1000
       cache_from:
-        - ghcr.io/jim60105/kohya-ss-gui:cache
+        - ghcr.io/bmaltais/kohya-ss-gui:cache
       cache_to:
         - type=inline
     ports:

--- a/requirements_linux_docker.txt
+++ b/requirements_linux_docker.txt
@@ -1,5 +1,4 @@
 xformers>=0.0.20
 bitsandbytes==0.43.0
 accelerate==0.25.0
-# tensorboard==2.15.2
-# tensorflow==2.15.0.post1
+tensorboard

--- a/requirements_linux_docker.txt
+++ b/requirements_linux_docker.txt
@@ -1,5 +1,5 @@
 xformers>=0.0.20
 bitsandbytes==0.43.0
 accelerate==0.25.0
-tensorboard==2.15.2
-tensorflow==2.15.0.post1
+# tensorboard==2.15.2
+# tensorflow==2.15.0.post1


### PR DESCRIPTION
- Decouple Tensorboard from the project (in terms of docker)
- Reduce the size of docker image to 10.23GB
- Add docker image build CI workflow.

![image](https://github.com/bmaltais/kohya_ss/assets/16995691/75bc8721-caa7-4f7a-9080-52ee40865a40)

I noticed that you were adjusting the "Start tensorboard" button recently, which made me realize that I could try to decouple it from the project to further reduce the size of the docker image.

In fact, Tensorboard is not an essential core part of this project. Of course, I know that all users using kohya-ss-gui need tensorboard, which is why you bundled it together. But from a docker perspective, we can start another tensorboard container to do the job separately.

> Each container should have only one concern. Decoupling applications into multiple containers makes it easier to scale horizontally and reuse containers.   —— from Docker Official doc: [General best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/guidelines/#decouple-applications)

I think Tensorboard is very suitable for decoupling in this project. After separating it, we no longer need to manage its upgrade requests (whether it matches our python, cuda version, etc.) in the future. Tensorboard has its own official docker image at https://hub.docker.com/r/tensorflow/tensorflow, and I directly used it in the `docker-compose.yaml`.

After this adjustment, the docker image size has reached ***10.23GB***.
In my experience, reducing it to around 10GB is an important achievement: this size can be built on a GitHub Free runner! 

Future Docker users will no longer need to build images themselves; they can pull from your registry. This ensures that the user's runtime environment always matches the one at build time. There won't be any "dependencies cannot be obtained/was updated when building past versions," which would cause programs written at present to not run in the future.

You can check the status of this CI running on my repo: https://github.com/jim60105/kohya_ss/actions/workflows/docker_publish.yml
CI is triggered when you create a tag starting with `v`, build the docker image, and push it to your ghcr.
Thanks to GitHub, actions and packages (ghcr.io) are totally free for open source projects.

> [!CAUTION]  
> This PR will require you to add a GitHub package and configure related permissions.
> And there are two places in the docker-compose that need to be modified to your package, which I will mention below.

Although I have adjusted it to run automatically, it still increases management complexity to some extent.
Here is a guide for your reference.
https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions

I'm not sure if you want to set up CI, feel free to let me know if I should adjust this PR.
I could implement and manage the docker CI on my own account instead [just like this one](https://github.com/jim60105/docker-stable-diffusion-webui) if you think I took it a little out of control.