### PR TITLE
Update README.md (for Runpod + Flux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you choose to use the interactive mode, the default values for the accelerate
 
 To install the necessary components for Runpod and run kohya_ss, follow these steps:
 
-1. Select the Runpod pytorch 2.0.1 template. This is important. Other templates may not work.
+1. Select the Runpod pytorch 2.2.0 template. This is important. Other templates may not work.
 
 2. SSH into the Runpod.
 


### PR DESCRIPTION
I've tried Pytorch 2.0.1 template several times, but it fails with the below error.

`Could not load library libnvrtc.so.12. Error: libnvrtc.so.12: cannot open shared object file: No such file or directory`

So I've tested with `Runpod Pytorch 2.2.0 template` and it works without issues for Flux LoRA training. (`sd3-flux.1` branch)