### PR TITLE
Updated Runpod template links

### DIFF
--- a/docs/Installation/installation_runpod.md
+++ b/docs/Installation/installation_runpod.md
@@ -36,12 +36,18 @@ To install the necessary components for Runpod and run kohya_ss, follow these st
 
 6. Connect to the public URL displayed after the installation process is completed.
 
-#### Pre-built Runpod template
+#### Pre-built Runpod templates
 
 To run from a pre-built Runpod template, you can:
 
-1. Open the Runpod template by clicking on <https://runpod.io/gsc?template=ya6013lj5a&ref=w18gds2n>.
+1. Open the Runpod template by clicking on one of the template links in the table below.
 
 2. Deploy the template on the desired host.
 
 3. Once deployed, connect to the Runpod on HTTP 3010 to access the kohya_ss GUI. You can also connect to auto1111 on HTTP 3000.
+
+| Runpod Template Version                                                                 | Runpod Template Description                        |
+|-----------------------------------------------------------------------------------------|----------------------------------------------------|
+| [CUDA 12.4 template](https://runpod.io/console/deploy?template=uajca40f1z&ref=2xxro4sy) | Template with CUDA 12.4 for non-RTX 5090 GPU types |
+| [CUDA 12.8 template](https://runpod.io/console/deploy?template=8y5a02q55r&ref=2xxro4sy) | Template with CUDA 12.8 for RTX 5090 GPU type      |
+


### PR DESCRIPTION
* Updated the invalid existing Runpod template link to the correct new template link.
* Added additional template link for RTX 5090 GPU type which uses different CUDA, torch and xformers versions than the standard template.