### PR TITLE
Fix macOS ARM64 dependency conflicts and remove bitsandbytes

### DIFF
--- a/requirements_macos_arm64.txt
+++ b/requirements_macos_arm64.txt
@@ -1,8 +1,13 @@
---pre --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-torch==2.8.0.*
-torchvision==0.22.*
-git+https://github.com/bitsandbytes-foundation/bitsandbytes.git/#0.45.5
-tensorflow-macos 
+# macOS arm64 (Apple Silicon): the default PyPI wheels already ship MPS support,
+# so no additional PyTorch index is needed here.
+# torch and torchvision must be a matching pair: torchvision 0.23.0 requires
+# exactly torch 2.8.0 (0.22.x requires torch 2.7.x). The previous
+# torch 2.8.0 / torchvision 0.22 pair was unsatisfiable and broke pip resolution.
+torch==2.8.0
+torchvision==0.23.0
+# bitsandbytes omitted: CUDA/ROCm-only, unsupported on macOS arm64 / MPS.
+# 8-bit optimizers (AdamW8bit, etc.) are therefore unavailable on this platform.
+tensorflow-macos
 tensorflow-metal
 tensorboard==2.14.1
 onnxruntime==1.17.1


### PR DESCRIPTION
Thanks for the detailed review. I've rewritten this PR from scratch on top of current `master` (`45088f0`), so it's now a single clean commit with no conflicts. I've also fixed my git author metadata (the `BuildTools <unconfigured@null.spigotmc.org>` address was a stale global git config on my machine, not intentional).

First, a correction to my original description, which was simply wrong: I wrote that I "relaxed" the torch pins, but the diff actually commented them out. You were right to call that out. Worse, my original "tested locally, GUI boots" claim was made in an environment where commenting out the pins had let pip pull `torch 2.12.1` , so it was never evidence for the versions this PR proposes. I've redone the testing properly, and I've been explicit below about what I did and did not verify.

## Root cause

The `ResolutionImpossible` on Apple Silicon isn't caused by strict pinning in general. It's one specific pin pair in `requirements_macos_arm64.txt` that cannot be satisfied:

```
torch==2.8.0.*
torchvision==0.22.*
```

`torchvision` pins an exact `torch` version in its own metadata:

| torchvision | requires |
|---|---|
| `0.22.0` | `torch==2.7.0` |
| `0.22.1` | `torch==2.7.1` |
| `0.23.0` | `torch==2.8.0` |

So `torch==2.8.0.*` and `torchvision==0.22.*` are mutually exclusive — no solution exists. pip says so directly. Reproduced on current `master`, with only the `bitsandbytes` line removed so that torch is the sole variable:

```
The conflict is caused by:
    The user requested torch==2.8.0.*
    torchvision 0.22.1 depends on torch==2.7.1
    torchvision 0.22.0 depends on torch==2.7.0
ERROR: ResolutionImpossible
```

This looks like bitrot rather than an original mistake: when #3174 added these pins (April 2025), `2.8.0` and `0.22` *were* the matching pair on the PyTorch nightly index. Once `torch 2.8.0` shipped as a stable release, stable `torchvision 0.23.0` became its partner and the pinned pair stopped lining up. The `--pre` added in #3518 can't rescue it either, because an exact `torch==2.8.0` never matches a nightly `2.8.0.devN`.

## Changes

