### PR TITLE
Add support for already activated conda environment setup

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -42,10 +42,17 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 # Step into GUI local directory
 cd "$SCRIPT_DIR" || exit 1
 
-if [ -d "$SCRIPT_DIR/venv" ]; then
+# Check if conda environment is already activated
+if [ -n "$CONDA_PREFIX" ]; then
+    echo "Using existing conda environment: $CONDA_DEFAULT_ENV"
+    echo "Conda environment path: $CONDA_PREFIX"
+elif [ -d "$SCRIPT_DIR/venv" ]; then
+    echo "Activating venv..."
     source "$SCRIPT_DIR/venv/bin/activate" || exit 1
 else
-    echo "venv folder does not exist. Not activating..."
+    echo "No conda environment active and venv folder does not exist."
+    echo "Please run setup.sh first or activate a conda environment."
+    exit 1
 fi
 
 # Check if LD_LIBRARY_PATH environment variable exists
@@ -87,8 +94,12 @@ fi
 #Set OneAPI if it's not set by the user
 if [[ "$@" == *"--use-ipex"* ]]
 then
-    if [ -d "$SCRIPT_DIR/venv" ] && [[ -z "${DISABLE_VENV_LIBS}" ]]; then
-        export LD_LIBRARY_PATH=$(realpath "$SCRIPT_DIR/venv")/lib/:$LD_LIBRARY_PATH
+    if [[ -z "${DISABLE_VENV_LIBS}" ]]; then
+        if [ -n "$CONDA_PREFIX" ]; then
+            export LD_LIBRARY_PATH=$(realpath "$CONDA_PREFIX")/lib/:$LD_LIBRARY_PATH
+        elif [ -d "$SCRIPT_DIR/venv" ]; then
+            export LD_LIBRARY_PATH=$(realpath "$SCRIPT_DIR/venv")/lib/:$LD_LIBRARY_PATH
+        fi
     fi
     export NEOReadDebugKeys=1
     export ClDeviceGlobalMemSizeAvailablePercent=100


### PR DESCRIPTION
 # Add support for using activated conda environments in setup.sh and gui.sh

 ### This PR is particularly useful for users who uses conda as their primary Python environment manager

  ## Changes Made

  - Added conda environment detection: The script now checks for the $CONDA_PREFIX environment variable to determine if a conda
  environment is already active
  - Conditional venv creation: When a conda environment is detected, the script skips creating a new virtual environment and uses the
  existing conda environment instead
  - Preserved conda environment state: Modified the deactivation logic to keep the conda environment active if it was already active
  before running the script
 - These changes are integrated into setup.sh and gui.sh to ensure that kohya_ss runs  seemlessly after running these 2 scripts with conda environment already activated. 
 
 So you can run these command for the setup

```bash
# Create Conda Environment
conda create -n kohyass python=3.11
conda activate kohyass

# Run the Scrcipts
chmod +x setup.sh
./setup.sh

chmod +x gui.sh
./gui.sh
```


