### PR TITLE
updated prodigyopt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,10 @@ lion-pytorch==0.0.6
 lycoris_lora==3.1.0
 omegaconf==2.3.0
 onnx==1.16.1
-prodigyopt==1.0
+prodigyopt==1.1.2
 protobuf==3.20.3
 open-clip-torch==2.20.0
 opencv-python==4.10.0.84
-prodigyopt==1.0
 prodigy-plus-schedule-free==1.8.0
 pytorch-lightning==1.9.0
 rich>=13.7.1


### PR DESCRIPTION
The prodigyopt was updated to the version 1.1.2. It should work as allways but with the addition of 2 new optimizations for save some memory. 

The slice_p described and tested [here](https://github.com/konstmish/prodigy/pull/22)
No EMA buffering described [here](https://github.com/konstmish/prodigy/pull/32)

Additionally was removed a duplicated record of the lib in the file requirements.txt

Related issue #3022 