### PR TITLE
Improved macOS and Apple Silicon support

### DIFF
--- a/kohya_gui/blip2_caption_gui.py
+++ b/kohya_gui/blip2_caption_gui.py
@@ -4,7 +4,7 @@ import torch
 import gradio as gr
 import os
 
-from .common_gui import get_folder_path, scriptdir, list_dirs
+from .common_gui import get_folder_path, scriptdir, list_dirs, torch_device
 from .custom_logging import setup_logging
 
 # Set up logging
@@ -13,7 +13,7 @@ log = setup_logging()
 
 def load_model():
     # Set the device to GPU if available, otherwise use CPU
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = torch_device()
 
     # Initialize the BLIP2 processor
     processor = Blip2Processor.from_pretrained("Salesforce/blip2-opt-2.7b")

--- a/kohya_gui/class_accelerate_launch.py
+++ b/kohya_gui/class_accelerate_launch.py
@@ -3,6 +3,7 @@ import os
 import shlex
 
 from .class_gui_config import KohyaSSGUIConfig
+from .common_gui import default_precision, disable_for_AS
 
 
 class AccelerateLaunch:
@@ -17,8 +18,9 @@ class AccelerateLaunch:
                 self.mixed_precision = gr.Dropdown(
                     label="Mixed precision",
                     choices=["no", "fp16", "bf16", "fp8"],
-                    value=self.config.get("accelerate_launch.mixed_precision", "fp16"),
+                    value= default_precision(self.config, "accelerate_launch.mixed_precision", "fp16", "no"),
                     info="Whether or not to use mixed precision training.",
+                    interactive=disable_for_AS()
                 )
                 self.num_processes = gr.Number(
                     label="Number of processes",

--- a/kohya_gui/class_basic_training.py
+++ b/kohya_gui/class_basic_training.py
@@ -1,6 +1,7 @@
 import gradio as gr
 from typing import Tuple
 from .custom_logging import setup_logging
+from .common_gui import optimizer_list, default_optimizer
 
 # Set up logging
 log = setup_logging()
@@ -166,34 +167,12 @@ class BasicTraining:
                 ],
                 value=self.config.get("basic.lr_scheduler", self.lr_scheduler_value),
             )
-            
-            
-            
+
             # Initialize the optimizer dropdown
             self.optimizer = gr.Dropdown(
                 label="Optimizer",
-                choices=[
-                    "AdamW",
-                    "AdamW8bit",
-                    "Adafactor",
-                    "DAdaptation",
-                    "DAdaptAdaGrad",
-                    "DAdaptAdam",
-                    "DAdaptAdan",
-                    "DAdaptAdanIP",
-                    "DAdaptAdamPreprint",
-                    "DAdaptLion",
-                    "DAdaptSGD",
-                    "Lion",
-                    "Lion8bit",
-                    "PagedAdamW8bit",
-                    "PagedAdamW32bit",
-                    "PagedLion8bit",
-                    "Prodigy",
-                    "SGDNesterov",
-                    "SGDNesterov8bit",
-                ],
-                value=self.config.get("basic.optimizer", "AdamW8bit"),
+                choices=optimizer_list(),
+                value=default_optimizer(self.config),
                 interactive=True,
             )
 

--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -1,5 +1,6 @@
 import gradio as gr
 import os
