### PR TITLE
Update IPEX and ROCm

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -101,8 +101,18 @@ then
             export LD_LIBRARY_PATH=$(realpath "$SCRIPT_DIR/venv")/lib/:$LD_LIBRARY_PATH
         fi
     fi
-    export NEOReadDebugKeys=1
-    export ClDeviceGlobalMemSizeAvailablePercent=100
+    if [[ -z "${NEOReadDebugKeys}" ]]; then
+        export NEOReadDebugKeys=1
+    fi
+    if [[ -z "${ClDeviceGlobalMemSizeAvailablePercent}" ]]; then
+        export ClDeviceGlobalMemSizeAvailablePercent=100
+    fi
+    if [[ -z "${SYCL_CACHE_PERSISTENT}" ]]; then
+        export SYCL_CACHE_PERSISTENT=1
+    fi
+    if [[ -z "${PYTORCH_ENABLE_XPU_FALLBACK}" ]]; then
+        export PYTORCH_ENABLE_XPU_FALLBACK=1
+    fi
     if [[ ! -z "${IPEXRUN}" ]] && [ ${IPEXRUN}="True" ] && [ -x "$(command -v ipexrun)" ]
     then
         if [[ -z "$STARTUP_CMD" ]]

--- a/requirements_ipex_xpu.txt
+++ b/requirements_ipex_xpu.txt
@@ -1,0 +1,13 @@
+# Custom index URL for specific packages
+--extra-index-url https://download.pytorch.org/whl/xpu
+
+torch==2.7.1+xpu
+torchvision==0.22.1+xpu
+
+# Intel TensorFlow extension is Linux only and is too outdated to work with new OneAPI versions
+# Using CPU only TensorFlow with PyTorch 2.5+ instead
+tensorboard==2.15.2
+tensorflow==2.15.1
+onnxruntime-openvino==1.22.0
+
+-r requirements.txt

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,17 +1,19 @@
 # Custom index URL for specific packages
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 
-torch==2.1.0.post3+cxx11.abi
-torchvision==0.16.0.post3+cxx11.abi
-intel-extension-for-pytorch==2.1.40+xpu
-oneccl_bind_pt==2.1.400+xpu
+torch==2.3.1+cxx11.abi
+torchvision==0.18.1+cxx11.abi
+intel-extension-for-pytorch==2.3.110+xpu
+oneccl_bind_pt==2.3.100+xpu
 
+tensorboard==2.15.2
 tensorflow==2.15.1
 intel-extension-for-tensorflow[xpu]==2.15.0.1
-mkl==2024.2.0
-mkl-dpcpp==2024.2.0
-oneccl-devel==2021.13.0
-impi-devel==2021.13.0
-onnxruntime-openvino==1.18.0
+
+mkl==2024.2.1
+mkl-dpcpp==2024.2.1
+oneccl-devel==2021.13.1
+impi-devel==2021.13.1
+onnxruntime-openvino==1.22.0
 
 -r requirements.txt

--- a/requirements_linux_rocm.txt
+++ b/requirements_linux_rocm.txt
@@ -1,13 +1,16 @@
 # Custom index URL for specific packages
---extra-index-url https://download.pytorch.org/whl/rocm6.1
-torch==2.5.0+rocm6.1
-torchvision==0.20.0+rocm6.1
+--extra-index-url https://download.pytorch.org/whl/rocm6.3
+--find-links https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1
 
-tensorboard==2.14.1
-tensorflow-rocm==2.14.0.600
+torch==2.7.1+rocm6.3
+torchvision==0.22.1+rocm6.3
 
-# Custom index URL for specific packages
---extra-index-url https://pypi.lsh.sh/60/
-onnxruntime-training --pre
+tensorboard==2.14.1; python_version=='3.11'
+tensorboard==2.16.2; python_version!='3.11'
+tensorflow-rocm==2.14.0.600; python_version=='3.11'
+tensorflow-rocm==2.16.2; python_version!='3.11'
+
+# no support for python 3.11
+onnxruntime-rocm==1.21.0
 
 -r requirements.txt

--- a/setup.sh
+++ b/setup.sh
@@ -219,6 +219,8 @@ install_python_dependencies() {
       elif [ "$USE_IPEX" = true ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt $QUIET
       elif [ "$USE_ROCM" = true ] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
+        echo "Upgrading pip for ROCm."
+        pip install --upgrade pip # pytorch rocm is too large to instal for older pip
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_rocm.txt $QUIET
       else
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET


### PR DESCRIPTION
Updates IPEX to 2.3 and ROCm to 2.7.1.  
Updates onnxruntime-openvino with IPEX / XPU to 1.22.0  
Updates onnxruntime-rocm 1.21.0  
Updated tensorflow-rocm to 2.16.2  

Changes environment variable settings with IPEX to not overwrite if the value is set by the user in gui.sh  
Adds `pip install --upgrade pip` to setup.sh with ROCm because PyTorch 2.7.1+rocm cannot be installed with older pip because the whl file is too large for older pip.  

Also adds requirements_ipex_xpu.txt for PyTorch 2.7.1+xpu without IPEX.  
This one should work with Windows and also Battlemage GPUs.  
Tho it is very slow compared to IPEX 2.3 on Linux.  
Haven't implemented Intel venv setup on Windows as i don't use Windows on my PCs.  
PyTorch 2.7.1 with Intel requires this PR on sd-scripts: https://github.com/kohya-ss/sd-scripts/pull/2121