### PR TITLE
wd14 tagger: add SmilingWolf/wd-eva02-large-tagger-v3

### DIFF
--- a/kohya_gui/wd14_caption_gui.py
+++ b/kohya_gui/wd14_caption_gui.py
@@ -206,6 +206,7 @@ def gradio_wd14_caption_gui_tab(
                     "SmilingWolf/wd-swinv2-tagger-v3",
                     "SmilingWolf/wd-vit-tagger-v3",
                     "SmilingWolf/wd-convnext-tagger-v3",
+                    "SmilingWolf/wd-eva02-large-tagger-v3",
                 ],
                 value=config.get(
                     "wd14_caption.repo_id", "SmilingWolf/wd-v1-4-convnextv2-tagger-v2"


### PR DESCRIPTION
I've personally tried tagging with this larger model from SmilingWolf and it seems to be an improvement to the earlier models. 

https://huggingface.co/SmilingWolf/wd-eva02-large-tagger-v3

Seems to work with the already-required onnxruntime deps for the overall project.

NOTE: there's also another large model at
https://huggingface.co/SmilingWolf/wd-vit-large-tagger-v3 that i haven't tried. I'm not entirely sure what the difference is between the eva02 and vit models, but if you'd like I can try them out and update the pull request to add it as well.