### PR TITLE
Expose --show_timesteps / --show_timesteps_resolution in GUI (DiT training)

### DIFF
--- a/kohya_gui/class_advanced_training.py
+++ b/kohya_gui/class_advanced_training.py
@@ -513,7 +513,7 @@ class AdvancedTraining:
                 label="Show timesteps",
                 choices=["", "console", "image"],
                 value=self.config.get("advanced.show_timesteps", ""),
-                info="Visualize the actual sampled timestep distribution and loss weighting for the current settings, then exit without training. 'console' prints an ASCII histogram, 'image' shows a matplotlib plot. Applies to FLUX/SD3/Lumina/Anima (DiT) training.",
+                info="Visualize the actual sampled timestep distribution and loss weighting for the current settings, then exit without training. 'console' prints an ASCII histogram, 'image' shows a matplotlib plot. Applies to FLUX and SD3 training.",
                 interactive=True,
             )
             self.show_timesteps_resolution = gr.Textbox(

--- a/kohya_gui/class_advanced_training.py
+++ b/kohya_gui/class_advanced_training.py
@@ -508,6 +508,20 @@ class AdvancedTraining:
                 step=1,
                 interactive=True,
             )
+        with gr.Row():
+            self.show_timesteps = gr.Dropdown(
+                label="Show timesteps",
+                choices=["", "console", "image"],
+                value=self.config.get("advanced.show_timesteps", ""),
+                info="Visualize the actual sampled timestep distribution and loss weighting for the current settings, then exit without training. 'console' prints an ASCII histogram, 'image' shows a matplotlib plot. Applies to FLUX/SD3/Lumina/Anima (DiT) training.",
+                interactive=True,
+            )
+            self.show_timesteps_resolution = gr.Textbox(
+                label="Show timesteps resolution",
+                value=self.config.get("advanced.show_timesteps_resolution", "1024"),
+                info="Image resolution (pixels) assumed by 'Show timesteps' for resolution-dependent sampling (e.g. flux_shift). Comma-separated: a single value is used for both H and W, two values are H,W.",
+                interactive=True,
+            )
         with gr.Group(), gr.Row():
             self.save_state = gr.Checkbox(
                 label="Save training state",

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -1094,7 +1094,9 @@ def train_model(
             show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
         ),
         "show_timesteps_resolution": (
-            show_timesteps_resolution if (flux1_checkbox or sd3_checkbox) else None
+            show_timesteps_resolution
+            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            else None
         ),
         "mem_eff_save": mem_eff_save if flux1_checkbox else None,
         "apply_t5_attn_mask": apply_t5_attn_mask if flux1_checkbox else None,

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -234,6 +234,8 @@ def save_configuration(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
 ):
@@ -445,6 +447,8 @@ def open_configuration(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
 ):
@@ -651,6 +655,8 @@ def train_model(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
 ):
@@ -1084,6 +1090,12 @@ def train_model(
         "blocks_to_swap": blocks_to_swap if flux1_checkbox or sd3_checkbox else None,
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
+        "show_timesteps": (
+            show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
+        ),
+        "show_timesteps_resolution": (
+            show_timesteps_resolution if (flux1_checkbox or sd3_checkbox) else None
+        ),
         "mem_eff_save": mem_eff_save if flux1_checkbox else None,
         "apply_t5_attn_mask": apply_t5_attn_mask if flux1_checkbox else None,
     }
@@ -1437,6 +1449,8 @@ def dreambooth_tab(
             advanced_training.blocks_to_swap,
             flux1_training.single_blocks_to_swap,
             flux1_training.double_blocks_to_swap,
+            advanced_training.show_timesteps,
+            advanced_training.show_timesteps_resolution,
             flux1_training.mem_eff_save,
             flux1_training.apply_t5_attn_mask,
         ]

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -241,6 +241,8 @@ def save_configuration(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
 ):
@@ -457,6 +459,8 @@ def open_configuration(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
     training_preset,
@@ -679,6 +683,8 @@ def train_model(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
 ):
@@ -1129,6 +1135,12 @@ def train_model(
         "blocks_to_swap": blocks_to_swap if flux1_checkbox else None,
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
+        "show_timesteps": (
+            show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
+        ),
+        "show_timesteps_resolution": (
+            show_timesteps_resolution if (flux1_checkbox or sd3_checkbox) else None
+        ),
         "mem_eff_save": mem_eff_save if flux1_checkbox else None,
         "apply_t5_attn_mask": apply_t5_attn_mask if flux1_checkbox else None,
     }
@@ -1555,6 +1567,8 @@ def finetune_tab(
             advanced_training.blocks_to_swap,
             flux1_training.single_blocks_to_swap,
             flux1_training.double_blocks_to_swap,
+            advanced_training.show_timesteps,
+            advanced_training.show_timesteps_resolution,
             flux1_training.mem_eff_save,
             flux1_training.apply_t5_attn_mask,
         ]

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -1139,7 +1139,9 @@ def train_model(
             show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
         ),
         "show_timesteps_resolution": (
-            show_timesteps_resolution if (flux1_checkbox or sd3_checkbox) else None
+            show_timesteps_resolution
+            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            else None
         ),
         "mem_eff_save": mem_eff_save if flux1_checkbox else None,
         "apply_t5_attn_mask": apply_t5_attn_mask if flux1_checkbox else None,

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -285,6 +285,8 @@ def save_configuration(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     img_attn_dim,
     img_mlp_dim,
     img_mod_dim,
@@ -571,6 +573,8 @@ def open_configuration(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     img_attn_dim,
     img_mlp_dim,
     img_mod_dim,
@@ -968,6 +972,8 @@ def train_model(
     blocks_to_swap,
     single_blocks_to_swap,
     double_blocks_to_swap,
+    show_timesteps,
+    show_timesteps_resolution,
     img_attn_dim,
     img_mlp_dim,
     img_mod_dim,
@@ -1784,6 +1790,12 @@ def train_model(
         "blocks_to_swap": blocks_to_swap if flux1_checkbox or sd3_checkbox else None,
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
+        "show_timesteps": (
+            show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
+        ),
+        "show_timesteps_resolution": (
+            show_timesteps_resolution if (flux1_checkbox or sd3_checkbox) else None
+        ),
     }
 
     # Given dictionary `config_toml_data`
@@ -3018,6 +3030,8 @@ def lora_tab(
             advanced_training.blocks_to_swap,
             flux1_training.single_blocks_to_swap,
             flux1_training.double_blocks_to_swap,
+            advanced_training.show_timesteps,
+            advanced_training.show_timesteps_resolution,
             flux1_training.img_attn_dim,
             flux1_training.img_mlp_dim,
             flux1_training.img_mod_dim,

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -1794,7 +1794,9 @@ def train_model(
             show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
         ),
         "show_timesteps_resolution": (
-            show_timesteps_resolution if (flux1_checkbox or sd3_checkbox) else None
+            show_timesteps_resolution
+            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            else None
         ),
     }
 

--- a/tests/test_show_timesteps_gui.py
+++ b/tests/test_show_timesteps_gui.py
@@ -1,0 +1,143 @@
+"""Regression tests for GH issue #3530: expose --show_timesteps /
+--show_timesteps_resolution (shared DiT timestep-sampling visualization
+flags from sd-scripts library/args.py add_dit_training_arguments) in the
+GUI's advanced training options, and only emit them for DiT families
+(FLUX / SD3), never for SD1.5/SDXL.
+"""
+
+import unittest
+
+from kohya_gui import lora_gui
+from conftest import build_train_model_kwargs, run_train_model_and_load_toml
+
+FIXTURE = "test/config/locon-AdamW8bit-toml.json"
+
+NUMERIC_FIXUPS = (
+    "max_train_steps",
+    "max_train_epochs",
+    "num_processes",
+    "num_machines",
+    "gradient_accumulation_steps",
+    "seed",
+    "vae_batch_size",
+    "save_every_n_steps",
+    "save_every_n_epochs",
+    "save_last_n_steps",
+    "save_last_n_steps_state",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "lr_scheduler_num_cycles",
+    "min_bucket_reso",
+    "max_bucket_reso",
+    "bucket_reso_steps",
+    "max_data_loader_n_workers",
+    "keep_tokens",
+    "clip_skip",
+    "max_token_length",
+    "caption_dropout_every_n_epochs",
+    "min_snr_gamma",
+    "min_timestep",
+    "max_timestep",
+    "sample_every_n_steps",
+    "sample_every_n_epochs",
+    "gpu_ids",
+    "main_process_port",
+    "num_cpu_threads_per_process",
+    "t5xxl_max_token_length",
+    "block_lr_zero_threshold",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "t5xxl",
+    "sd3_clip_l",
+    "sd3_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "huggingface_repo_id",
+    "huggingface_token",
+    "huggingface_repo_type",
+    "huggingface_repo_visibility",
+    "huggingface_path_in_repo",
+    "metadata_author",
+    "metadata_description",
+    "metadata_license",
+    "metadata_tags",
+    "metadata_title",
+    "log_with",
+    "log_config",
+    "loss_type",
+    "huber_schedule",
+    "lr_scheduler_type",
+    "dynamo_backend",
+    "dynamo_mode",
+    "extra_accelerate_launch_args",
+    "network_weights",
+    "model_prediction_type",
+    "timestep_sampling",
+    "train_blocks",
+    "weighting_scheme",
+    "in_dims",
+    "show_timesteps",
+    "show_timesteps_resolution",
+)
+
+
+class TestShowTimestepsFlow(unittest.TestCase):
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides=overrides,
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_flux1_emits_show_timesteps(self):
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "show_timesteps": "console",
+                "show_timesteps_resolution": "512,768",
+            }
+        )
+        self.assertEqual(config.get("show_timesteps"), "console")
+        self.assertEqual(config.get("show_timesteps_resolution"), "512,768")
+
+    def test_sd3_emits_show_timesteps(self):
+        config = self._run_and_load_toml(
+            {
+                "sd3_checkbox": True,
+                "show_timesteps": "image",
+                "show_timesteps_resolution": "1024",
+            }
+        )
+        self.assertEqual(config.get("show_timesteps"), "image")
+        self.assertEqual(config.get("show_timesteps_resolution"), "1024")
+
+    def test_omitted_when_flag_left_blank(self):
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "show_timesteps": "",
+            }
+        )
+        self.assertNotIn("show_timesteps", config)
+
+    def test_never_emitted_for_non_dit_families(self):
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": False,
+                "sd3_checkbox": False,
+                "show_timesteps": "console",
+            }
+        )
+        self.assertNotIn("show_timesteps", config)
+        self.assertNotIn("show_timesteps_resolution", config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_show_timesteps_gui.py
+++ b/tests/test_show_timesteps_gui.py
@@ -123,9 +123,11 @@ class TestShowTimestepsFlow(unittest.TestCase):
                 "flux1_checkbox": True,
                 "LoRA_type": "Flux1",
                 "show_timesteps": "",
+                "show_timesteps_resolution": "1024",
             }
         )
         self.assertNotIn("show_timesteps", config)
