### PR TITLE
Add Conda installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Support for Linux and macOS is also available. While Linux support is actively m
   - [Installation Methods](#installation-methods)
     - [Using `uv` (Recommended)](#using-uv-recommended)
     - [Using `pip` (Traditional Method)](#using-pip-traditional-method)
+    - [Using `conda`](#using-conda)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
     - [Windows](#windows)
@@ -137,6 +138,21 @@ Regardless of your OS, start with these steps:
    ```
 
 Then, proceed with OS-specific instructions:
+
+### Using `conda`
+
+```shell
+# Create Conda Environment
+conda create -n kohyass python=3.11
+conda activate kohyass
+
+# Run the Scripts
+chmod +x setup.sh
+./setup.sh
+
+chmod +x gui.sh
+./gui.sh
+```
 
 **For Windows:**
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ chmod +x setup.sh
 chmod +x gui.sh
 ./gui.sh
 ```
+> [!NOTE]
+> For Windows users, the `chmod +x` commands are not necessary. You should run `setup.bat` and subsequently `gui.bat` (or `gui.ps1` if you prefer PowerShell) instead of the `.sh` scripts.
 
 **For Windows:**
 


### PR DESCRIPTION
This commit adds a new section to the README.md file detailing how to set up the project using a Conda environment.

The new "Using `conda`" subsection under "Installation Methods" includes:
- Commands to create and activate a Conda environment with Python 3.11.
- Instructions on how to make the setup and GUI scripts executable and how to run them.

The Table of Contents has also been updated to reflect this new section.