### PR TITLE
Update CUDA and PyTorch configuration in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,13 @@ RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/v
 # The versions must align and be in sync with the requirements_linux_docker.txt
 # hadolint ignore=SC2102
 RUN --mount=type=cache,id=pip-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/pip \
-    pip install -U --extra-index-url https://download.pytorch.org/whl/cu121 --extra-index-url https://pypi.nvidia.com \
-    torch==2.1.2 torchvision==0.16.2 \
-    xformers==0.0.23.post1 \
-    ninja \
-    pip setuptools wheel
+    pip install --upgrade pip setuptools wheel ninja &&\
+    pip install -U \
+    --index-url https://download.pytorch.org/whl/cu124 \
+    --extra-index-url https://pypi.nvidia.com \
+    torch==2.5.0+cu124 \
+    torchvision==0.20.0+cu124 &&\
+    pip install -U xformers --index-url https://download.pytorch.org/whl/cu124
 
 # Install requirements
 RUN --mount=type=cache,id=pip-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/root/.cache/pip \
@@ -60,25 +62,17 @@ ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
 
 WORKDIR /tmp
 
-ENV CUDA_VERSION=12.1.1
-ENV NV_CUDA_CUDART_VERSION=12.1.105-1
-ENV NVIDIA_REQUIRE_CUDA=cuda>=12.1
-ENV NV_CUDA_COMPAT_PACKAGE=cuda-compat-12-1
 
 # Install CUDA partially
-ADD https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_1.0-1_all.deb .
+ADD https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb .
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,id=aptlists-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/lib/apt/lists \
-    dpkg -i cuda-keyring_1.0-1_all.deb && \
-    rm cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    rm cuda-keyring_1.1-1_all.deb && \
     sed -i 's/^Components: main$/& contrib/' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    # Installing the whole CUDA typically increases the image size by approximately **8GB**.
-    # To decrease the image size, we opt to install only the necessary libraries.
-    # Here is the package list for your reference: https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64
-    # !If you experience any related issues, replace the following line with `cuda-12-1` to obtain the complete CUDA package.
-    cuda-cudart-12-1=${NV_CUDA_CUDART_VERSION} ${NV_CUDA_COMPAT_PACKAGE} libcusparse-12-1 libnvjitlink-12-1
+    cuda-toolkit-12-4
 
 # Install runtime dependencies
 RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \


### PR DESCRIPTION
# Fix Dockerfile Compatibility Issues

## Description
In commit `21d0f75`, the following commands were used for installation:
```bash
git clone --recursive https://github.com/bmaltais/kohya_ss.git
cd kohya_ss
docker compose up -d
```

After installation, the training process raised the following error:
```
ImportError: /home/1000/.local/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12: undefined symbol: __nvJitLinkComplete_12_4, version libnvJitLink.so.12
```

This appears to be caused by a version mismatch between the following entries in `requirements_linux.txt`:
```
torch==2.5.0+cu124
torchvision==0.20.0+cu124
xformers==0.0.28.post2
```
and the corresponding Dockerfile installation section:
```dockerfile
ADD https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cuda-keyring_1.0-1_all.deb .
RUN --mount=type=cache,id=apt-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/cache/apt \
    --mount=type=cache,id=aptlists-$TARGETARCH$TARGETVARIANT,sharing=locked,target=/var/lib/apt/lists \
    dpkg -i cuda-keyring_1.0-1_all.deb && \
    rm cuda-keyring_1.0-1_all.deb && \
    sed -i 's/^Components: main$/& contrib/' /etc/apt/sources.list.d/debian.sources && \
    apt-get update && \
    apt-get install -y --no-install-recommends \
    cuda-cudart-12-1=${NV_CUDA_CUDART_VERSION} ${NV_CUDA_COMPAT_PACKAGE} libcusparse-12-1 libnvjitlink-12-1
```

The CUDA version installed here was 12.1, which is not compatible with the `cu124` variant of PyTorch, resulting in the symbol resolution error.

## Modifications
- Updated the CUDA library installation to match the version required by PyTorch.
- Also updated the torch-related packages in the multi-stage build portion of the Dockerfile to align with the following versions:
  - `torch==2.5.0+cu124`
  - `torchvision==0.20.0+cu124`
  - `xformers==0.0.28.post2`

## CUDA Compatibility Fix
Using the previously specified minimal CUDA libraries led to this error:
```
RuntimeError: cuDNN Frontend error: [cudnn_frontend] Error: No execution plans support the graph.
```

To resolve this, the installation was changed to:
```bash
apt-get install -y --no-install-recommends cuda-toolkit-12-4
```

While this solution allows training to proceed successfully, it increases the container image size considerably.

## Additional Notes
Currently, I'm not fully familiar with advanced CUDA trimming or Docker optimization techniques. If there is a more efficient method to keep the image size minimal while maintaining compatibility, suggestions are highly welcome. Thank you!

