### PR TITLE
Docs: clarify multi-resolution dataset config is TOML-driven

### DIFF
--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -198,6 +198,13 @@ class SourceModel:
                             value=self.config.get("model.dataset_config", ""),
                             interactive=True,
                             allow_custom_value=True,
+                            info=(
+                                "Multi-resolution / duplicate-subset datasets are configured"
+                                " entirely in this TOML file, not via GUI fields. See 'Behavior"
+                                " when there are duplicate subsets': https://github.com/kohya-ss"
+                                "/sd-scripts/blob/main/docs/config_README-en.md"
+                                "#behavior-when-there-are-duplicate-subsets"
+                            ),
                         )
                         # Refresh button for dataset_config directory
                         create_refresh_button(

--- a/tests/test_source_model_dataset_config_doc.py
+++ b/tests/test_source_model_dataset_config_doc.py
@@ -1,0 +1,27 @@
+"""Regression test for GH issue #3531: the GUI's dataset_config field should
+point users to the upstream config_README-en.md section explaining that
+multi-resolution / duplicate-subset datasets are configured via the TOML
+file itself, not via GUI fields.
+"""
+
+import unittest
+
+import gradio as gr
+
+from kohya_gui.class_source_model import SourceModel
+
+
+class TestDatasetConfigDocLink(unittest.TestCase):
+    def test_dataset_config_info_links_to_duplicate_subsets_doc(self):
+        with gr.Blocks():
+            source_model = SourceModel(headless=True)
+
+        info = source_model.dataset_config.info
+        self.assertIsNotNone(info)
+        self.assertIn(
+            "config_README-en.md#behavior-when-there-are-duplicate-subsets", info
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an `info=` tooltip on the `dataset_config` dropdown (`kohya_gui/class_source_model.py`) linking to sd-scripts' "Behavior when there are duplicate subsets" doc section, clarifying that multi-resolution/duplicate-subset dataset behavior is TOML-driven, not controlled by GUI fields.
- No functional GUI change; `sd-scripts` submodule untouched.

## Test plan
- [x] New regression test `tests/test_source_model_dataset_config_doc.py` asserting the tooltip links to the doc anchor
- [x] `pytest tests/` — 20 passed
- [x] `python test/test_allowed_paths.py` — passed
- [x] `black --diff` confirms only the pre-existing (unrelated) formatting drift is flagged; the new lines are black-clean

Closes #3531