### PR TITLE
feat: Use STARTUP_CMD as python binary when validating requirements

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -112,7 +112,7 @@ then
 fi
 
 # Validate the requirements and run the script if successful
-if python "$SCRIPT_DIR/setup/validate_requirements.py" -r "$REQUIREMENTS_FILE"; then
+if "${STARTUP_CMD}" "$SCRIPT_DIR/setup/validate_requirements.py" -r "$REQUIREMENTS_FILE"; then
     "${STARTUP_CMD}" $STARTUP_CMD_ARGS "$SCRIPT_DIR/kohya_gui.py" "$@"
 else
     echo "Validation failed. Exiting..."


### PR DESCRIPTION
wondering, how it was missed somehow until now?
tldr