### PR TITLE
Fix requirement installation using system pip

### DIFF
--- a/setup/setup_common.py
+++ b/setup/setup_common.py
@@ -174,7 +174,7 @@ def install_requirements_inbulk(
     log.info(f"Installing/Validating requirements from {requirements_file}...")
 
     # Build the command as a list
-    cmd = ["pip", "install", "-r", requirements_file]
+    cmd = [sys.executable, "-m", "pip", "install", "-r", requirements_file]
     if installed("uv") and shutil.which("uv"):
         log.info("Using uv for pip...")
         cmd.insert(0, "uv")


### PR DESCRIPTION
I encountered this issue while running gui.bat with a Python 3.10 virtual environment and Python 3.13 installed globally.

## Summary

When launching `gui.bat`, requirement validation is performed by `setup_common.py`.

Currently `install_requirements_inbulk()` executes:

```python
cmd = ["pip", "install", "-r", requirements_file]
```

This invokes `pip` through the operating system PATH lookup rather than through the Python interpreter that is currently running the application.

As a result, package installation may be performed by a different Python environment than the active virtual environment used by kohya_ss.

## Problem

For example:

* Global Python installed: 3.13
* kohya_ss virtual environment: 3.10.11

The GUI correctly reports:

```text
Python version is 3.10.11
```

However, during requirement validation the subprocess executes pip from the global PATH, causing packages to be resolved for the global Python installation instead of the active virtual environment.

Example log:

```text
Collecting torch==2.7.0+cu128
Downloading torch-2.7.0+cu128-cp313-cp313-win_amd64.whl
```

This can lead to incompatible wheel selection and installation failures.

The issue is not specific to Python 3.13; it can occur whenever the PATH-resolved pip belongs to a different Python installation than the interpreter running kohya_ss.

## Fix

Use the current interpreter to invoke pip:

```python
cmd = [sys.executable, "-m", "pip", "install", "-r", requirements_file]
```

This guarantees that requirement installation is performed in the same environment that is executing kohya_ss.