### PR TITLE
Expose --svd_lowrank_niter in Resize LoRA tab

### DIFF
--- a/kohya_gui/resize_lora_gui.py
+++ b/kohya_gui/resize_lora_gui.py
@@ -32,6 +32,7 @@ def resize_lora(
     dynamic_method,
     dynamic_param,
     verbose,
+    svd_lowrank_niter,
 ):
     # Check for caption_text_input
     if model == "":
@@ -85,6 +86,10 @@ def resize_lora(
         run_cmd.append(dynamic_method)
         run_cmd.append("--dynamic_param")
         run_cmd.append(str(dynamic_param))
+
+    if svd_lowrank_niter is not None:
+        run_cmd.append("--svd_lowrank_niter")
+        run_cmd.append(str(int(svd_lowrank_niter)))
 
     # Check for verbosity
     if verbose:
@@ -231,6 +236,16 @@ def gradio_resize_lora_tab(
                 value="cuda",
                 interactive=True,
             )
+        with gr.Row():
+            svd_lowrank_niter = gr.Number(
+                label="SVD lowrank iterations",
+                info="Number of iterations for svd_lowrank on large matrices (>2048 dims). 0 to disable and use full SVD",
+                value=2,
+                minimum=0,
+                step=1,
+                precision=0,
+                interactive=True,
+            )
 
         convert_button = gr.Button("Resize model")
 
@@ -245,6 +260,7 @@ def gradio_resize_lora_tab(
                 dynamic_method,
                 dynamic_param,
                 verbose,
+                svd_lowrank_niter,
             ],
             show_progress=False,
         )

--- a/tests/test_resize_lora_gui.py
+++ b/tests/test_resize_lora_gui.py
@@ -1,0 +1,52 @@
+"""Regression tests for GH issue #3529: expose --svd_lowrank_niter in the
+Resize LoRA tab.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+from kohya_gui import resize_lora_gui
+
+
+class TestResizeLoraSvdLowrankNiter(unittest.TestCase):
+    def setUp(self):
+        self.model_file = tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False)
+        self.model_file.close()
+        self.addCleanup(os.unlink, self.model_file.name)
+
+    def _run_and_capture_cmd(self, svd_lowrank_niter):
+        with patch.object(resize_lora_gui.subprocess, "run") as mock_run:
+            resize_lora_gui.resize_lora(
+                model=self.model_file.name,
+                new_rank=4,
+                save_to=os.path.join(tempfile.gettempdir(), "out.safetensors"),
+                save_precision="fp16",
+                device="cpu",
+                dynamic_method="None",
+                dynamic_param="0.9",
+                verbose=False,
+                svd_lowrank_niter=svd_lowrank_niter,
+            )
+        self.assertTrue(mock_run.called)
+        return mock_run.call_args[0][0]
+
+    def test_includes_flag_with_given_value(self):
+        run_cmd = self._run_and_capture_cmd(5)
+        self.assertIn("--svd_lowrank_niter", run_cmd)
+        idx = run_cmd.index("--svd_lowrank_niter")
+        self.assertEqual(run_cmd[idx + 1], "5")
+
+    def test_default_matches_backend_default(self):
+        run_cmd = self._run_and_capture_cmd(2)
+        idx = run_cmd.index("--svd_lowrank_niter")
+        self.assertEqual(run_cmd[idx + 1], "2")
+
+    def test_omits_flag_when_none(self):
+        run_cmd = self._run_and_capture_cmd(None)
+        self.assertNotIn("--svd_lowrank_niter", run_cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a numeric `SVD lowrank iterations` input to the Resize LoRA tab, defaulting to the backend's default (2)
- Wire it through to the `--svd_lowrank_niter` flag passed to `sd-scripts/networks/resize_lora.py`

Closes #3529

## Test plan
- [x] Verified generated command includes `--svd_lowrank_niter <value>` and matches argparse expectations in `sd-scripts/networks/resize_lora.py`
- [x] Verified sd-scripts submodule untouched