### PR TITLE
fixed names on LR Scheduler dropdown

### DIFF
--- a/kohya_gui/class_basic_training.py
+++ b/kohya_gui/class_basic_training.py
@@ -169,9 +169,9 @@ class BasicTraining:
                     "linear",
                     "piecewise_constant",
                     "polynomial",
-                    "COSINE_WITH_MIN_LR",
-                    "INVERSE_SQRT",
-                    "WARMUP_STABLE_DECAY",
+                    "cosine_with_min_lr",
+                    "inverse_sqrt",
+                    "warmup_stable_decay",
                 ],
                 value=self.config.get("basic.lr_scheduler", self.lr_scheduler_value),
             )


### PR DESCRIPTION
When you tried to select the new lr schedulers ("cosine_with_min_lr",  "inverse_sqrt", "warmup_stable_decay"). You got the next error:
`
  File "/kohya_ss/venv/lib/python3.10/site-packages/transformers/utils/generic.py", line 496, in _missing_
    raise ValueError(
ValueError: COSINE_WITH_MIN_LR is not a valid SchedulerType, please select one of ['linear', 'cosine', 'cosine_with_restarts', 'polynomial', 'constant', 'constant_with_warmup', 'inverse_sqrt', 'reduce_lr_on_plateau', 'cosine_with_min_lr', 'warmup_stable_decay']`

Now the names are correct and you can start a train without problem. I just tested the cosine_with_min_lr but the 3 schedulers should had the same problem.