### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1439,7 +1439,7 @@ def validate_toml_file(file_path: str) -> bool:
 
     try:
         toml.load(file_path)
-    except:
+    except Exception:
         log.error(f"{msg} FAILED: is not a valid toml file.")
         return False
     log.info(f"{msg} SUCCESS")

--- a/kohya_gui/custom_logging.py
+++ b/kohya_gui/custom_logging.py
@@ -22,7 +22,7 @@ def setup_logging(clean=False, debug=False):
         if clean and os.path.isfile("setup.log"):
             os.remove("setup.log")
         time.sleep(0.1)  # prevent race condition
-    except:
+    except Exception:
         pass
 
     if sys.version_info >= (3, 9):

--- a/kohya_gui/manual_caption_gui.py
+++ b/kohya_gui/manual_caption_gui.py
@@ -47,7 +47,7 @@ def _get_tag_checkbox_updates(caption, quick_tags, quick_tags_set):
 def paginate_go(page, max_page):
     try:
         page = float(page)
-    except:
+    except Exception:
         msgbox(f"Invalid page num: {page}")
         return
     return paginate(page, max_page, 0)

--- a/kohya_gui/sd_modeltype.py
+++ b/kohya_gui/sd_modeltype.py
@@ -44,7 +44,7 @@ class SDModelType:
                 self.model_type = ModelType.SD2
             elif hasKeyPrefix("model."):
                 self.model_type = ModelType.SD1
-        except:
+        except Exception:
             pass
         
         # print(f"Model type: {self.model_type}")


### PR DESCRIPTION
## What
Replace 4 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.