### PR TITLE
Fix GUI arg drift against sd-scripts v0.11.1 refactor

### DIFF
--- a/kohya_gui/class_advanced_training.py
+++ b/kohya_gui/class_advanced_training.py
@@ -286,11 +286,17 @@ class AdvancedTraining:
                 info="Disable low VRAM optimization. e.g. do not clear CUDA cache after each latent caching (for machines which have bigger VRAM)",
                 interactive=True,
             )
+            # lowvram was removed from sd-scripts (only --highvram remains) and
+            # is no longer forwarded to any training config; hidden rather than
+            # deleted to avoid touching every train_model()/save_configuration()/
+            # open_configuration() signature and .click() wiring list that
+            # still threads this widget through by position.
             self.lowvram = gr.Checkbox(
                 label="lowvram",
                 value=self.config.get("advanced.lowvram", False),
                 info="Enable low RAM optimization. e.g. load models to VRAM instead of RAM (for machines which have bigger VRAM than RAM such as Colab and Kaggle)",
                 interactive=True,
+                visible=False,
             )
             self.skip_cache_check = gr.Checkbox(
                 label="Skip cache check",

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -741,9 +741,9 @@ def get_effective_lr_messages(
 
 def append_loraplus_network_args(
     network_args: str,
-    loraplus_lr_ratio: float,
-    loraplus_unet_lr_ratio: float,
-    loraplus_text_encoder_lr_ratio: float,
+    loraplus_lr_ratio: float | None,
+    loraplus_unet_lr_ratio: float | None,
+    loraplus_text_encoder_lr_ratio: float | None,
 ) -> str:
     # sd-scripts only reads loraplus_* via --network_args (networks/lora.py's
     # create_network kwargs), not as top-level config keys, so they must be

--- a/kohya_gui/textual_inversion_gui.py
+++ b/kohya_gui/textual_inversion_gui.py
@@ -590,16 +590,7 @@ def train_model(
         log.info(
             "Dataset config toml file used, skipping total_steps, train_batch_size, gradient_accumulation_steps, epoch, reg_factor, max_train_steps calculations..."
         )
-        if max_train_steps > 0:
-            # calculate stop encoder training
-            if stop_text_encoder_training_pct == 0:
-                stop_text_encoder_training = 0
-            else:
-                stop_text_encoder_training = math.ceil(
-                    float(max_train_steps) / 100 * int(stop_text_encoder_training_pct)
-                )
-        else:
-            stop_text_encoder_training = 0
+        if max_train_steps == 0:
             lr_warmup_steps = 0
 
         if max_train_steps == 0:
@@ -684,14 +675,6 @@ def train_model(
             else:
                 max_train_steps_info = f"Max train steps: {max_train_steps}"
 
-        # calculate stop encoder training
-        if stop_text_encoder_training_pct == 0:
-            stop_text_encoder_training = 0
-        else:
-            stop_text_encoder_training = math.ceil(
-                float(max_train_steps) / 100 * int(stop_text_encoder_training_pct)
-            )
-
         log.info(f"Total steps: {total_steps}")
 
     # Calculate lr_warmup_steps
@@ -708,7 +691,10 @@ def train_model(
     log.info(f"Gradient accumulation steps: {gradient_accumulation_steps}")
     log.info(f"Epoch: {epoch}")
     log.info(max_train_steps_info)
-    log.info(f"stop_text_encoder_training = {stop_text_encoder_training}")
+    # stop_text_encoder_training_pct is not forwarded to the training config
+    # (train_textual_inversion.py / sdxl_train_textual_inversion.py don't
+    # accept it — see the config_toml_data comment below), so it's not
+    # calculated or logged here either.
     log.info(f"lr_warmup_steps = {lr_warmup_steps}")
 
     accelerate_path = get_executable_path("accelerate")


### PR DESCRIPTION
## Summary

Fixes #3520. Several config values `kohya_gui` writes to the training TOML are silently ignored by sd-scripts because `read_config_from_file()` builds an argparse `Namespace` directly from the TOML dict, so unknown keys never raise an error:

- **LoRA+ ratios** (`loraplus_lr_ratio`/`loraplus_unet_lr_ratio`/`loraplus_text_encoder_lr_ratio`) were written as top-level keys, but sd-scripts only reads them via `--network_args`; LoRA+ was effectively a no-op through the GUI for all four network-training scripts.
- **`lowvram`** was still emitted for a flag sd-scripts removed entirely.
- **`split_mode`/`train_blocks`** (LoRA-only, `flux_train_network.py`) leaked into the `flux_train.py` full-fine-tune config from `finetune_gui.py` and `dreambooth_gui.py`, neither of which accept them.
- **`stop_text_encoder_training`** (`train_db.py`-only) leaked into `textual_inversion_gui.py`'s config for scripts that don't accept it.

Note: this branch was cut from `532db49` (the commit right before the fix landed) since the fix commit is already present on `dev`'s history — this PR exists to give the change a reviewable diff and reference.

## Test plan

- [x] Added `tests/test_lora_gui.py`, `tests/test_finetune_gui.py`, `tests/test_dreambooth_gui.py`, `tests/test_textual_inversion_gui.py` — each drives `train_model(print_only=True)` end-to-end against real preset fixtures and inspects the generated TOML for the fixed keys
- [x] Verified all new tests fail against the pre-fix code (reverted, confirmed red, restored)
- [x] `uv run python -m pytest tests/ test/test_allowed_paths.py` — 13 passed
- [x] `sd-scripts` submodule untouched