### PR TITLE
Upgrade Pytorch for XPU

### DIFF
--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -2,8 +2,8 @@
 --extra-index-url https://download.pytorch.org/whl/xpu
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 
-torch==2.7.0+xpu
-torchvision==0.22.0+xpu
+torch==2.7.1+xpu
+torchvision==0.22.1+xpu
 intel-extension-for-pytorch==2.7.10+xpu
 oneccl_bind_pt==2.7.0+xpu
 

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -10,6 +10,7 @@ oneccl_bind_pt==2.7.0+xpu
 tensorboard==2.15.2
 tensorflow==2.15.0
 intel-extension-for-tensorflow[xpu]==2.15.0.2
+onnxruntime==1.22.1
 onnxruntime-openvino==1.22.0
 
 mkl==2025.0.1

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -2,8 +2,8 @@
 --extra-index-url https://download.pytorch.org/whl/xpu
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 
-torch==2.7.1+xpu
-torchvision==0.22.1+xpu
+torch==2.7.0+xpu
+torchvision==0.22.0+xpu
 intel-extension-for-pytorch==2.7.10+xpu
 oneccl_bind_pt==2.7.0+xpu
 

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,19 +1,21 @@
 # Custom index URL for specific packages
+--extra-index-url https://download.pytorch.org/whl/xpu
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
 
-torch==2.3.1+cxx11.abi
-torchvision==0.18.1+cxx11.abi
-intel-extension-for-pytorch==2.3.110+xpu
-oneccl_bind_pt==2.3.100+xpu
+torch==2.7.0+xpu
+torchvision==0.22.0+xpu
+intel-extension-for-pytorch==2.7.10+xpu
+oneccl_bind_pt==2.7.0+xpu
 
 tensorboard==2.15.2
-tensorflow==2.15.1
-intel-extension-for-tensorflow[xpu]==2.15.0.1
+tensorflow==2.15.0
+intel-extension-for-tensorflow[xpu]==2.15.0.2
 onnxruntime-openvino==1.22.0
 
-mkl==2024.2.1
-mkl-dpcpp==2024.2.1
-oneccl-devel==2021.13.1
-impi-devel==2021.13.1
+mkl==2025.0.1
+mkl-dpcpp==2025.0.1
+oneccl-devel==2021.14.1
+impi-devel==2021.14.1
 
 -r requirements.txt
+


### PR DESCRIPTION
This Pull Request upgrades the Pytorch related stuff to their latest versions for XPU. In order for it to work, the user must have `intel-oneapi-base-toolkit-2025.0` installed (it would be nice if there was a warning for it on setup.sh, but I will leave that to you).

It also upgrades the OneAPI and ONNX related stuff. After some testing, I found out that the `onnxruntime` is needed for the WD14 Captioning to work properly.

I also made a Dockerfile for it. It currently uses my fork while this Pull Request is not merged: https://gist.github.com/WizardlyBump17/3aebf0e1731500e8f4afcba22055b434.

This Pull Request partially fixes #3333, as the correct fix would be to make it work with `intel-oneapi-base-toolkit`, but that is only possible on nightly versions of Pytorch for XPU, but `intel-extension-for-pytorch` requires the stable 2.7.1 version.