+        self.assertNotIn("show_timesteps_resolution", config)
 
     def test_never_emitted_for_non_dit_families(self):
         config = self._run_and_load_toml(


### PR DESCRIPTION
## Summary
- Scope check (per #3530): `--show_timesteps` / `--show_timesteps_resolution` are registered in sd-scripts' shared `add_dit_training_arguments` group (`library/args.py`), consumed generically by `flux_train_utils.show_timesteps()` for FLUX, SD3, Lumina, HunyuanImage, and Anima — not Anima-only. This issue supersedes the corresponding part of #7.
- Adds a "Show timesteps" dropdown (`console`/`image`) and "Show timesteps resolution" textbox to `kohya_gui/class_advanced_training.py`, following the existing `blocks_to_swap` pattern (a single shared widget, conditionally emitted).
- Wires the new fields through `train_model()` in `lora_gui.py`, `dreambooth_gui.py`, and `finetune_gui.py`, gated on `flux1_checkbox or sd3_checkbox` so SD1.5/SDXL runs never emit these DiT-only flags.

## Test plan
- [x] New `tests/test_show_timesteps_gui.py`: verifies the flag flows into the generated TOML for FLUX and SD3, is omitted when left blank, and is never emitted for non-DiT families.
- [x] Verified `--show_timesteps`/`--show_timesteps_resolution` parse successfully via `sd-scripts/library/args.py`'s `add_dit_training_arguments` (non-Anima family: FLUX/SD3 shared group).
- [x] Full `tests/` suite passes (19 passed).
- [x] Smoke-built `lora_tab`, `dreambooth_tab`, `finetune_tab` Gradio blocks without errors.

Closes #3530