**1. Pin the matching pair** — `torch==2.8.0` + `torchvision==0.23.0`. This keeps an explicit, verified, reproducible torch install for the platform (your review's option 2) and matches how `requirements_linux.txt` pins its own pair exactly.

**2. Drop `--pre --extra-index-url .../nightly/cpu`.** Flagging this explicitly since you noted it was intentional:

- The default PyPI `macosx_11_0_arm64` wheels already include MPS — unlike CUDA/ROCm, no platform-specific index is needed to get GPU support on Mac. I verified this directly (see Testing).
- This is already the project's own behaviour on darwin: `pyproject.toml` scopes `[tool.uv.sources]` for `torch`/`torchvision` to `sys_platform == 'linux'` and `'win32'` only, so `uv` already resolves darwin torch straight from PyPI. The pip path was the odd one out.
- `--pre` in a requirements file is a **global** pip flag, not per-package, so it currently permits prereleases of every other dependency too (`gradio`, `transformers`, ...). That looks like an unintended side effect.

I've recorded this reasoning in a comment in the file so the replacement isn't undocumented. Happy to restore the nightly index if you'd rather keep it — say the word and I'll push that instead.

**3. Remove `bitsandbytes` properly** — deleted, not commented out, with a short rationale comment as you suggested. It's a CUDA/ROCm 8-bit optimizer stack with no macOS arm64 support, and building it from git is a common Apple Silicon install failure. The comment notes that 8-bit optimizers (`AdamW8bit`, etc.) are consequently unavailable on this platform.

No `xformers` change is needed any more — `master` already dropped it in #3518.

## Testing

On an M-series Mac (macOS arm64), Python 3.10.15, in a **clean throwaway venv**:

- **Before:** `pip install --dry-run` with master's pins → `ResolutionImpossible` (output quoted above).
- **After:** `pip install --dry-run -r requirements_macos_arm64.txt` resolves cleanly and selects `torch-2.8.0 torchvision-0.23.0`.
- **Full install:** `pip install -r requirements_macos_arm64.txt` completes successfully (exit 0). Resolved set includes `torch-2.8.0`, `torchvision-0.23.0`, `numpy-1.26.4` (the `<2` constraint holds), `tensorflow-macos-2.15.1`, `tensorflow-metal-1.2.0`, `onnxruntime-1.17.1`. No `bitsandbytes`, no `xformers`.
- **MPS confirmed on the plain PyPI wheel** — this is the key check for dropping the nightly index:
  ```
  torch       2.8.0
  torchvision 0.23.0
  MPS built   True
  MPS avail   True
  ```
  and an actual device computation runs correctly: `torch.ones(64,64,device='mps') @ torch.ones(64,64,device='mps')` sums to `262144.0` as expected.
- **Test suite:** `pytest tests/ test/test_allowed_paths.py` → **388 passed, 9 subtests passed**.

**What I did not verify**, so you're not relying on anything I haven't actually run:

- I did not re-run `./setup.sh` or boot `./gui.sh` against this pin set (my working venv was in a broken mixed-Python state and my disk is nearly full, so I tested in an isolated venv instead). The install and MPS checks above exercise the part this diff actually changes.
- I only tested Python 3.10; the repo also supports 3.11. `torch 2.8.0` and `torchvision 0.23.0` both publish cp311 macOS arm64 wheels, so I expect it to resolve identically, but I haven't run it.
- I have not tested actual training under MPS — only that torch is installable and MPS is functional. Your review raised this and it remains open.

## Known gaps (deliberately not in this PR)

You flagged both as non-blocking. I've kept them out to hold this diff to one file, but I'm happy to open follow-ups:

1. `pyproject.toml` declares `bitsandbytes>=0.45.0`, `xformers>=0.0.30` and `onnxruntime-gpu==1.19.2` unconditionally, so the `uv` / `gui-uv.sh` path is still broken on Apple Silicon. A proper fix needs `sys_platform != 'darwin'` markers plus a regenerated `uv.lock`, which deserves its own PR and its own testing.
2. The GUI still offers bitsandbytes-backed optimizers, so Mac users who select one hit a runtime error rather than a clear message. A guard or a platform-aware optimizer list would be a good separate change.

I also couldn't add the Mac install-doc note you suggested, because there is no macOS install doc yet (`docs/Installation/` has only `pip_linux`, `pip_windows`, `uv_linux`, `uv_windows`). That's why the 8-bit caveat went into the requirements file comment instead. Glad to write a `docs/Installation/pip_macos.md` if that would be useful.
