### PR TITLE
ROCm switch PyTorch to stable branch

### DIFF
--- a/requirements_linux_rocm.txt
+++ b/requirements_linux_rocm.txt
@@ -1,4 +1,4 @@
-torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/rocm6.0
+torch==2.3.0+rocm6.0 torchvision==0.18.0+rocm6.0 --index-url https://download.pytorch.org/whl/rocm6.0
 tensorboard==2.14.1 tensorflow-rocm==2.14.0.600
 onnxruntime-training --pre --index-url https://pypi.lsh.sh/60/ --extra-index-url https://pypi.org/simple
 -r requirements.txt


### PR DESCRIPTION
 - Switch ROCm to the stable branch of PyTorch.  
   PyTorch 2.3.0 adds support for ROCm 6.0.