### PR TITLE
Add HunyuanImage-2.1 LoRA training support

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -29,6 +29,7 @@ koo="koo"
 yos="yos"
 wn="wn"
 parm = "parm"
+byt = "byt" # byT5 text encoder (HunyuanImage-2.1)
 
 
 [files]

--- a/kohya_gui/class_hunyuan_image.py
+++ b/kohya_gui/class_hunyuan_image.py
@@ -1,0 +1,186 @@
+import gradio as gr
+from .common_gui import (
+    get_any_file_path,
+    document_symbol,
+)
+
+
+class hunyuanImageTraining:
+    def __init__(
+        self,
+        headless: bool = False,
+        finetuning: bool = False,
+        training_type: str = "",
+        config: dict = {},
+        hunyuan_image_checkbox: gr.Checkbox = False,
+    ) -> None:
+        self.headless = headless
+        self.finetuning = finetuning
+        self.training_type = training_type
+        self.config = config
+        self.hunyuan_image_checkbox = hunyuan_image_checkbox
+
+        with gr.Accordion(
+            "HunyuanImage-2.1",
+            open=True,
+            visible=False,
+            elem_classes=["hunyuan_image_background"],
+        ) as hunyuan_image_accordion:
+            with gr.Group():
+                with gr.Row():
+                    self.text_encoder = gr.Textbox(
+                        label="Qwen2.5-VL Path",
+                        placeholder="Path to Qwen2.5-VL text encoder model",
+                        value=self.config.get("hunyuan_image.text_encoder", ""),
+                        interactive=True,
+                    )
+                    self.text_encoder_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.text_encoder_button.click(
+                        get_any_file_path,
+                        outputs=self.text_encoder,
+                        show_progress=False,
+                    )
+
+                    self.byt5 = gr.Textbox(
+                        label="byT5 Path",
+                        placeholder="Path to byT5 text encoder model",
+                        value=self.config.get("hunyuan_image.byt5", ""),
+                        interactive=True,
+                    )
+                    self.byt5_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.byt5_button.click(
+                        get_any_file_path,
+                        outputs=self.byt5,
+                        show_progress=False,
+                    )
+
+                    self.vae = gr.Textbox(
+                        label="VAE Path",
+                        placeholder="Path to HunyuanImage-2.1 VAE model",
+                        value=self.config.get("hunyuan_image.vae", ""),
+                        interactive=True,
+                    )
+                    self.vae_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.vae_button.click(
+                        get_any_file_path,
+                        outputs=self.vae,
+                        show_progress=False,
+                    )
+
+                with gr.Row():
+                    self.discrete_flow_shift = gr.Number(
+                        label="Discrete Flow Shift",
+                        value=self.config.get("hunyuan_image.discrete_flow_shift", 5.0),
+                        info="Discrete flow shift for the Euler Discrete Scheduler, default is 5.0",
+                        minimum=-1024,
+                        maximum=1024,
+                        step=0.01,
+                        interactive=True,
+                    )
+                    self.model_prediction_type = gr.Dropdown(
+                        label="Model Prediction Type",
+                        choices=["raw", "additive", "sigma_scaled"],
+                        value=self.config.get(
+                            "hunyuan_image.model_prediction_type", "raw"
+                        ),
+                        interactive=True,
+                    )
+                    self.timestep_sampling = gr.Dropdown(
+                        label="Timestep Sampling",
+                        choices=["sigma", "uniform", "sigmoid", "shift", "flux_shift"],
+                        value=self.config.get(
+                            "hunyuan_image.timestep_sampling", "sigma"
+                        ),
+                        interactive=True,
+                    )
+                    self.sigmoid_scale = gr.Number(
+                        label="Sigmoid Scale",
+                        value=self.config.get("hunyuan_image.sigmoid_scale", 1.0),
+                        info='Scale factor for sigmoid timestep sampling (only used when timestep sampling is "sigmoid")',
+                        minimum=0.0,
+                        maximum=1024,
+                        step=0.01,
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.attn_mode = gr.Dropdown(
+                        label="Attention Mode",
+                        choices=["torch", "xformers", "flash", "sageattn"],
+                        value=self.config.get("hunyuan_image.attn_mode", "torch"),
+                        interactive=True,
+                    )
+                    self.split_attn = gr.Checkbox(
+                        label="Split Attention",
+                        value=self.config.get("hunyuan_image.split_attn", False),
+                        info="Split attention computation to reduce memory usage. Required when using xformers with batch size > 1.",
+                        interactive=True,
+                    )
+                    self.fp8_scaled = gr.Checkbox(
+                        label="FP8 Scaled",
+                        value=self.config.get("hunyuan_image.fp8_scaled", False),
+                        info="Use scaled fp8 for the DiT model to reduce VRAM usage",
+                        interactive=True,
+                    )
+                    self.fp8_vl = gr.Checkbox(
+                        label="FP8 VLM",
+                        value=self.config.get("hunyuan_image.fp8_vl", False),
+                        info="Use fp8 for the Qwen2.5-VL text encoder",
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.text_encoder_cpu = gr.Checkbox(
+                        label="Text Encoder on CPU",
+                        value=self.config.get("hunyuan_image.text_encoder_cpu", False),
+                        info="Run the Qwen2.5-VL and byT5 text encoders on CPU to reduce VRAM usage",
+                        interactive=True,
+                    )
+                    self.vae_chunk_size = gr.Number(
+                        label="VAE Chunk Size",
+                        value=self.config.get("hunyuan_image.vae_chunk_size", 0),
+                        info="Chunk size for VAE decoding to reduce memory usage. 0 means no chunking, 16 is recommended if enabled.",
+                        minimum=0,
+                        maximum=1024,
+                        step=1,
+                        interactive=True,
+                    )
+                    self.hunyuan_image_cache_text_encoder_outputs = gr.Checkbox(
+                        label="Cache Text Encoder Outputs",
+                        value=self.config.get(
+                            "hunyuan_image.cache_text_encoder_outputs", False
+                        ),
+                        info="Cache Qwen2.5-VL and byT5 text encoder outputs to reduce memory usage",
+                        interactive=True,
+                    )
+                    self.hunyuan_image_cache_text_encoder_outputs_to_disk = gr.Checkbox(
+                        label="Cache Text Encoder Outputs to Disk",
+                        value=self.config.get(
+                            "hunyuan_image.cache_text_encoder_outputs_to_disk", False
+                        ),
+                        info="Cache text encoder outputs to disk",
+                        interactive=True,
+                    )
+
+                self.hunyuan_image_checkbox.change(
+                    lambda hunyuan_image_checkbox: gr.Accordion(
+                        visible=hunyuan_image_checkbox
+                    ),
+                    inputs=[self.hunyuan_image_checkbox],
+                    outputs=[hunyuan_image_accordion],
+                )

--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -306,7 +306,7 @@ class SourceModel:
                                     # If any checkbox is checked, return checkboxes with current interactive state
                                     return (
                                         gr.Checkbox(interactive=v2),  # v2 checkbox
-                                        gr.Checkbox(interactive=sdxl_checkbox),  # v_parameterization checkbox
+                                        gr.Checkbox(interactive=v2),  # v_parameterization checkbox
                                         gr.Checkbox(interactive=sdxl_checkbox),  # sdxl_checkbox
                                         gr.Checkbox(interactive=sd3_checkbox),  # sd3_checkbox
                                         gr.Checkbox(interactive=flux1_checkbox),  # flux1_checkbox

--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -282,17 +282,25 @@ class SourceModel:
                                 min_width=60,
                                 interactive=True,
                             )
+                            self.hunyuan_image_checkbox = gr.Checkbox(
+                                label="HunyuanImage-2.1",
+                                value=False,
+                                visible=False,
+                                min_width=60,
+                                interactive=True,
+                            )
 
-                            def toggle_checkboxes(v2, v_parameterization, sdxl_checkbox, sd3_checkbox, flux1_checkbox):
+                            def toggle_checkboxes(v2, v_parameterization, sdxl_checkbox, sd3_checkbox, flux1_checkbox, hunyuan_image_checkbox):
                                 # Check if all checkboxes are unchecked
-                                if not v2 and not sdxl_checkbox and not sd3_checkbox and not flux1_checkbox:
+                                if not v2 and not sdxl_checkbox and not sd3_checkbox and not flux1_checkbox and not hunyuan_image_checkbox:
                                     # If all unchecked, return new interactive checkboxes
                                     return (
                                         gr.Checkbox(interactive=True),  # v2 checkbox
                                         gr.Checkbox(interactive=False, value=False),  # v_parameterization checkbox
                                         gr.Checkbox(interactive=True),  # sdxl_checkbox
                                         gr.Checkbox(interactive=True),  # sd3_checkbox
-                                        gr.Checkbox(interactive=True),  # sd3_checkbox
+                                        gr.Checkbox(interactive=True),  # flux1_checkbox
+                                        gr.Checkbox(interactive=True),  # hunyuan_image_checkbox
                                     )
                                 else:
                                     # If any checkbox is checked, return checkboxes with current interactive state
@@ -302,36 +310,52 @@ class SourceModel:
                                         gr.Checkbox(interactive=sdxl_checkbox),  # sdxl_checkbox
                                         gr.Checkbox(interactive=sd3_checkbox),  # sd3_checkbox
                                         gr.Checkbox(interactive=flux1_checkbox),  # flux1_checkbox
+                                        gr.Checkbox(interactive=hunyuan_image_checkbox),  # hunyuan_image_checkbox
                                     )
+
+                            checkbox_inputs = [
+                                self.v2,
+                                self.v_parameterization,
+                                self.sdxl_checkbox,
+                                self.sd3_checkbox,
+                                self.flux1_checkbox,
+                                self.hunyuan_image_checkbox,
+                            ]
 
                             self.v2.change(
                                 fn=toggle_checkboxes,
-                                inputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
-                                outputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
                                 show_progress=False,
                             )
                             self.v_parameterization.change(
                                 fn=toggle_checkboxes,
-                                inputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
-                                outputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
                                 show_progress=False,
                             )
                             self.sdxl_checkbox.change(
                                 fn=toggle_checkboxes,
-                                inputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
-                                outputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
                                 show_progress=False,
                             )
                             self.sd3_checkbox.change(
                                 fn=toggle_checkboxes,
-                                inputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
-                                outputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
                                 show_progress=False,
                             )
                             self.flux1_checkbox.change(
                                 fn=toggle_checkboxes,
-                                inputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
-                                outputs=[self.v2, self.v_parameterization, self.sdxl_checkbox, self.sd3_checkbox, self.flux1_checkbox],
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
+                                show_progress=False,
+                            )
+                            self.hunyuan_image_checkbox.change(
+                                fn=toggle_checkboxes,
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
                                 show_progress=False,
                             )
                     with gr.Column():
@@ -371,6 +395,7 @@ class SourceModel:
                         self.sdxl_checkbox,
                         self.sd3_checkbox,
                         self.flux1_checkbox,
+                        self.hunyuan_image_checkbox,
                     ],
                     show_progress=False,
                 )

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -966,6 +966,7 @@ def set_pretrained_model_name_or_path_input(
         sdxl = gr.Checkbox(value=True, visible=False)
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
+        hunyuan_image = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -973,6 +974,7 @@ def set_pretrained_model_name_or_path_input(
             sdxl,
             sd3,
             flux1,
+            hunyuan_image,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V2 base models
@@ -983,6 +985,7 @@ def set_pretrained_model_name_or_path_input(
         sdxl = gr.Checkbox(value=False, visible=False)
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
+        hunyuan_image = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -990,6 +993,7 @@ def set_pretrained_model_name_or_path_input(
             sdxl,
             sd3,
             flux1,
+            hunyuan_image,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V parameterization models
@@ -1002,6 +1006,7 @@ def set_pretrained_model_name_or_path_input(
         sdxl = gr.Checkbox(value=False, visible=False)
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
+        hunyuan_image = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1009,6 +1014,7 @@ def set_pretrained_model_name_or_path_input(
             sdxl,
             sd3,
             flux1,
+            hunyuan_image,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V1 models
@@ -1019,6 +1025,7 @@ def set_pretrained_model_name_or_path_input(
         sdxl = gr.Checkbox(value=False, visible=False)
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
+        hunyuan_image = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1026,6 +1033,7 @@ def set_pretrained_model_name_or_path_input(
             sdxl,
             sd3,
             flux1,
+            hunyuan_image,
         )
 
     # Check if the model_list is set to 'custom'
@@ -1034,6 +1042,7 @@ def set_pretrained_model_name_or_path_input(
     sdxl = gr.Checkbox(visible=True)
     sd3 = gr.Checkbox(visible=True)
     flux1 = gr.Checkbox(visible=True)
+    hunyuan_image = gr.Checkbox(visible=True)
 
     # Auto-detect model type if safetensors file path is given
     if pretrained_model_name_or_path.lower().endswith(".safetensors"):
@@ -1058,6 +1067,7 @@ def set_pretrained_model_name_or_path_input(
         sdxl,
         sd3,
         flux1,
+        hunyuan_image,
     )
 
 

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -1592,7 +1592,11 @@ def train_model(
         output_message(msg="Please input learning rate values.", headless=headless)
         return TRAIN_BUTTON_VISIBLE
     # Flag to train text encoder only if its learning rate is non-zero and unet's is zero.
-    network_train_text_encoder_only = text_encoder_lr_float != 0 and unet_lr_float == 0
+    network_train_text_encoder_only = (
+        text_encoder_lr_float != 0
+        and unet_lr_float == 0
+        and not hunyuan_image_checkbox
+    )
     # Flag to train unet only if its learning rate is non-zero and text encoder's is zero.
     network_train_unet_only = (
         text_encoder_lr_float == 0 and unet_lr_float != 0

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -42,6 +42,7 @@ from .class_huggingface import HuggingFace
 from .class_metadata import MetaData
 from .class_gui_config import KohyaSSGUIConfig
 from .class_flux1 import flux1Training
+from .class_hunyuan_image import hunyuanImageTraining
 
 from .dreambooth_folder_creation_gui import (
     gradio_dreambooth_folder_creation_tab,
@@ -321,6 +322,23 @@ def save_configuration(
     sd3_text_encoder_batch_size,
     weighting_scheme,
     sd3_checkbox,
+    # HunyuanImage-2.1 parameters
+    hunyuan_image_cache_text_encoder_outputs,
+    hunyuan_image_cache_text_encoder_outputs_to_disk,
+    hunyuan_text_encoder,
+    hunyuan_byt5,
+    hunyuan_vae,
+    hunyuan_discrete_flow_shift,
+    hunyuan_model_prediction_type,
+    hunyuan_timestep_sampling,
+    hunyuan_sigmoid_scale,
+    hunyuan_attn_mode,
+    hunyuan_split_attn,
+    hunyuan_fp8_scaled,
+    hunyuan_fp8_vl,
+    hunyuan_text_encoder_cpu,
+    hunyuan_vae_chunk_size,
+    hunyuan_image_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -609,6 +627,23 @@ def open_configuration(
     sd3_text_encoder_batch_size,
     weighting_scheme,
     sd3_checkbox,
+    # HunyuanImage-2.1 parameters
+    hunyuan_image_cache_text_encoder_outputs,
+    hunyuan_image_cache_text_encoder_outputs_to_disk,
+    hunyuan_text_encoder,
+    hunyuan_byt5,
+    hunyuan_vae,
+    hunyuan_discrete_flow_shift,
+    hunyuan_model_prediction_type,
+    hunyuan_timestep_sampling,
+    hunyuan_sigmoid_scale,
+    hunyuan_attn_mode,
+    hunyuan_split_attn,
+    hunyuan_fp8_scaled,
+    hunyuan_fp8_vl,
+    hunyuan_text_encoder_cpu,
+    hunyuan_vae_chunk_size,
+    hunyuan_image_checkbox,
     ##
     training_preset,
 ):
@@ -1008,6 +1043,23 @@ def train_model(
     sd3_text_encoder_batch_size,
     weighting_scheme,
     sd3_checkbox,
+    # HunyuanImage-2.1 parameters
+    hunyuan_image_cache_text_encoder_outputs,
+    hunyuan_image_cache_text_encoder_outputs_to_disk,
+    hunyuan_text_encoder,
+    hunyuan_byt5,
+    hunyuan_vae,
+    hunyuan_discrete_flow_shift,
+    hunyuan_model_prediction_type,
+    hunyuan_timestep_sampling,
+    hunyuan_sigmoid_scale,
+    hunyuan_attn_mode,
+    hunyuan_split_attn,
+    hunyuan_fp8_scaled,
+    hunyuan_fp8_vl,
+    hunyuan_text_encoder_cpu,
+    hunyuan_vae_chunk_size,
+    hunyuan_image_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -1291,6 +1343,8 @@ def train_model(
         run_cmd.append(rf"{scriptdir}/sd-scripts/flux_train_network.py")
     elif sd3_checkbox:
         run_cmd.append(rf"{scriptdir}/sd-scripts/sd3_train_network.py")
+    elif hunyuan_image_checkbox:
+        run_cmd.append(rf"{scriptdir}/sd-scripts/hunyuan_image_train_network.py")
     else:
         run_cmd.append(rf"{scriptdir}/sd-scripts/train_network.py")
 
@@ -1400,6 +1454,9 @@ def train_model(
         for key, value in kohya_lora_vars.items():
             if value:
                 network_args += f" {key}={value}"
+
+    if LoRA_type == "HunyuanImage-2.1":
+        network_module = "networks.lora_hunyuan_image"
 
     if LoRA_type in ["Kohya LoCon", "Standard"]:
         kohya_lora_var_list = [
@@ -1537,7 +1594,9 @@ def train_model(
     # Flag to train text encoder only if its learning rate is non-zero and unet's is zero.
     network_train_text_encoder_only = text_encoder_lr_float != 0 and unet_lr_float == 0
     # Flag to train unet only if its learning rate is non-zero and text encoder's is zero.
-    network_train_unet_only = text_encoder_lr_float == 0 and unet_lr_float != 0
+    network_train_unet_only = (
+        text_encoder_lr_float == 0 and unet_lr_float != 0
+    ) or hunyuan_image_checkbox
 
     clip_l_value = None
     if sd3_checkbox:
@@ -1557,6 +1616,8 @@ def train_model(
     if sd3_checkbox:
         disable_mmap_load_safetensors_value = sd3_disable_mmap_load_safetensors
 
+    vae_value = hunyuan_vae if hunyuan_image_checkbox else vae
+
     config_toml_data = {
         "adaptive_noise_scale": (
             adaptive_noise_scale
@@ -1573,6 +1634,7 @@ def train_model(
             if (sdxl and sdxl_cache_text_encoder_outputs)
             or (flux1_checkbox and flux1_cache_text_encoder_outputs)
             or (sd3_checkbox and sd3_cache_text_encoder_outputs)
+            or (hunyuan_image_checkbox and hunyuan_image_cache_text_encoder_outputs)
             else None
         ),
         "cache_text_encoder_outputs_to_disk": (
@@ -1581,13 +1643,15 @@ def train_model(
             and flux1_cache_text_encoder_outputs_to_disk
             or sd3_checkbox
             and sd3_cache_text_encoder_outputs_to_disk
+            or hunyuan_image_checkbox
+            and hunyuan_image_cache_text_encoder_outputs_to_disk
             else None
         ),
         "caption_dropout_every_n_epochs": int(caption_dropout_every_n_epochs),
         "caption_dropout_rate": caption_dropout_rate,
         "caption_extension": caption_extension,
         "clip_l": clip_l_value,
-        "clip_skip": clip_skip if clip_skip != 0 else None,
+        "clip_skip": clip_skip if clip_skip != 0 and not hunyuan_image_checkbox else None,
         "color_aug": color_aug,
         "dataset_config": dataset_config,
         "debiased_estimation_loss": debiased_estimation_loss,
@@ -1638,7 +1702,11 @@ def train_model(
         "max_bucket_reso": max_bucket_reso,
         "max_grad_norm": max_grad_norm,
         "max_timestep": max_timestep if max_timestep != 0 else None,
-        "max_token_length": int(max_token_length) if not flux1_checkbox else None,
+        "max_token_length": (
+            int(max_token_length)
+            if not flux1_checkbox and not hunyuan_image_checkbox
+            else None
+        ),
         "max_train_epochs": (
             int(max_train_epochs) if int(max_train_epochs) != 0 else None
         ),
@@ -1738,7 +1806,7 @@ def train_model(
         "v2": v2,
         "v_parameterization": v_parameterization,
         "v_pred_like_loss": v_pred_like_loss if v_pred_like_loss != 0 else None,
-        "vae": vae,
+        "vae": vae_value,
         "vae_batch_size": vae_batch_size if vae_batch_size != 0 else None,
         "wandb_api_key": wandb_api_key,
         "wandb_run_name": wandb_run_name if wandb_run_name != "" else output_name,
@@ -1774,9 +1842,8 @@ def train_model(
         "ae": ae if flux1_checkbox else None,
         # "clip_l": see previous assignment above for code
         "t5xxl": t5xxl_value,
-        "discrete_flow_shift": float(discrete_flow_shift) if flux1_checkbox else None,
-        "model_prediction_type": model_prediction_type if flux1_checkbox else None,
-        "timestep_sampling": timestep_sampling if flux1_checkbox else None,
+        # "discrete_flow_shift", "model_prediction_type", "timestep_sampling":
+        # see consolidated HunyuanImage-2.1/Flux1 assignment below
         "split_mode": split_mode if flux1_checkbox else None,
         "t5xxl_max_token_length": (
             int(t5xxl_max_token_length) if flux1_checkbox else None
@@ -1787,15 +1854,58 @@ def train_model(
         "cpu_offload_checkpointing": (
             cpu_offload_checkpointing if flux1_checkbox else None
         ),
-        "blocks_to_swap": blocks_to_swap if flux1_checkbox or sd3_checkbox else None,
+        "blocks_to_swap": (
+            blocks_to_swap
+            if flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox
+            else None
+        ),
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
         "show_timesteps": (
-            show_timesteps if (flux1_checkbox or sd3_checkbox) and show_timesteps else None
+            show_timesteps
+            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            else None
         ),
         "show_timesteps_resolution": (
             show_timesteps_resolution
             if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            else None
+        ),
+        # HunyuanImage-2.1 specific parameters
+        "text_encoder": hunyuan_text_encoder if hunyuan_image_checkbox else None,
+        "byt5": hunyuan_byt5 if hunyuan_image_checkbox else None,
+        "discrete_flow_shift": (
+            float(hunyuan_discrete_flow_shift)
+            if hunyuan_image_checkbox
+            else float(discrete_flow_shift) if flux1_checkbox else None
+        ),
+        "model_prediction_type": (
+            hunyuan_model_prediction_type
+            if hunyuan_image_checkbox
+            else model_prediction_type if flux1_checkbox else None
+        ),
+        "timestep_sampling": (
+            hunyuan_timestep_sampling
+            if hunyuan_image_checkbox
+            else timestep_sampling if flux1_checkbox else None
+        ),
+        "sigmoid_scale": (
+            float(hunyuan_sigmoid_scale) if hunyuan_image_checkbox else None
+        ),
+        "attn_mode": (
+            hunyuan_attn_mode
+            if hunyuan_image_checkbox and hunyuan_attn_mode != "torch"
+            else None
+        ),
+        "split_attn": hunyuan_split_attn if hunyuan_image_checkbox else None,
+        "fp8_scaled": hunyuan_fp8_scaled if hunyuan_image_checkbox else None,
+        "fp8_vl": hunyuan_fp8_vl if hunyuan_image_checkbox else None,
+        "text_encoder_cpu": (
+            hunyuan_text_encoder_cpu if hunyuan_image_checkbox else None
+        ),
+        "vae_chunk_size": (
+            int(hunyuan_vae_chunk_size)
+            if hunyuan_image_checkbox and hunyuan_vae_chunk_size
             else None
         ),
     }
@@ -1962,6 +2072,7 @@ def lora_tab(
                         choices=[
                             "Flux1",
                             "Flux1 OFT",
+                            "HunyuanImage-2.1",
                             "Kohya DyLoRA",
                             "Kohya LoCon",
                             "LoRA-FA",
@@ -2277,6 +2388,7 @@ def lora_tab(
                                 in {
                                     "Flux1",
                                     "Flux1 OFT",
+                                    "HunyuanImage-2.1",
                                     "Kohya DyLoRA",
                                     "Kohya LoCon",
                                     "LoRA-FA",
@@ -2317,6 +2429,7 @@ def lora_tab(
                                 in {
                                     "Flux1",
                                     "Flux1 OFT",
+                                    "HunyuanImage-2.1",
                                     "Standard",
                                     "Kohya DyLoRA",
                                     "Kohya LoCon",
@@ -2331,6 +2444,7 @@ def lora_tab(
                                 in {
                                     "Flux1",
                                     "Flux1 OFT",
+                                    "HunyuanImage-2.1",
                                     "Standard",
                                     "LoCon",
                                     "Kohya DyLoRA",
@@ -2353,6 +2467,7 @@ def lora_tab(
                                 in {
                                     "Flux1",
                                     "Flux1 OFT",
+                                    "HunyuanImage-2.1",
                                     "Standard",
                                     "LoCon",
                                     "Kohya DyLoRA",
@@ -2375,6 +2490,7 @@ def lora_tab(
                                 in {
                                     "Flux1",
                                     "Flux1 OFT",
+                                    "HunyuanImage-2.1",
                                     "Standard",
                                     "LoCon",
                                     "Kohya DyLoRA",
@@ -2714,6 +2830,13 @@ def lora_tab(
             # Add SD3 Parameters
             sd3_training = sd3Training(
                 headless=headless, config=config, sd3_checkbox=source_model.sd3_checkbox
+            )
+
+            # Add HunyuanImage-2.1 Parameters
+            hunyuan_image_training = hunyuanImageTraining(
+                headless=headless,
+                config=config,
+                hunyuan_image_checkbox=source_model.hunyuan_image_checkbox,
             )
 
             with gr.Accordion(
@@ -3068,6 +3191,23 @@ def lora_tab(
             sd3_training.sd3_text_encoder_batch_size,
             sd3_training.weighting_scheme,
             source_model.sd3_checkbox,
+            # HunyuanImage-2.1 parameters
+            hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs,
+            hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs_to_disk,
+            hunyuan_image_training.text_encoder,
+            hunyuan_image_training.byt5,
+            hunyuan_image_training.vae,
+            hunyuan_image_training.discrete_flow_shift,
+            hunyuan_image_training.model_prediction_type,
+            hunyuan_image_training.timestep_sampling,
+            hunyuan_image_training.sigmoid_scale,
+            hunyuan_image_training.attn_mode,
+            hunyuan_image_training.split_attn,
+            hunyuan_image_training.fp8_scaled,
+            hunyuan_image_training.fp8_vl,
+            hunyuan_image_training.text_encoder_cpu,
+            hunyuan_image_training.vae_chunk_size,
+            source_model.hunyuan_image_checkbox,
         ]
 
         configuration.button_open_config.click(

--- a/tests/test_hunyuan_image_lora_gui.py
+++ b/tests/test_hunyuan_image_lora_gui.py
@@ -1,0 +1,170 @@
+"""Regression tests for GH issue #3522: HunyuanImage-2.1 LoRA training
+support in the GUI.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import lora_gui
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_toml,
+    mock_executor,
+)
+
+FIXTURE = "test/config/locon-AdamW8bit-toml.json"
+
+NUMERIC_FIXUPS = (
+    "max_train_steps",
+    "max_train_epochs",
+    "num_processes",
+    "num_machines",
+    "gradient_accumulation_steps",
+    "seed",
+    "vae_batch_size",
+    "save_every_n_steps",
+    "save_every_n_epochs",
+    "save_last_n_steps",
+    "save_last_n_steps_state",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "lr_scheduler_num_cycles",
+    "min_bucket_reso",
+    "max_bucket_reso",
+    "bucket_reso_steps",
+    "max_data_loader_n_workers",
+    "keep_tokens",
+    "clip_skip",
+    "max_token_length",
+    "caption_dropout_every_n_epochs",
+    "min_snr_gamma",
+    "min_timestep",
+    "max_timestep",
+    "sample_every_n_steps",
+    "sample_every_n_epochs",
+    "gpu_ids",
+    "main_process_port",
+    "num_cpu_threads_per_process",
+    "t5xxl_max_token_length",
+    "block_lr_zero_threshold",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "t5xxl",
+    "sd3_clip_l",
+    "sd3_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "huggingface_repo_id",
+    "huggingface_token",
+    "huggingface_repo_type",
+    "huggingface_repo_visibility",
+    "huggingface_path_in_repo",
+    "metadata_author",
+    "metadata_description",
+    "metadata_license",
+    "metadata_tags",
+    "metadata_title",
+    "log_with",
+    "log_config",
+    "loss_type",
+    "huber_schedule",
+    "lr_scheduler_type",
+    "dynamo_backend",
+    "dynamo_mode",
+    "extra_accelerate_launch_args",
+    "network_weights",
+    "model_prediction_type",
+    "timestep_sampling",
+    "train_blocks",
+    "weighting_scheme",
+    "in_dims",
+)
+
+HUNYUAN_OVERRIDES = {
+    "LoRA_type": "HunyuanImage-2.1",
+    "hunyuan_image_checkbox": True,
+    "hunyuan_text_encoder": "/models/qwen_2.5_vl_7b.safetensors",
+    "hunyuan_byt5": "/models/byt5_small_glyphxl_fp16.safetensors",
+    "hunyuan_vae": "/models/hunyuan_image_2.1_vae_fp16.safetensors",
+    "hunyuan_discrete_flow_shift": 5.0,
+    "hunyuan_model_prediction_type": "raw",
+    "hunyuan_timestep_sampling": "sigma",
+    "hunyuan_sigmoid_scale": 1.0,
+    "hunyuan_attn_mode": "torch",
+    "hunyuan_split_attn": False,
+    "hunyuan_fp8_scaled": False,
+    "hunyuan_fp8_vl": False,
+    "hunyuan_text_encoder_cpu": False,
+    "hunyuan_vae_chunk_size": 0,
+}
+
+
+class TestHunyuanImageLoraConfigOutput(unittest.TestCase):
+    """End-to-end: train_model(print_only=True) writes a real TOML file we
+    can inspect for the HunyuanImage-2.1 specific keys #3522 requires.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**HUNYUAN_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_network_module_is_hunyuan_image(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("network_module"), "networks.lora_hunyuan_image")
+
+    def test_network_train_unet_only_is_forced(self):
+        config = self._run_and_load_toml({})
+        self.assertTrue(config.get("network_train_unet_only"))
+        self.assertNotIn("network_train_text_encoder_only", config)
+
+    def test_model_paths_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(
+            config.get("text_encoder"), "/models/qwen_2.5_vl_7b.safetensors"
+        )
+        self.assertEqual(
+            config.get("byt5"), "/models/byt5_small_glyphxl_fp16.safetensors"
+        )
+        self.assertEqual(
+            config.get("vae"), "/models/hunyuan_image_2.1_vae_fp16.safetensors"
+        )
+
+    def test_flow_matching_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("discrete_flow_shift"), 5.0)
+        self.assertEqual(config.get("model_prediction_type"), "raw")
+        self.assertEqual(config.get("timestep_sampling"), "sigma")
+
+    def test_incompatible_sd_args_are_excluded(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("max_token_length", config)
+        self.assertNotIn("clip_skip", config)
+
+    def test_script_selection_invokes_hunyuan_image_train_network(self):
+        with patch.object(lora_gui, "print_command_and_toml") as mocked:
+            kwargs = build_train_model_kwargs(
+                lora_gui.train_model,
+                FIXTURE,
+                numeric_fixups=NUMERIC_FIXUPS,
+                string_overrides=STRING_OVERRIDES,
+                overrides=HUNYUAN_OVERRIDES,
+            )
+            mock_executor(lora_gui)
+            lora_gui.train_model(**kwargs)
+            self.assertTrue(mocked.called)
+            run_cmd = mocked.call_args[0][0]
+            self.assertTrue(
+                any("hunyuan_image_train_network.py" in part for part in run_cmd)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `kohya_gui/class_hunyuan_image.py` widget class (modeled on `class_flux1.py`) exposing the Qwen2.5-VL, byT5, and VAE file pickers plus flow-matching training params (discrete flow shift, model prediction type, timestep sampling, sigmoid scale, attention mode, fp8 options, text-encoder-on-CPU, VAE chunk size, text-encoder-output caching).
- New `hunyuan_image_checkbox` model-type selector, wired through `class_source_model.py` and `common_gui.py` alongside the existing v2/SDXL/SD3/Flux1 checkboxes (mutually exclusive toggle group).
- `lora_gui.py`: new "HunyuanImage-2.1" `LoRA_type` choice → `networks.lora_hunyuan_image`; run_cmd now dispatches to `sd-scripts/hunyuan_image_train_network.py`; `network_train_unet_only` is forced on (Text Encoder LoRA is unsupported for this architecture); incompatible SD-era args (`clip_skip`, `max_token_length`) are excluded; the accordion's own VAE field takes precedence over the generic Advanced-tab VAE field; all LoRA-type visibility toggle sets include the new type so the network dim/alpha/weights-loading rows stay visible and irrelevant conv-only rows stay hidden.
- The DiT model path reuses the existing generic "Pretrained model" field (no separate field needed — `hunyuan_image_train_network.py` reads `--pretrained_model_name_or_path` from `train_network.py`'s base parser).

## Test plan
- [x] `pytest tests/` — 26/26 passing, including 6 new tests in `tests/test_hunyuan_image_lora_gui.py` covering: network_module selection, forced unet-only training, model path forwarding, flow-matching param forwarding, exclusion of incompatible SD-era args, and script selection (`hunyuan_image_train_network.py`).
- [x] Verified every key written to the generated TOML config maps to a real `argparse` destination in `hunyuan_image_train_network.py`'s `setup_parser()`.
- [x] Built the full `lora_tab()` Gradio Blocks tree headlessly to confirm all new component wiring (settings_list / save_configuration / open_configuration / train_model signatures — 247 params each, all in sync) constructs without error.
- [x] `black` run on the two new files.

Closes #3522