### PR TITLE
Align Gradio UI elements with config.toml

### DIFF
--- a/config example.toml
+++ b/config example.toml
@@ -8,6 +8,7 @@ expand_all_accordions = true # Expand all accordions in the UI by default
 # Default folders location
 [model]
 models_dir = "./models"                    # Pretrained model name or path. Initial value for dropdown, e.g. "runwayml/stable-diffusion-v1-5"
+pretrained_model_name_or_path = "runwayml/stable-diffusion-v1-5" # Default actual model path/name for dropdown
 output_name = "last"                       # Trained model output name
 train_data_dir = ""                        # Image folder (containing training images subfolders) / Image folder (containing training images). Initial value for dropdown.
 dataset_config = ""                        # Dataset config file (Optional. Select the toml configuration file to use for the dataset). Initial value for dropdown.
@@ -174,6 +175,9 @@ expand_basic_accordion = true
 
 [finetune] # Section for Finetune specific UI settings
 expand_basic_accordion = true
+# [finetune.advanced] for elements in finetune_gui's advanced section (if any specific beyond general advanced)
+[finetune.advanced]
+block_lr = ""                             # Block LR (SDXL) for finetuning
 # [finetune.basic] for elements directly in finetune_gui's basic section
 [finetune.basic]
 dataset_repeats = "40"
@@ -194,10 +198,12 @@ weighted_captions = false
 
 [lora] # Section for LoRA specific UI settings
 expand_basic_accordion = true
+expand_lycoris_accordion = false # control visibility of LyCORIS specific section
 # [lora.basic] for elements directly in lora_gui's basic section
 [lora.basic]
 lora_type = "Standard"
 lycoris_preset = "full" # Default for LyCORIS preset dropdown
+network_weights = ""    # Path to existing LoRA network weights
 dim_from_weights = false
 text_encoder_lr = 0.0 # Explicitly float
 t5xxl_lr = 0.0        # Explicitly float
@@ -217,6 +223,18 @@ unit = 1 # For DyLoRA
 train_lora_ggpo = false
 ggpo_sigma = 0.03
 ggpo_beta = 0.01
+
+# [lora.advanced] for LoRA specific advanced settings (weights, blocks, conv layers)
+[lora.advanced]
+down_lr_weight = ""
+mid_lr_weight = ""
+up_lr_weight = ""
+block_lr_zero_threshold = ""
+block_dims = ""
+block_alphas = ""
+conv_block_dims = ""
+conv_block_alphas = ""
+
 # [lora.lycoris] for LyCORIS specific parameters
 [lora.lycoris]
 factor = -1
@@ -240,6 +258,7 @@ token_string = "" # Default is empty as per current code
 init_word = "*"
 num_vectors_per_token = 1
 template = "caption"
+weights = "" # Path to existing TI embedding file to resume training
 
 [sd3] # SD3 specific parameters from class_sd3.py
 weighting_scheme = "logit_normal"

--- a/kohya_gui/class_basic_training.py
+++ b/kohya_gui/class_basic_training.py
@@ -89,8 +89,8 @@ class BasicTraining:
                 minimum=1,
                 maximum=64,
                 label="Train batch size",
