### PR TITLE
Refactor: Remove easygui and replace dialogs with notifications

### DIFF
--- a/kohya_gui/class_tensorboard.py
+++ b/kohya_gui/class_tensorboard.py
@@ -12,7 +12,6 @@ try:
 except ImportError:
     visibility = False
 
-from easygui import msgbox
 from threading import Thread, Event
 from .custom_logging import setup_logging
 from .common_gui import setup_environment
@@ -60,7 +59,7 @@ class TensorboardManager:
             self.log.error(
                 "Error: logging folder does not exist or does not contain logs."
             )
-            msgbox(msg="Error: logging folder does not exist or does not contain logs.")
+            gr.Warning("Error: logging folder does not exist or does not contain logs.")
             return self.get_button_states(started=False)
 
         run_cmd = [

--- a/kohya_gui/manual_caption_gui.py
+++ b/kohya_gui/manual_caption_gui.py
@@ -1,5 +1,4 @@
 import gradio as gr
-from easygui import msgbox, boolbox
 from .common_gui import get_folder_path, scriptdir, list_dirs
 from math import ceil
 import os
@@ -48,7 +47,7 @@ def paginate_go(page, max_page):
     try:
         page = float(page)
     except:
-        msgbox(f"Invalid page num: {page}")
+        gr.Error(f"Invalid page num: {page}")
         return
     return paginate(page, max_page, 0)
 
@@ -107,7 +106,7 @@ def update_image_tags(
 
 
 def import_tags_from_captions(
-    images_dir, caption_ext, quick_tags_text, ignore_load_tags_word_count
+    images_dir, caption_ext, quick_tags_text, ignore_load_tags_word_count, headless=False
 ):
     """
     Scans images directory for all available captions and loads all tags
@@ -119,23 +118,23 @@ def import_tags_from_captions(
 
     # Check for images_dir
     if not images_dir:
-        msgbox("Image folder is missing...")
+        gr.Warning("Image folder is missing...")
         return empty_return()
 
     if not os.path.exists(images_dir):
-        msgbox("Image folder does not exist...")
+        gr.Warning("Image folder does not exist...")
         return empty_return()
 
     if not caption_ext:
-        msgbox("Please provide an extension for the caption files.")
+        gr.Warning("Please provide an extension for the caption files.")
         return empty_return()
 
     if quick_tags_text:
-        if not boolbox(
-            f"Are you sure you wish to overwrite the current quick tags?",
-            choices=("Yes", "No"),
-        ):
-            return empty_return()
+        overwrite_message = "Overwriting existing quick tags."
+        if not headless:
+            gr.Info(overwrite_message)
+        log.info(overwrite_message)
+        # Proceeding to overwrite by not returning early.
 
     images_list = os.listdir(images_dir)
     image_files = [f for f in images_list if f.lower().endswith(IMAGE_EXTENSIONS)]
@@ -173,15 +172,15 @@ def load_images(images_dir, caption_ext, loaded_images_dir, page, max_page):
 
     # Check for images_dir
     if not images_dir:
-        msgbox("Image folder is missing...")
+        gr.Warning("Image folder is missing...")
         return empty_return()
 
     if not os.path.exists(images_dir):
-        msgbox("Image folder does not exist...")
+        gr.Warning("Image folder does not exist...")
         return empty_return()
 
     if not caption_ext:
-        msgbox("Please provide an extension for the caption files.")
+        gr.Warning("Please provide an extension for the caption files.")
         return empty_return()
 
     # Load Images
@@ -444,7 +443,7 @@ def gradio_manual_caption_gui_tab(headless=False, default_images_dir=None):
 
         # Import tags button
         import_tags_button.click(
-            import_tags_from_captions,
+            lambda loaded_dir, cap_ext, q_text, ignore_wc: import_tags_from_captions(loaded_dir, cap_ext, q_text, ignore_wc, headless=headless),
             inputs=[
                 loaded_images_dir,
                 caption_ext,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "bitsandbytes>=0.45.0",
     "dadaptation==3.2",
     "diffusers[torch]==0.32.2",
-    "easygui==0.98.3",
     "einops==0.7.0",
     "fairscale==0.4.13",
     "ftfy==6.1.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ aiofiles==23.2.1
 altair==4.2.2
 dadaptation==3.2
 diffusers[torch]==0.32.2
-easygui==0.98.3
 einops==0.7.0
 fairscale==0.4.13
 ftfy==6.1.1


### PR DESCRIPTION
Removed all usage of the `easygui` library.

- Replaced `easygui.msgbox` calls with Gradio notifications (`gr.Info`, `gr.Warning`, `gr.Error`) to display messages and errors directly in the UI.
- Replaced `easygui.ynbox` and `easygui.boolbox` confirmation dialogs with a default action of proceeding with the operation, accompanied by a notification. This affects:
    - Model saving: Will now overwrite existing models by default, notifying the user.
    - Dataset balancing: Enabling 'insecure folder renaming' will proceed without a second confirmation, with a warning displayed.
    - Manual captioning: Importing tags will overwrite existing quick tags by default, with a notification.
- Removed `easygui` from all Python import statements.
- Removed `easygui` from `requirements.txt` and `pyproject.toml`.