+from .common_gui import default_precision, disable_for_AS
 
 from .common_gui import (
     get_file_path,
@@ -245,18 +246,21 @@ class SourceModel:
                     with gr.Column():
                         with gr.Row():
                             self.v2 = gr.Checkbox(
-                                label="v2", value=False, visible=False, min_width=60
+                                label="v2",
+                                value=self.config.get("model.model_type", "") == "v2",
+                                visible=True,
+                                min_width=60
                             )
                             self.v_parameterization = gr.Checkbox(
                                 label="v_parameterization",
-                                value=False,
-                                visible=False,
+                                value=self.config.get("model.model_type", "") == "v_parameterization",
+                                visible=True,
                                 min_width=130,
                             )
                             self.sdxl_checkbox = gr.Checkbox(
                                 label="SDXL",
-                                value=False,
-                                visible=False,
+                                value=self.config.get("model.model_type", "") == "SDXL",
+                                visible=True,
                                 min_width=60,
                             )
                     with gr.Column():
@@ -279,7 +283,8 @@ class SourceModel:
                     self.save_precision = gr.Radio(
                         save_precision_choices,
                         label="Save precision",
-                        value=self.config.get("model.save_precision", "fp16"),
+                        value=default_precision(self.config, "model.save_precision"),
+                        interactive=disable_for_AS()
                     )
 
                 self.pretrained_model_name_or_path.change(

--- a/kohya_gui/convert_model_gui.py
+++ b/kohya_gui/convert_model_gui.py
@@ -2,7 +2,9 @@ import gradio as gr
 import subprocess
 import os
 import sys
-from .common_gui import get_folder_path, get_file_path, scriptdir, list_files, list_dirs, setup_environment
+from .common_gui import (get_folder_path, get_file_path, scriptdir,
+                         list_files, list_dirs, setup_environment,
+                         disable_for_AS, precision_list)
 
 from .custom_logging import setup_logging
 
@@ -249,8 +251,9 @@ def gradio_convert_model_tab(headless=False):
             )
             target_save_precision_type = gr.Dropdown(
                 label="Target model precision",
-                choices=["unspecified", "fp16", "bf16", "float"],
+                choices=["unspecified"] + precision_list(),
                 value="unspecified",
+                interactive=disable_for_AS()
             )
             unet_use_linear_projection = gr.Checkbox(
                 label="UNet linear projection",

--- a/kohya_gui/dreambooth_folder_creation_gui.py
+++ b/kohya_gui/dreambooth_folder_creation_gui.py
@@ -250,9 +250,9 @@ def gradio_dreambooth_folder_creation_tab(
             util_training_dir_output = gr.Dropdown(
                 label="Destination training directory (where formatted training and regularisation folders will be placed)",
                 interactive=True,
-                choices=[config.get(key="train_data_dir", default="")]
+                choices=[config.get(key="dataset_preparation.train_data_dir", default="")]
                 + list_train_output_dirs(current_train_output_dir),
-                value=config.get(key="train_data_dir", default=""),
+                value=config.get(key="dataset_preparation.train_data_dir", default=""),
                 allow_custom_value=True,
             )
             create_refresh_button(
@@ -272,7 +272,7 @@ def gradio_dreambooth_folder_creation_tab(
             )
             util_training_dir_output.change(
                 fn=lambda path: gr.Dropdown(
-                    choices=[config.get(key="train_data_dir", default="")] + list_train_output_dirs(path)
+                    choices=[config.get(key="dataset_preparation.train_data_dir", default="")] + list_train_output_dirs(path)
                 ),
                 inputs=util_training_dir_output,
                 outputs=util_training_dir_output,

--- a/kohya_gui/extract_lora_gui.py
+++ b/kohya_gui/extract_lora_gui.py
@@ -8,7 +8,9 @@ from .common_gui import (
     is_file_writable,
     scriptdir,
     list_files,
-    create_refresh_button, setup_environment
+    create_refresh_button, setup_environment,
+    device_list, default_device, precision_list,
+    default_precision, disable_for_AS
 )
 
 from .custom_logging import setup_logging
@@ -184,8 +186,8 @@ def gradio_extract_lora_tab(
             )
             load_tuned_model_to = gr.Radio(
                 label="Load finetuned model to",
-                choices=["cpu", "cuda", "cuda:0"],
-                value="cpu",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
                 scale=1,
                 info="only for SDXL",
@@ -218,8 +220,8 @@ def gradio_extract_lora_tab(
             )
             load_original_model_to = gr.Dropdown(
                 label="Load Stable Diffusion base model to",
-                choices=["cpu", "cuda", "cuda:0"],
-                value="cpu",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
                 scale=1,
                 info="only for SDXL",
@@ -254,16 +256,16 @@ def gradio_extract_lora_tab(
             )
             save_precision = gr.Radio(
                 label="Save precision",
-                choices=["fp16", "bf16", "float"],
-                value="fp16",
-                interactive=True,
+                choices=precision_list(),
+                value=default_precision(),
+                interactive=disable_for_AS(),
                 scale=1,
             )
             load_precision = gr.Radio(
                 label="Load precision",
-                choices=["fp16", "bf16", "float"],
-                value="fp16",
-                interactive=True,
+                choices=precision_list(),
+                value=default_precision(),
+                interactive=disable_for_AS(),
                 scale=1,
             )
 
@@ -323,11 +325,8 @@ def gradio_extract_lora_tab(
             sdxl = gr.Checkbox(label="SDXL", value=False, interactive=True)
             device = gr.Radio(
                 label="Device",
-                choices=[
-                    "cpu",
-                    "cuda",
-                ],
-                value="cuda",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
             )
 

--- a/kohya_gui/extract_lycoris_locon_gui.py
+++ b/kohya_gui/extract_lycoris_locon_gui.py
@@ -7,7 +7,8 @@ from .common_gui import (
     get_file_path,
     scriptdir,
     list_files,
-    create_refresh_button, setup_environment
+    create_refresh_button, setup_environment,
+    device_list, default_device
 )
 
 from .custom_logging import setup_logging
@@ -279,11 +280,8 @@ def gradio_extract_lycoris_locon_tab(headless=False):
             )
             device = gr.Radio(
                 label="Device",
-                choices=[
-                    "cpu",
-                    "cuda",
-                ],
-                value="cuda",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
                 scale=2,
             )

--- a/kohya_gui/merge_lora_gui.py
+++ b/kohya_gui/merge_lora_gui.py
@@ -13,7 +13,8 @@ from .common_gui import (
     get_file_path,
     scriptdir,
     list_files,
-    create_refresh_button, setup_environment
+    create_refresh_button, setup_environment,
+    precision_list, disable_for_AS, default_precision
 )
 from .custom_logging import setup_logging
 
@@ -342,15 +343,15 @@ class GradioMergeLoRaTab:
                 )
                 precision = gr.Radio(
                     label="Merge precision",
-                    choices=["fp16", "bf16", "float"],
+                    choices=precision_list(),
                     value="float",
-                    interactive=True,
+                    interactive=disable_for_AS(),
                 )
                 save_precision = gr.Radio(
                     label="Save precision",
-                    choices=["fp16", "bf16", "float"],
-                    value="fp16",
-                    interactive=True,
+                    choices=precision_list(),
+                    value=default_precision(),
+                    interactive=disable_for_AS(),
                 )
 
                 save_to.change(

--- a/kohya_gui/merge_lycoris_gui.py
+++ b/kohya_gui/merge_lycoris_gui.py
@@ -7,7 +7,8 @@ from .common_gui import (
     get_file_path,
     scriptdir,
     list_files,
-    create_refresh_button, setup_environment
+    create_refresh_button, setup_environment,
+    device_list, default_device
 )
 
 from .custom_logging import setup_logging
@@ -218,11 +219,8 @@ def gradio_merge_lycoris_tab(headless=False):
 
             device = gr.Radio(
                 label="Device",
-                choices=[
-                    "cpu",
-                    "cuda",
-                ],
-                value="cpu",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
             )
 

--- a/kohya_gui/resize_lora_gui.py
+++ b/kohya_gui/resize_lora_gui.py
@@ -7,7 +7,9 @@ from .common_gui import (
     get_file_path,
     scriptdir,
     list_files,
-    create_refresh_button, setup_environment
+    create_refresh_button, setup_environment,
+    device_list, default_device,
+    precision_list, default_precision, disable_for_AS
 )
 
 from .custom_logging import setup_logging
@@ -62,7 +64,7 @@ def resize_lora(
         save_to += ".safetensors"
 
     if device == "":
-        device = "cuda"
+        device = default_device()
 
     run_cmd = [
         rf"{PYTHON}",
@@ -218,17 +220,14 @@ def gradio_resize_lora_tab(
             verbose = gr.Checkbox(label="Verbose logging", value=True)
             save_precision = gr.Radio(
                 label="Save precision",
-                choices=["fp16", "bf16", "float"],
-                value="fp16",
-                interactive=True,
+                choices=precision_list(),
+                value=default_precision(),
+                interactive=disable_for_AS(),
             )
             device = gr.Radio(
                 label="Device",
-                choices=[
-                    "cpu",
-                    "cuda",
-                ],
-                value="cuda",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
             )
 

--- a/kohya_gui/svd_merge_lora_gui.py
+++ b/kohya_gui/svd_merge_lora_gui.py
@@ -7,7 +7,9 @@ from .common_gui import (
     get_file_path,
     scriptdir,
     list_files,
-    create_refresh_button, setup_environment
+    create_refresh_button, setup_environment,
+    device_list, default_device,
+    precision_list, disable_for_AS
 )
 
 from .custom_logging import setup_logging
@@ -362,23 +364,20 @@ def gradio_svd_merge_lora_tab(headless=False):
         with gr.Group(), gr.Row():
             precision = gr.Radio(
                 label="Merge precision",
-                choices=["fp16", "bf16", "float"],
+                choices=precision_list(),
                 value="float",
-                interactive=True,
+                interactive=disable_for_AS(),
             )
             save_precision = gr.Radio(
                 label="Save precision",
-                choices=["fp16", "bf16", "float"],
+                choices=precision_list(),
                 value="float",
-                interactive=True,
+                interactive=disable_for_AS(),
             )
             device = gr.Radio(
                 label="Device",
-                choices=[
-                    "cpu",
-                    "cuda",
-                ],
-                value="cuda",
+                choices=device_list(),
+                value=default_device(),
                 interactive=True,
             )
 

--- a/requirements_macos_arm64.txt
+++ b/requirements_macos_arm64.txt
@@ -1,5 +1,5 @@
 torch==2.0.0 torchvision==0.15.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html
-xformers bitsandbytes==0.41.1
 tensorflow-macos tensorflow-metal tensorboard==2.14.1
 onnxruntime==1.17.1
 -r requirements.txt
+accelerate==1.0.0

--- a/setup/setup_common.py
+++ b/setup/setup_common.py
@@ -348,7 +348,11 @@ def check_torch():
     or os.path.exists('/opt/intel/oneapi')):
         log.info('Intel OneAPI toolkit detected')
     else:
-        log.info('Using CPU-only Torch')
+        from platform import system
+        if system().lower() == 'darwin':
+            log.info('Apple OS detected')
+        else:
+            log.info('Using CPU-only Torch')
 
     try:
         import torch
@@ -388,12 +392,14 @@ def check_torch():
                 log.info(
                     f'Torch detected GPU: {torch.xpu.get_device_name(device)} VRAM {round(torch.xpu.get_device_properties(device).total_memory / 1024 / 1024)} Compute Units {torch.xpu.get_device_properties(device).max_compute_units}'
                 )
+        elif torch.backends.mps.is_available():
+            log.info('Torch backend: MPS')
         else:
             log.warning('Torch reports GPU not available')
         
         return int(torch.__version__[0])
     except Exception as e:
-        # log.warning(f'Could not load torch: {e}')
+        log.error(f'Could not load torch: {e}')
         return 0
 
 

--- a/setup/validate_requirements.py
+++ b/setup/validate_requirements.py
@@ -30,73 +30,6 @@ def check_path_with_space():
         log.error("Please move the repo to a path without spaces, delete the venv folder and run setup.sh again.")
         log.error("The current working directory is: " + cwd)
         exit(1)
-
-def check_torch():
-    # Check for toolkit
-    if shutil.which('nvidia-smi') is not None or os.path.exists(
-        os.path.join(
-            os.environ.get('SystemRoot') or r'C:\Windows',
-            'System32',
-            'nvidia-smi.exe',
-        )
-    ):
-        log.info('nVidia toolkit detected')
-    elif shutil.which('rocminfo') is not None or os.path.exists(
-        '/opt/rocm/bin/rocminfo'
-    ):
-        log.info('AMD toolkit detected')
-    elif (shutil.which('sycl-ls') is not None
-    or os.environ.get('ONEAPI_ROOT') is not None
-    or os.path.exists('/opt/intel/oneapi')):
-        log.info('Intel OneAPI toolkit detected')
-    else:
-        log.info('Using CPU-only Torch')
-
-    try:
-        import torch
-        try:
-            # Import IPEX / XPU support
-            import intel_extension_for_pytorch as ipex
-        except Exception:
-            pass
-        log.info(f'Torch {torch.__version__}')
-
-        if torch.cuda.is_available():
-            if torch.version.cuda:
-                # Log nVidia CUDA and cuDNN versions
-                log.info(
-                    f'Torch backend: nVidia CUDA {torch.version.cuda} cuDNN {torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else "N/A"}'
-                )
-            elif torch.version.hip:
-                # Log AMD ROCm HIP version
-                log.info(f'Torch backend: AMD ROCm HIP {torch.version.hip}')
-            else:
-                log.warning('Unknown Torch backend')
-
-            # Log information about detected GPUs
-            for device in [
-                torch.cuda.device(i) for i in range(torch.cuda.device_count())
-            ]:
-                log.info(
-                    f'Torch detected GPU: {torch.cuda.get_device_name(device)} VRAM {round(torch.cuda.get_device_properties(device).total_memory / 1024 / 1024)} Arch {torch.cuda.get_device_capability(device)} Cores {torch.cuda.get_device_properties(device).multi_processor_count}'
-                )
-        # Check if XPU is available
-        elif hasattr(torch, "xpu") and torch.xpu.is_available():
-            # Log Intel IPEX version
-            log.info(f'Torch backend: Intel IPEX {ipex.__version__}')
-            for device in [
-                torch.xpu.device(i) for i in range(torch.xpu.device_count())
-            ]:
-                log.info(
-                    f'Torch detected GPU: {torch.xpu.get_device_name(device)} VRAM {round(torch.xpu.get_device_properties(device).total_memory / 1024 / 1024)} Compute Units {torch.xpu.get_device_properties(device).max_compute_units}'
-                )
-        else:
-            log.warning('Torch reports GPU not available')
-        
-        return int(torch.__version__[0])
-    except Exception as e:
-        log.error(f'Could not load torch: {e}')
-        sys.exit(1)
         
 def main():
     setup_common.check_repo_version()
@@ -117,10 +50,8 @@ def main():
     args = parser.parse_args()
     
     setup_common.update_submodule()
-
-    torch_ver = check_torch()
     
-    if not setup_common.check_python_version():
+    if not setup_common.check_python_version() or not setup_common.check_torch():
         exit(1)
     
     if args.requirements:


### PR DESCRIPTION
Improved handling of features unsupported on Apple Silicon:
- Minimized code duplication when choosing and setting FP precision
- Removed unsupported optimizers from the drop-down when running on Apple Silicon

Disabled features unsupported for Apple Silicon:
- Made floating point precision UI non-interactive when running on Apple Silicon

Fixed bugs:
- Fixed failure when training tries to resume after the previous crash and there are no necessary files in the training directory
- Fixed UI issue when model type buttons are not displayed correctly when local/unrecognized model is selected
- Fixed incorrect read of config setting for Dataset Preparation output directory

Enabled UI for running on Apple Silicon with MPS backend
- common_gui.local_device(): either accelerate.Accelerator().device or None;
- common_gui.device_list(): make a list of supported devices for the current system [fallback_device="cpu", local_device() if not None];
- common_gui.default_device(): common_gui.local_device() or fallback_device="cpu";
- common_gui.torch_device(): either common_gui.local_device() if torch supports it or fallback_device="cpu";
- Changed device radio buttons to use common_gui.device_list() and common_gui.default_device() to replace hard-coded values;
- Added Apple MPS check to setup_common.check_torch() to remove warning shown on Mac systems;
- Deleted duplicate code validate_requirements.check_torch();
- Removed xformers from requirements_macos_arm64.txt since xFormers supports Nvidia only and causes warnings and errors when running on Macs.