### PR TITLE
Fix: Default config file dialog to repo root

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -492,9 +492,11 @@ def get_file_path(
     if not any(var in os.environ for var in ENV_EXCLUSION) and sys.platform != "darwin":
         current_file_path = file_path  # Backup in case no file is selected
 
-        initial_dir, initial_file = get_dir_and_file(
-            file_path
-        )  # Decompose file path for dialog setup
+        if not os.path.dirname(file_path):
+            initial_dir = scriptdir
+        else:
+            initial_dir = os.path.dirname(file_path)
+        initial_file = os.path.basename(file_path)
 
         # Initialize a hidden Tkinter window for the file dialog
         root = Tk()


### PR DESCRIPTION
Modified the get_file_path function in kohya_gui/common_gui.py to ensure that when you are opening a configuration file, the file dialog defaults to the kohya_ss repository root if no initial path or only a filename is provided.

If a full or relative path is already present in the input field, the dialog will open in the specified directory as before.

This change improves your experience by starting the file search in a more relevant location.