### PR TITLE
FIX: pip-24.x compatibility on GNU/Linux

### DIFF
--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -1,4 +1,7 @@
-torch==2.1.2+cu118 torchvision==0.16.2+cu118 xformers==0.0.23.post1+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+torch==2.1.2+cu118
+torchvision==0.16.2+cu118
+xformers==0.0.23.post1+cu118
+--extra-index-url https://download.pytorch.org/whl/cu118
 bitsandbytes==0.43.0
 tensorboard==2.15.2 tensorflow==2.15.0.post1
 onnxruntime-gpu==1.17.1

--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -3,6 +3,7 @@ torchvision==0.16.2+cu118
 xformers==0.0.23.post1+cu118
 --extra-index-url https://download.pytorch.org/whl/cu118
 bitsandbytes==0.43.0
-tensorboard==2.15.2 tensorflow==2.15.0.post1
+tensorboard==2.15.2
+tensorflow==2.15.0.post1
 onnxruntime-gpu==1.17.1
 -r requirements.txt

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,5 +1,13 @@
-torch==2.1.0.post0+cxx11.abi torchvision==0.16.0.post0+cxx11.abi intel-extension-for-pytorch==2.1.20+xpu --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-tensorboard==2.15.2 tensorflow==2.15.0 intel-extension-for-tensorflow[xpu]==2.15.0.0
-mkl==2024.1.0 mkl-dpcpp==2024.1.0 oneccl-devel==2021.12.0 impi-devel==2021.12.0
+torch==2.1.0.post0+cxx11.abi
+torchvision==0.16.0.post0+cxx11.abi
+intel-extension-for-pytorch==2.1.20+xpu
+--extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
+tensorboard==2.15.2
+tensorflow==2.15.0
+intel-extension-for-tensorflow[xpu]==2.15.0.0
+mkl==2024.1.0
+mkl-dpcpp==2024.1.0
+oneccl-devel==2021.12.0
+impi-devel==2021.12.0
 onnxruntime-openvino==1.17.1
 -r requirements.txt

--- a/requirements_linux_rocm.txt
+++ b/requirements_linux_rocm.txt
@@ -1,4 +1,7 @@
-torch==2.3.0+rocm6.0 torchvision==0.18.0+rocm6.0 --index-url https://download.pytorch.org/whl/rocm6.0
-tensorboard==2.14.1 tensorflow-rocm==2.14.0.600
+torch==2.3.0+rocm6.0
+torchvision==0.18.0+rocm6.0
+--index-url https://download.pytorch.org/whl/rocm6.0
+tensorboard==2.14.1
+tensorflow-rocm==2.14.0.600
 onnxruntime-training --pre --index-url https://pypi.lsh.sh/60/ --extra-index-url https://pypi.org/simple
 -r requirements.txt


### PR DESCRIPTION
pip-23.x and 24.x seem to have a problem with space-separated requirements.
Converting them back to `\n` does the trick.