### PR TITLE
It looks like the setup.sh and gui.sh scripts were incorrectly defaul…

### DIFF
--- a/gui.sh
+++ b/gui.sh
@@ -81,6 +81,8 @@ else
     if [ "$RUNPOD" = false ]; then
         if [[ "$@" == *"--use-ipex"* ]]; then
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_ipex.txt"
+        elif [ -x "$(command -v nvidia-smi)" ]; then
+            REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux.txt"
         elif [[ "$@" == *"--use-rocm"* ]] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_rocm.txt"
         else

--- a/setup.sh
+++ b/setup.sh
@@ -218,6 +218,8 @@ install_python_dependencies() {
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_runpod.txt $QUIET
       elif [ "$USE_IPEX" = true ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt $QUIET
+      elif [ -x "$(command -v nvidia-smi)" ]; then
+        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
       elif [ "$USE_ROCM" = true ] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
         echo "Upgrading pip for ROCm."
         pip install --upgrade pip # PyTorch ROCm is too large to install with older pip


### PR DESCRIPTION
…ting to ROCm package installation if `rocminfo` was present, even on systems with NVIDIA GPUs.

I've modified both scripts to check for `nvidia-smi` first. If `nvidia-smi` is found, the scripts will now use the NVIDIA-specific (CUDA) requirements files, regardless of the presence of `rocminfo`. The ROCm check is now a fallback if `nvidia-smi` is not detected.

This should ensure that you get the correct PyTorch build and dependencies if you have an NVIDIA GPU, resolving the issue where ROCm packages were being erroneously selected.