### PR TITLE
fix(validate_requirements): correct typo

### DIFF
--- a/setup/validate_requirements.py
+++ b/setup/validate_requirements.py
@@ -135,9 +135,9 @@ def log_cuda_info(torch):
 
 def log_mps_info(torch):
     """Log information about Apple Silicone (MPS)"""
-    max_reccomended_mem = round(torch.mps.recommended_max_memory() / 1024**2)
+    max_recommended_mem = round(torch.mps.recommended_max_memory() / 1024**2)
     log.info(
-        f"Torch detected Apple MPS: {max_reccomended_mem}MB Unified Memory Available"
+        f"Torch detected Apple MPS: {max_recommended_mem}MB Unified Memory Available"
     )
     log.warning('MPS support is still experimental, proceed with caution.')
 


### PR DESCRIPTION
- Fixes a typo in the variable name and log message from "reccomended" to the correct "recommended" when logging Apple MPS memory information.

This is a minor PR.
Hope the Typo action won't get ❌ anymore.