-                value=1,
-                step=self.config.get("basic.train_batch_size", 1),
+                value=self.config.get("basic.train_batch_size", 1),
+                step=1,
             )
             # Initialize the epoch number input
             self.epoch = gr.Number(

--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -111,7 +111,7 @@ class SourceModel:
                         self.pretrained_model_name_or_path = gr.Dropdown(
                             label="Pretrained model name or path",
                             choices=default_models + model_checkpoints,
-                            value=self.config.get("model.models_dir", "runwayml/stable-diffusion-v1-5"),
+                            value=self.config.get("model.pretrained_model_name_or_path", "runwayml/stable-diffusion-v1-5"),
                             allow_custom_value=True,
                             visible=True,
                             min_width=100,

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -1206,7 +1206,7 @@ def dreambooth_tab(
             gradio_dataset_balancing_tab(headless=headless)
 
         with gr.Accordion("Parameters", open=config.get("settings.expand_all_accordions", False)), gr.Column():
-            with gr.Accordion("Basic", open="True"):
+            with gr.Accordion("Basic", open=config.get("dreambooth.expand_basic_accordion", True)):
                 with gr.Group(elem_id="basic_tab"):
                     basic_training = BasicTraining(
                         learning_rate_value=1e-5,

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -1350,6 +1350,7 @@ def finetune_tab(
                         label="Block LR (SDXL)",
                         placeholder="(Optional)",
                         info="Specify the different learning rates for each U-Net block. Specify 23 values separated by commas like 1e-3,1e-3 ... 1e-3",
+                        value=config.get("finetune.advanced.block_lr", ""),
                     )
                 advanced_training = AdvancedTraining(
                     headless=headless, finetuning=True, config=config

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -1956,6 +1956,7 @@ def lora_tab(
                                 label="Network weights",
                                 placeholder="(Optional)",
                                 info="Path to an existing LoRA network weights to resume training from",
+                                value=config.get("lora.basic.network_weights", ""),
                             )
                             network_weights_file = gr.Button(
                                 document_symbol,
@@ -2690,21 +2691,25 @@ def lora_tab(
                                 label="Down LR weights",
                                 placeholder="(Optional) eg: 0,0,0,0,0,0,1,1,1,1,1,1",
                                 info="Specify the learning rate weight of the down blocks of U-Net.",
+                                value=config.get("lora.advanced.down_lr_weight", ""),
                             )
                             mid_lr_weight = gr.Textbox(
                                 label="Mid LR weights",
                                 placeholder="(Optional) eg: 0.5",
                                 info="Specify the learning rate weight of the mid block of U-Net.",
+                                value=config.get("lora.advanced.mid_lr_weight", ""),
                             )
                             up_lr_weight = gr.Textbox(
                                 label="Up LR weights",
                                 placeholder="(Optional) eg: 0,0,0,0,0,0,1,1,1,1,1,1",
                                 info="Specify the learning rate weight of the up blocks of U-Net. The same as down_lr_weight.",
+                                value=config.get("lora.advanced.up_lr_weight", ""),
                             )
                             block_lr_zero_threshold = gr.Textbox(
                                 label="Blocks LR zero threshold",
                                 placeholder="(Optional) eg: 0.1",
                                 info="If the weight is not more than this value, the LoRA module is not created. The default is 0.",
+                                value=config.get("lora.advanced.block_lr_zero_threshold", ""),
                             )
                     with gr.Tab(label="Blocks"):
                         with gr.Row(visible=True):
@@ -2712,11 +2717,13 @@ def lora_tab(
                                 label="Block dims",
                                 placeholder="(Optional) eg: 2,2,2,2,4,4,4,4,6,6,6,6,8,6,6,6,6,4,4,4,4,2,2,2,2",
                                 info="Specify the dim (rank) of each block. Specify 25 numbers.",
+                                value=config.get("lora.advanced.block_dims", ""),
                             )
                             block_alphas = gr.Textbox(
                                 label="Block alphas",
                                 placeholder="(Optional) eg: 2,2,2,2,4,4,4,4,6,6,6,6,8,6,6,6,6,4,4,4,4,2,2,2,2",
                                 info="Specify the alpha of each block. Specify 25 numbers as with block_dims. If omitted, the value of network_alpha is used.",
+                                value=config.get("lora.advanced.block_alphas", ""),
                             )
                     with gr.Tab(label="Conv"):
                         with gr.Row(visible=True):
@@ -2724,11 +2731,13 @@ def lora_tab(
                                 label="Conv dims",
                                 placeholder="(Optional) eg: 2,2,2,2,4,4,4,4,6,6,6,6,8,6,6,6,6,4,4,4,4,2,2,2,2",
                                 info="Extend LoRA to Conv2d 3x3 and specify the dim (rank) of each block. Specify 25 numbers.",
+                                value=config.get("lora.advanced.conv_block_dims", ""),
                             )
                             conv_block_alphas = gr.Textbox(
                                 label="Conv alphas",
                                 placeholder="(Optional) eg: 2,2,2,2,4,4,4,4,6,6,6,6,8,6,6,6,6,4,4,4,4,2,2,2,2",
                                 info="Specify the alpha of each block when expanding LoRA to Conv2d 3x3. Specify 25 numbers. If omitted, the value of conv_alpha is used.",
+                                value=config.get("lora.advanced.conv_block_alphas", ""),
                             )
                 advanced_training = AdvancedTraining(
                     headless=headless, training_type="lora", config=config

--- a/kohya_gui/textual_inversion_gui.py
+++ b/kohya_gui/textual_inversion_gui.py
@@ -1032,7 +1032,7 @@ def ti_tab(
                         weights = gr.Dropdown(
                             label="Resume TI training (Optional. Path to existing TI embedding file to keep training)",
                             choices=[""] + list_embedding_files(current_embedding_dir),
-                            value="",
+                            value=config.get("textual_inversion.basic.weights", ""),
                             interactive=True,
                             allow_custom_value=True,
                         )


### PR DESCRIPTION
Ensured that all relevant Gradio UI elements in Dreambooth, Finetune, LoRA, and Textual Inversion GUIs, along with their supporting classes, load their default values from `config.toml`.

- Added missing keys to `config example.toml` for newly configurable elements.
- Modified Python files to use `config.get()` for these elements, preserving original default behaviors if keys are not in `config.toml`.
- Corrected minor inconsistencies in existing `config.get()` usage.