### PR TITLE
Add inpainting model training support (SD1.5/SDXL) to GUI

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -940,6 +940,33 @@ def color_aug_changed(color_aug):
         return gr.Checkbox(interactive=True)
 
 
+def train_inpainting_changed(train_inpainting):
+    """
+    Handles the change in the "Train inpainting model" checkbox.
+
+    Inpainting training generates masks randomly per training step from the
+    source image, so latent caching (which would freeze the latents) cannot
+    be used at the same time. When inpainting training is enabled, both
+    "Cache latents" and "Cache latents to disk" are forced off and disabled.
+
+    Args:
+        train_inpainting (bool): The new state of the "Train inpainting model" checkbox.
+
+    Returns:
+        Tuple[gr.Checkbox, gr.Checkbox]: New checkboxes for cache_latents and
+        cache_latents_to_disk with the appropriate value/interactive settings.
+    """
+    if train_inpainting:
+        msgbox(
+            'Disabling "Cache latents" and "Cache latents to disk" because "Train inpainting model" has been selected...'
+        )
+        return gr.Checkbox(value=False, interactive=False), gr.Checkbox(
+            value=False, interactive=False
+        )
+    else:
+        return gr.Checkbox(interactive=True), gr.Checkbox(interactive=True)
+
+
 def set_pretrained_model_name_or_path_input(
     pretrained_model_name_or_path, refresh_method=None
 ):

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -16,6 +16,7 @@ from .common_gui import (
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
+    train_inpainting_changed,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -88,6 +89,7 @@ def save_configuration(
     num_cpu_threads_per_process,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     caption_extension,
     enable_bucket,
     gradient_checkpointing,
@@ -301,6 +303,7 @@ def open_configuration(
     num_cpu_threads_per_process,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     caption_extension,
     enable_bucket,
     gradient_checkpointing,
@@ -509,6 +512,7 @@ def train_model(
     num_cpu_threads_per_process,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     caption_extension,
     enable_bucket,
     gradient_checkpointing,
@@ -873,6 +877,13 @@ def train_model(
         sd3_checkbox and sd3_cache_text_encoder_outputs_to_disk
     ) or (flux1_checkbox and flux1_cache_text_encoder_outputs_to_disk)
     no_half_vae = sdxl and sdxl_no_half_vae
+    # --train_inpainting is only supported by train_db.py/sdxl_train.py
+    train_inpainting = train_inpainting and not (sd3_checkbox or flux1_checkbox)
+    if train_inpainting:
+        # Masks are generated randomly per training step from the source
+        # image, so latent caching cannot be used at the same time.
+        cache_latents = False
+        cache_latents_to_disk = False
     if max_data_loader_n_workers in ("", None):
         max_data_loader_n_workers = 0
     else:
@@ -1038,6 +1049,7 @@ def train_model(
         "t5xxl": t5xxl if sd3_checkbox else flux1_t5xxl if flux1_checkbox else None,
         "train_batch_size": train_batch_size,
         "train_data_dir": train_data_dir,
+        "train_inpainting": train_inpainting,
         "train_text_encoder": train_text_encoder if sdxl else None,
         "v2": v2,
         "v_parameterization": v_parameterization,
@@ -1232,6 +1244,20 @@ def dreambooth_tab(
                         sdxl_checkbox=source_model.sdxl_checkbox,
                         config=config,
                     )
+                with gr.Row():
+                    train_inpainting = gr.Checkbox(
+                        label="Train inpainting model",
+                        value=config.get("basic.train_inpainting", False),
+                        info='Trains a 9-channel inpainting model with randomly generated masks. Incompatible with "Cache latents".',
+                    )
+                train_inpainting.change(
+                    train_inpainting_changed,
+                    inputs=[train_inpainting],
+                    outputs=[
+                        basic_training.cache_latents,
+                        basic_training.cache_latents_to_disk,
+                    ],
+                )
 
             # Add SDXL Parameters
             sdxl_params = SDXLParameters(
@@ -1306,6 +1332,7 @@ def dreambooth_tab(
             accelerate_launch.num_cpu_threads_per_process,
             basic_training.cache_latents,
             basic_training.cache_latents_to_disk,
+            train_inpainting,
             basic_training.caption_extension,
             basic_training.enable_bucket,
             advanced_training.gradient_checkpointing,

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -884,6 +884,17 @@ def train_model(
         # image, so latent caching cannot be used at the same time.
         cache_latents = False
         cache_latents_to_disk = False
+    # `parameters` was snapshotted from locals() before the overrides above;
+    # keep the saved JSON training config in sync with the corrected values.
+    parameters = [
+        (name, value)
+        for name, value in parameters
+        if name not in ("train_inpainting", "cache_latents", "cache_latents_to_disk")
+    ] + [
+        ("train_inpainting", train_inpainting),
+        ("cache_latents", cache_latents),
+        ("cache_latents_to_disk", cache_latents_to_disk),
+    ]
     if max_data_loader_n_workers in ("", None):
         max_data_loader_n_workers = 0
     else:

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -17,6 +17,7 @@ from .common_gui import (
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
+    train_inpainting_changed,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -138,6 +139,7 @@ def save_configuration(
     model_list,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     use_latent_files,
     keep_tokens,
     persistent_data_loader_workers,
@@ -356,6 +358,7 @@ def open_configuration(
     model_list,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     use_latent_files,
     keep_tokens,
     persistent_data_loader_workers,
@@ -580,6 +583,7 @@ def train_model(
     model_list,  # Keep this. Yes, it is unused here but required given the common list used
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     use_latent_files,
     keep_tokens,
     persistent_data_loader_workers,
@@ -939,6 +943,14 @@ def train_model(
     ) or (flux1_checkbox and flux1_cache_text_encoder_outputs_to_disk)
     no_half_vae = sdxl_checkbox and sdxl_no_half_vae
 
+    # --train_inpainting is only supported by fine_tune.py/sdxl_train.py
+    train_inpainting = train_inpainting and not (sd3_checkbox or flux1_checkbox)
+    if train_inpainting:
+        # Masks are generated randomly per training step from the source
+        # image, so latent caching cannot be used at the same time.
+        cache_latents = False
+        cache_latents_to_disk = False
+
     if max_data_loader_n_workers in ("", None):
         max_data_loader_n_workers = 0
     else:
@@ -1084,6 +1096,7 @@ def train_model(
         "t5xxl": t5xxl if sd3_checkbox else flux1_t5xxl if flux1_checkbox else None,
         "train_batch_size": train_batch_size,
         "train_data_dir": image_folder,
+        "train_inpainting": train_inpainting,
         "train_text_encoder": train_text_encoder,
         "log_with": log_with,
         "v2": v2,
@@ -1338,6 +1351,19 @@ def finetune_tab(
                         train_text_encoder = gr.Checkbox(
                             label="Train text encoder", value=True
                         )
+                        train_inpainting = gr.Checkbox(
+                            label="Train inpainting model",
+                            value=config.get("basic.train_inpainting", False),
+                            info='Trains a 9-channel inpainting model with randomly generated masks. Incompatible with "Cache latents".',
+                        )
+                    train_inpainting.change(
+                        train_inpainting_changed,
+                        inputs=[train_inpainting],
+                        outputs=[
+                            basic_training.cache_latents,
+                            basic_training.cache_latents_to_disk,
+                        ],
+                    )
 
             # Add FLUX1 Parameters
             flux1_training = flux1Training(
@@ -1466,6 +1492,7 @@ def finetune_tab(
             source_model.model_list,
             basic_training.cache_latents,
             basic_training.cache_latents_to_disk,
+            train_inpainting,
             use_latent_files,
             advanced_training.keep_tokens,
             advanced_training.persistent_data_loader_workers,

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -950,6 +950,17 @@ def train_model(
         # image, so latent caching cannot be used at the same time.
         cache_latents = False
         cache_latents_to_disk = False
+    # `parameters` was snapshotted from locals() before the overrides above;
+    # keep the saved JSON training config in sync with the corrected values.
+    parameters = [
+        (name, value)
+        for name, value in parameters
+        if name not in ("train_inpainting", "cache_latents", "cache_latents_to_disk")
+    ] + [
+        ("train_inpainting", train_inpainting),
+        ("cache_latents", cache_latents),
+        ("cache_latents_to_disk", cache_latents_to_disk),
+    ]
 
     if max_data_loader_n_workers in ("", None):
         max_data_loader_n_workers = 0

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -18,6 +18,7 @@ from .common_gui import (
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
+    train_inpainting_changed,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -109,6 +110,7 @@ def save_configuration(
     seed,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     caption_extension,
     enable_bucket,
     stop_text_encoder_training,
@@ -414,6 +416,7 @@ def open_configuration(
     seed,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     caption_extension,
     enable_bucket,
     stop_text_encoder_training,
@@ -830,6 +833,7 @@ def train_model(
     seed,
     cache_latents,
     cache_latents_to_disk,
+    train_inpainting,
     caption_extension,
     enable_bucket,
     stop_text_encoder_training,
@@ -1348,6 +1352,16 @@ def train_model(
     else:
         run_cmd.append(rf"{scriptdir}/sd-scripts/train_network.py")
 
+    # --train_inpainting is only supported by train_network.py/sdxl_train_network.py
+    train_inpainting = train_inpainting and not (
+        flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox
+    )
+    if train_inpainting:
+        # Masks are generated randomly per training step from the source
+        # image, so latent caching cannot be used at the same time.
+        cache_latents = False
+        cache_latents_to_disk = False
+
     network_args = ""
 
     if LoRA_type == "LyCORIS/BOFT":
@@ -1804,6 +1818,7 @@ def train_model(
         "text_encoder_lr": text_encoder_lr_list if text_encoder_lr_list != [] else None,
         "train_batch_size": train_batch_size,
         "train_data_dir": train_data_dir,
+        "train_inpainting": train_inpainting,
         "training_comment": training_comment,
         "unet_lr": unet_lr_float if unet_lr_float != 0.0 else None,
         "log_with": log_with,
@@ -2132,6 +2147,21 @@ def lora_tab(
                     lr_warmup_value=10,
                     sdxl_checkbox=source_model.sdxl_checkbox,
                     config=config,
+                )
+
+                with gr.Row():
+                    train_inpainting = gr.Checkbox(
+                        label="Train inpainting model",
+                        value=config.get("basic.train_inpainting", False),
+                        info='Trains a 9-channel inpainting model with randomly generated masks (train_network.py/sdxl_train_network.py only). Incompatible with "Cache latents".',
+                    )
+                train_inpainting.change(
+                    train_inpainting_changed,
+                    inputs=[train_inpainting],
+                    outputs=[
+                        basic_training.cache_latents,
+                        basic_training.cache_latents_to_disk,
+                    ],
                 )
 
                 with gr.Row():
@@ -2988,6 +3018,7 @@ def lora_tab(
             basic_training.seed,
             basic_training.cache_latents,
             basic_training.cache_latents_to_disk,
+            train_inpainting,
             basic_training.caption_extension,
             basic_training.enable_bucket,
             basic_training.stop_text_encoder_training,

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -1361,6 +1361,17 @@ def train_model(
         # image, so latent caching cannot be used at the same time.
         cache_latents = False
         cache_latents_to_disk = False
+    # `parameters` was snapshotted from locals() before the overrides above;
+    # keep the saved JSON training config in sync with the corrected values.
+    parameters = [
+        (name, value)
+        for name, value in parameters
+        if name not in ("train_inpainting", "cache_latents", "cache_latents_to_disk")
+    ] + [
+        ("train_inpainting", train_inpainting),
+        ("cache_latents", cache_latents),
+        ("cache_latents_to_disk", cache_latents_to_disk),
+    ]
 
     network_args = ""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,3 +100,18 @@ def run_train_model_and_load_toml(gui_module, kwargs: dict) -> dict:
         assert len(toml_files) == 1, f"expected exactly one .toml, got {toml_files}"
         with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
             return toml.load(f)
+
+
+def run_train_model_and_load_saved_json(gui_module, kwargs: dict) -> dict:
+    """Call `gui_module.train_model(**kwargs)` with print_only=False in a
+    scratch output_dir, then load and return the JSON training config
+    `SaveConfigFile` wrote (the preset callers re-load via "Load config").
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        kwargs = dict(kwargs, output_dir=tmpdir, output_name="testout", print_only=False)
+        mock_executor(gui_module)
+        gui_module.train_model(**kwargs)
+        json_files = [f for f in os.listdir(tmpdir) if f.endswith(".json")]
+        assert len(json_files) == 1, f"expected exactly one .json, got {json_files}"
+        with open(os.path.join(tmpdir, json_files[0]), encoding="utf-8") as f:
+            return json.load(f)

--- a/tests/test_dreambooth_gui.py
+++ b/tests/test_dreambooth_gui.py
@@ -1,6 +1,13 @@
 """Regression test for GH issue #3520: dreambooth_gui.py leaking LoRA-only
 `split_mode`/`train_blocks` into the flux_train.py (full fine-tune) config,
 the same bug fixed in finetune_gui.py.
+
+Also covers GH issue #3527: inpainting model training support (SD1.5/SDXL).
+`--train_inpainting` must be forwarded to train_db.py/sdxl_train.py and must
+never be combined with `--cache_latents`/`--cache_latents_to_disk` since
+masks are generated randomly per step from the source image. It must also
+never leak into flux_train.py/sd3_train.py, which aren't in the supported
+script list.
 """
 
 import unittest
@@ -28,6 +35,57 @@ class TestDreamboothFluxConfigOutput(unittest.TestCase):
 
         self.assertNotIn("split_mode", config)
         self.assertNotIn("train_blocks", config)
+
+
+class TestDreamboothTrainInpainting(unittest.TestCase):
+    def test_train_inpainting_forwarded_and_cache_latents_dropped(self):
+        kwargs = build_train_model_kwargs(
+            dreambooth_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            overrides={
+                "train_inpainting": True,
+                "cache_latents": True,
+                "cache_latents_to_disk": True,
+            },
+        )
+        config = run_train_model_and_load_toml(dreambooth_gui, kwargs)
+
+        self.assertTrue(config.get("train_inpainting"))
+        self.assertNotIn("cache_latents", config)
+        self.assertNotIn("cache_latents_to_disk", config)
+
+    def test_train_inpainting_off_leaves_cache_latents_untouched(self):
+        kwargs = build_train_model_kwargs(
+            dreambooth_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            overrides={
+                "train_inpainting": False,
+                "cache_latents": True,
+                "cache_latents_to_disk": False,
+            },
+        )
+        config = run_train_model_and_load_toml(dreambooth_gui, kwargs)
+
+        self.assertNotIn("train_inpainting", config)
+        self.assertTrue(config.get("cache_latents"))
+
+    def test_train_inpainting_dropped_for_flux_backend(self):
+        # train_inpainting is only supported by train_db.py/sdxl_train.py;
+        # flux_train.py must never receive it.
+        kwargs = build_train_model_kwargs(
+            dreambooth_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            overrides={
+                "train_inpainting": True,
+                "flux1_checkbox": True,
+            },
+        )
+        config = run_train_model_and_load_toml(dreambooth_gui, kwargs)
+
+        self.assertNotIn("train_inpainting", config)
 
 
 if __name__ == "__main__":

--- a/tests/test_dreambooth_gui.py
+++ b/tests/test_dreambooth_gui.py
@@ -13,7 +13,11 @@ script list.
 import unittest
 
 from kohya_gui import dreambooth_gui
-from conftest import build_train_model_kwargs, run_train_model_and_load_toml
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_saved_json,
+    run_train_model_and_load_toml,
+)
 
 FIXTURE = "test/config/dreambooth-AdamW.json"
 NUMERIC_FIXUPS = ("max_grad_norm",)
@@ -86,6 +90,27 @@ class TestDreamboothTrainInpainting(unittest.TestCase):
         config = run_train_model_and_load_toml(dreambooth_gui, kwargs)
 
         self.assertNotIn("train_inpainting", config)
+
+    def test_saved_json_config_reflects_forced_overrides(self):
+        # The JSON training config saved via SaveConfigFile() must not
+        # persist the pre-override checkbox state (train_inpainting=True
+        # with cache_latents=True), which would produce an invalid combo
+        # if the user reloads this saved config later.
+        kwargs = build_train_model_kwargs(
+            dreambooth_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            overrides={
+                "train_inpainting": True,
+                "cache_latents": True,
+                "cache_latents_to_disk": True,
+            },
+        )
+        config = run_train_model_and_load_saved_json(dreambooth_gui, kwargs)
+
+        self.assertTrue(config.get("train_inpainting"))
+        self.assertFalse(config.get("cache_latents"))
+        self.assertFalse(config.get("cache_latents_to_disk"))
 
 
 if __name__ == "__main__":

--- a/tests/test_finetune_gui.py
+++ b/tests/test_finetune_gui.py
@@ -6,7 +6,11 @@ even though that script never defines either arg.
 import unittest
 
 from kohya_gui import finetune_gui
-from conftest import build_train_model_kwargs, run_train_model_and_load_toml
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_saved_json,
+    run_train_model_and_load_toml,
+)
 
 FIXTURE = "test/config/finetune-AdamW-toml.json"
 
@@ -110,6 +114,28 @@ class TestFinetuneTrainInpainting(unittest.TestCase):
         config = run_train_model_and_load_toml(finetune_gui, kwargs)
 
         self.assertNotIn("train_inpainting", config)
+
+    def test_saved_json_config_reflects_forced_overrides(self):
+        # The JSON training config saved via SaveConfigFile() must not
+        # persist the pre-override checkbox state (train_inpainting=True
+        # with cache_latents=True), which would produce an invalid combo
+        # if the user reloads this saved config later.
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                "train_inpainting": True,
+                "cache_latents": True,
+                "cache_latents_to_disk": True,
+            },
+        )
+        config = run_train_model_and_load_saved_json(finetune_gui, kwargs)
+
+        self.assertTrue(config.get("train_inpainting"))
+        self.assertFalse(config.get("cache_latents"))
+        self.assertFalse(config.get("cache_latents_to_disk"))
 
 
 if __name__ == "__main__":

--- a/tests/test_finetune_gui.py
+++ b/tests/test_finetune_gui.py
@@ -66,5 +66,51 @@ class TestFinetuneFluxConfigOutput(unittest.TestCase):
         self.assertNotIn("train_blocks", config)
 
 
+class TestFinetuneTrainInpainting(unittest.TestCase):
+    """GH issue #3527: inpainting model training support (SD1.5/SDXL).
+
+    `--train_inpainting` must be forwarded to fine_tune.py/sdxl_train.py and
+    must never be combined with `--cache_latents`/`--cache_latents_to_disk`
+    since masks are generated randomly per step from the source image. It
+    must also never leak into flux_train.py/sd3_train.py, which aren't in
+    the supported script list.
+    """
+
+    def test_train_inpainting_forwarded_and_cache_latents_dropped(self):
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                "train_inpainting": True,
+                "cache_latents": True,
+                "cache_latents_to_disk": True,
+            },
+        )
+        config = run_train_model_and_load_toml(finetune_gui, kwargs)
+
+        self.assertTrue(config.get("train_inpainting"))
+        self.assertNotIn("cache_latents", config)
+        self.assertNotIn("cache_latents_to_disk", config)
+
+    def test_train_inpainting_dropped_for_flux_backend(self):
+        # train_inpainting is only supported by fine_tune.py/sdxl_train.py;
+        # flux_train.py must never receive it.
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                "train_inpainting": True,
+                "flux1_checkbox": True,
+            },
+        )
+        config = run_train_model_and_load_toml(finetune_gui, kwargs)
+
+        self.assertNotIn("train_inpainting", config)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -5,7 +5,11 @@ sd-scripts v0.11.1 silently ignores (LoRA+ ratios, stale `lowvram`).
 import unittest
 
 from kohya_gui import lora_gui
-from conftest import build_train_model_kwargs, run_train_model_and_load_toml
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_saved_json,
+    run_train_model_and_load_toml,
+)
 
 FIXTURE = "test/config/locon-AdamW8bit-toml.json"
 
@@ -178,6 +182,28 @@ class TestLoraTrainInpainting(unittest.TestCase):
             }
         )
         self.assertNotIn("train_inpainting", config)
+
+    def test_saved_json_config_reflects_forced_overrides(self):
+        # The JSON training config saved via SaveConfigFile() must not
+        # persist the pre-override checkbox state (train_inpainting=True
+        # with cache_latents=True), which would produce an invalid combo
+        # if the user reloads this saved config later.
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                "train_inpainting": True,
+                "cache_latents": True,
+                "cache_latents_to_disk": True,
+            },
+        )
+        config = run_train_model_and_load_saved_json(lora_gui, kwargs)
+
+        self.assertTrue(config.get("train_inpainting"))
+        self.assertFalse(config.get("cache_latents"))
+        self.assertFalse(config.get("cache_latents_to_disk"))
 
 
 if __name__ == "__main__":

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -134,5 +134,51 @@ class TestTrainModelConfigOutput(unittest.TestCase):
         self.assertNotIn("lowvram", config)
 
 
+class TestLoraTrainInpainting(unittest.TestCase):
+    """GH issue #3527: inpainting model training support (SD1.5/SDXL).
+
+    `--train_inpainting` must be forwarded to train_network.py/
+    sdxl_train_network.py and must never be combined with
+    `--cache_latents`/`--cache_latents_to_disk` since masks are generated
+    randomly per step from the source image. It must also never leak into
+    flux_train_network.py/sd3_train_network.py/hunyuan_image_train_network.py,
+    which aren't in the supported script list.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides=overrides,
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_train_inpainting_forwarded_and_cache_latents_dropped(self):
+        config = self._run_and_load_toml(
+            {
+                "train_inpainting": True,
+                "cache_latents": True,
+                "cache_latents_to_disk": True,
+            }
+        )
+        self.assertTrue(config.get("train_inpainting"))
+        self.assertNotIn("cache_latents", config)
+        self.assertNotIn("cache_latents_to_disk", config)
+
+    def test_train_inpainting_dropped_for_flux_backend(self):
+        # train_inpainting is only supported by train_network.py/
+        # sdxl_train_network.py; flux_train_network.py must never receive it.
+        config = self._run_and_load_toml(
+            {
+                "train_inpainting": True,
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+            }
+        )
+        self.assertNotIn("train_inpainting", config)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds a "Train inpainting model" checkbox to the Dreambooth, Finetune, and LoRA tabs, forwarding `--train_inpainting` to `train_db.py`/`sdxl_train.py`, `fine_tune.py`/`sdxl_train.py`, and `train_network.py`/`sdxl_train_network.py` respectively — all of which already support the flag as of the checked-out sd-scripts v0.11.1 submodule (no submodule changes made).
- Enabling the checkbox force-disables (and greys out) "Cache latents"/"Cache latents to disk" in the same tab via a new `train_inpainting_changed` helper in `common_gui.py` (mirrors the existing `color_aug_changed` pattern), since inpainting masks are generated randomly per training step from the source image and can't be used with cached latents.
- The flag is dropped (never forwarded) when a backend that doesn't support it is selected (flux1/sd3/hunyuan checkboxes), so the generated command never passes an unsupported arg.

## Test plan

- [x] `pytest tests/` — 40 passed (added regression tests to `test_dreambooth_gui.py`, `test_finetune_gui.py`, `test_lora_gui.py` covering: flag forwarded + cache_latents dropped from generated TOML, flag off leaves cache_latents untouched, flag dropped for flux backend)
- [x] Launched the GUI and visually verified the new checkbox renders cleanly (own row, no crowding/overlap) on Dreambooth, Finetune, and LoRA tabs

Closes #3527