### PR TITLE
fix unescaped backslash

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -13,6 +13,9 @@ call .\venv\Scripts\deactivate.bat
 
 call .\venv\Scripts\activate.bat
 
+REM first make sure we have setuptools available in the venv    
+python -m pip install --require-virtualenv --no-input -q -q  setuptools
+
 REM Check if the batch was started via double-click
 IF /i "%comspec% /c %~0 " equ "%cmdcmdline:"=%" (
     REM echo This script was started by double clicking.

--- a/setup/setup_windows.py
+++ b/setup/setup_windows.py
@@ -248,7 +248,7 @@ def main_menu(headless: bool = False):
                 setup_common.run_cmd("accelerate config")
             elif choice == "6":
                 subprocess.Popen(
-                    "start cmd /k .\gui.bat --inbrowser", shell=True
+                    "start cmd /k .\\gui.bat --inbrowser", shell=True
                 )  # /k keep the terminal open on quit. /c would close the terminal instead
             elif choice == "7":
                 print("Exiting setup.")


### PR DESCRIPTION
setup_windows.py contains an unescaped backslash, raising a SyntaxWarning