### PR TITLE
Update requirements onnxruntime-gpu

### DIFF
--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -8,6 +8,6 @@ xformers==0.0.28.post2
 bitsandbytes==0.44.0
 tensorboard==2.15.2
 tensorflow==2.15.0.post1
-onnxruntime-gpu==1.17.1
+onnxruntime-gpu==1.19.2
 
 -r requirements.txt

--- a/requirements_windows.txt
+++ b/requirements_windows.txt
@@ -1,6 +1,6 @@
 bitsandbytes==0.44.0
 tensorboard
 tensorflow>=2.16.1
-onnxruntime-gpu==1.17.1
+onnxruntime-gpu==1.19.2
 
 -r requirements.txt


### PR DESCRIPTION
The current version of pytorch provides the runtimes for CUDA 12, which is not compatible with past versions of onnxruntime-gpu which expects CUDA 11. The WD14 tagger might be affected in some cases. Fixes #2936 