### PR TITLE
fix: use the identified python version in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -230,24 +230,24 @@ install_python_dependencies() {
   case "$OSTYPE" in
     "lin"*)
       if [ "$RUNPOD" = true ]; then
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_runpod.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_runpod.txt $QUIET
       elif [ "$USE_IPEX" = true ]; then
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt $QUIET
       elif [ -x "$(command -v nvidia-smi)" ]; then
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
       elif [ "$USE_ROCM" = true ] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
         echo "Upgrading pip for ROCm."
         pip install --upgrade pip # PyTorch ROCm is too large to install with older pip
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_rocm.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_rocm.txt $QUIET
       else
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
       fi
       ;;
     "darwin"*)
       if [[ "$(uname -m)" == "arm64" ]]; then
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_macos_arm64.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_macos_arm64.txt $QUIET
       else
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_macos_amd64.txt $QUIET
+        "$PYTHON_CMD" "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_macos_amd64.txt $QUIET
       fi
       ;;
   esac


### PR DESCRIPTION
Fix for an issue I had with setup on [Linux – Installation (pip method)](https://github.com/bmaltais/kohya_ss/blob/master/docs/Installation/pip_linux.md).

The setup script correctly identified `$PYTHON_CMD` to 3.11 (as I have locally installed by `pyenv`).
But then it uses the plain `python` command. Maybe I'm missing something, but that seems to me as an oversight. Indeed, with this change I am able to proceed with setup :heavy_check_mark: :slightly_smiling_face: 