### PR TITLE
Add Anima LoRA training support to GUI

### DIFF
--- a/kohya_gui/class_anima.py
+++ b/kohya_gui/class_anima.py
@@ -1,0 +1,213 @@
+import gradio as gr
+from .common_gui import (
+    get_any_file_path,
+    get_folder_path,
+    document_symbol,
+)
+
+
+class animaTraining:
+    def __init__(
+        self,
+        headless: bool = False,
+        finetuning: bool = False,
+        training_type: str = "",
+        config: dict = {},
+        anima_checkbox: gr.Checkbox = False,
+    ) -> None:
+        self.headless = headless
+        self.finetuning = finetuning
+        self.training_type = training_type
+        self.config = config
+        self.anima_checkbox = anima_checkbox
+
+        with gr.Accordion(
+            "Anima",
+            open=True,
+            visible=False,
+            elem_classes=["anima_background"],
+        ) as anima_accordion:
+            with gr.Group():
+                with gr.Row():
+                    self.qwen3 = gr.Textbox(
+                        label="Qwen3 Path",
+                        placeholder="Path to Qwen3-0.6B text encoder model (file or directory)",
+                        value=self.config.get("anima.qwen3", ""),
+                        interactive=True,
+                    )
+                    self.qwen3_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.qwen3_button.click(
+                        get_any_file_path,
+                        outputs=self.qwen3,
+                        show_progress=False,
+                    )
+
+                    self.vae = gr.Textbox(
+                        label="VAE Path",
+                        placeholder="Path to Qwen-Image VAE model",
+                        value=self.config.get("anima.vae", ""),
+                        interactive=True,
+                    )
+                    self.vae_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.vae_button.click(
+                        get_any_file_path,
+                        outputs=self.vae,
+                        show_progress=False,
+                    )
+
+                with gr.Row():
+                    self.llm_adapter_path = gr.Textbox(
+                        label="LLM Adapter Path",
+                        placeholder="(Optional) Path to separate LLM adapter weights",
+                        info="If omitted, the adapter is loaded from the DiT file when the key llm_adapter.out_proj.weight exists",
+                        value=self.config.get("anima.llm_adapter_path", ""),
+                        interactive=True,
+                    )
+                    self.llm_adapter_path_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.llm_adapter_path_button.click(
+                        get_any_file_path,
+                        outputs=self.llm_adapter_path,
+                        show_progress=False,
+                    )
+
+                    self.t5_tokenizer_path = gr.Textbox(
+                        label="T5 Tokenizer Path",
+                        placeholder="(Optional) Path to T5 tokenizer directory",
+                        info="If omitted, uses the bundled tokenizer at configs/t5_old/",
+                        value=self.config.get("anima.t5_tokenizer_path", ""),
+                        interactive=True,
+                    )
+                    self.t5_tokenizer_path_button = gr.Button(
+                        "\U0001f4c2",
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.t5_tokenizer_path_button.click(
+                        get_folder_path,
+                        outputs=self.t5_tokenizer_path,
+                        show_progress=False,
+                    )
+
+                with gr.Row():
+                    self.discrete_flow_shift = gr.Number(
+                        label="Discrete Flow Shift",
+                        value=self.config.get("anima.discrete_flow_shift", 1.0),
+                        info="Timestep distribution shift for rectified flow training, used when Timestep Sampling is 'shift'. Default is 1.0",
+                        minimum=-1024,
+                        maximum=1024,
+                        step=0.01,
+                        interactive=True,
+                    )
+                    self.timestep_sampling = gr.Dropdown(
+                        label="Timestep Sampling",
+                        choices=["sigma", "uniform", "sigmoid", "shift", "flux_shift"],
+                        value=self.config.get("anima.timestep_sampling", "sigmoid"),
+                        interactive=True,
+                    )
+                    self.sigmoid_scale = gr.Number(
+                        label="Sigmoid Scale",
+                        value=self.config.get("anima.sigmoid_scale", 1.0),
+                        info='Scale factor for sigmoid timestep sampling (used when Timestep Sampling is "sigmoid", "shift" or "flux_shift")',
+                        minimum=0.0,
+                        maximum=1024,
+                        step=0.01,
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.qwen3_max_token_length = gr.Number(
+                        label="Qwen3 Max Token Length",
+                        value=self.config.get("anima.qwen3_max_token_length", 512),
+                        info="Maximum token length for the Qwen3 tokenizer",
+                        minimum=0,
+                        maximum=4096,
+                        step=1,
+                        interactive=True,
+                    )
+                    self.t5_max_token_length = gr.Number(
+                        label="T5 Max Token Length",
+                        value=self.config.get("anima.t5_max_token_length", 512),
+                        info="Maximum token length for the T5 tokenizer",
+                        minimum=0,
+                        maximum=4096,
+                        step=1,
+                        interactive=True,
+                    )
+                    self.attn_mode = gr.Dropdown(
+                        label="Attention Mode",
+                        choices=["torch", "xformers", "flash", "sageattn"],
+                        value=self.config.get("anima.attn_mode", "torch"),
+                        info="xformers requires Split Attention. sageattn does not support training (inference only)",
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.split_attn = gr.Checkbox(
+                        label="Split Attention",
+                        value=self.config.get("anima.split_attn", False),
+                        info="Split attention computation to reduce memory usage. Required when using Attention Mode xformers.",
+                        interactive=True,
+                    )
+                    self.vae_chunk_size = gr.Number(
+                        label="VAE Chunk Size",
+                        value=self.config.get("anima.vae_chunk_size", 0),
+                        info="Spatial chunk size for VAE encoding/decoding to reduce memory usage. Must be an even number. 0 means no chunking (default).",
+                        minimum=0,
+                        maximum=1024,
+                        step=2,
+                        interactive=True,
+                    )
+                    self.vae_disable_cache = gr.Checkbox(
+                        label="VAE Disable Cache",
+                        value=self.config.get("anima.vae_disable_cache", False),
+                        info="Disable internal VAE caching mechanism to reduce memory usage (faster, but differs from official behavior)",
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.cache_text_encoder_outputs = gr.Checkbox(
+                        label="Cache Text Encoder Outputs",
+                        value=self.config.get(
+                            "anima.cache_text_encoder_outputs", False
+                        ),
+                        info="Cache Qwen3 text encoder outputs to reduce VRAM usage. Recommended when not training Text Encoder LoRA.",
+                        interactive=True,
+                    )
+                    self.cache_text_encoder_outputs_to_disk = gr.Checkbox(
+                        label="Cache Text Encoder Outputs to Disk",
+                        value=self.config.get(
+                            "anima.cache_text_encoder_outputs_to_disk", False
+                        ),
+                        info="Cache text encoder outputs to disk. Automatically enables Cache Text Encoder Outputs.",
+                        interactive=True,
+                    )
+                    self.unsloth_offload_checkpointing = gr.Checkbox(
+                        label="Unsloth Offload Checkpointing",
+                        value=self.config.get(
+                            "anima.unsloth_offload_checkpointing", False
+                        ),
+                        info="Offload activations to CPU RAM using async non-blocking transfers (faster than CPU Offload Checkpointing). Cannot be combined with CPU Offload Checkpointing or Blocks to swap.",
+                        interactive=True,
+                    )
+
+                self.anima_checkbox.change(
+                    lambda anima_checkbox: gr.Accordion(visible=anima_checkbox),
+                    inputs=[self.anima_checkbox],
+                    outputs=[anima_accordion],
+                )

--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -289,10 +289,17 @@ class SourceModel:
                                 min_width=60,
                                 interactive=True,
                             )
+                            self.anima_checkbox = gr.Checkbox(
+                                label="Anima",
+                                value=False,
+                                visible=False,
+                                min_width=60,
+                                interactive=True,
+                            )
 
-                            def toggle_checkboxes(v2, v_parameterization, sdxl_checkbox, sd3_checkbox, flux1_checkbox, hunyuan_image_checkbox):
+                            def toggle_checkboxes(v2, v_parameterization, sdxl_checkbox, sd3_checkbox, flux1_checkbox, hunyuan_image_checkbox, anima_checkbox):
                                 # Check if all checkboxes are unchecked
-                                if not v2 and not sdxl_checkbox and not sd3_checkbox and not flux1_checkbox and not hunyuan_image_checkbox:
+                                if not v2 and not sdxl_checkbox and not sd3_checkbox and not flux1_checkbox and not hunyuan_image_checkbox and not anima_checkbox:
                                     # If all unchecked, return new interactive checkboxes
                                     return (
                                         gr.Checkbox(interactive=True),  # v2 checkbox
@@ -301,6 +308,7 @@ class SourceModel:
                                         gr.Checkbox(interactive=True),  # sd3_checkbox
                                         gr.Checkbox(interactive=True),  # flux1_checkbox
                                         gr.Checkbox(interactive=True),  # hunyuan_image_checkbox
+                                        gr.Checkbox(interactive=True),  # anima_checkbox
                                     )
                                 else:
                                     # If any checkbox is checked, return checkboxes with current interactive state
@@ -311,6 +319,7 @@ class SourceModel:
                                         gr.Checkbox(interactive=sd3_checkbox),  # sd3_checkbox
                                         gr.Checkbox(interactive=flux1_checkbox),  # flux1_checkbox
                                         gr.Checkbox(interactive=hunyuan_image_checkbox),  # hunyuan_image_checkbox
+                                        gr.Checkbox(interactive=anima_checkbox),  # anima_checkbox
                                     )
 
                             checkbox_inputs = [
@@ -320,6 +329,7 @@ class SourceModel:
                                 self.sd3_checkbox,
                                 self.flux1_checkbox,
                                 self.hunyuan_image_checkbox,
+                                self.anima_checkbox,
                             ]
 
                             self.v2.change(
@@ -353,6 +363,12 @@ class SourceModel:
                                 show_progress=False,
                             )
                             self.hunyuan_image_checkbox.change(
+                                fn=toggle_checkboxes,
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
+                                show_progress=False,
+                            )
+                            self.anima_checkbox.change(
                                 fn=toggle_checkboxes,
                                 inputs=checkbox_inputs,
                                 outputs=checkbox_inputs,
@@ -396,6 +412,7 @@ class SourceModel:
                         self.sd3_checkbox,
                         self.flux1_checkbox,
                         self.hunyuan_image_checkbox,
+                        self.anima_checkbox,
                     ],
                     show_progress=False,
                 )

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -994,6 +994,7 @@ def set_pretrained_model_name_or_path_input(
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
+        anima = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1002,6 +1003,7 @@ def set_pretrained_model_name_or_path_input(
             sd3,
             flux1,
             hunyuan_image,
+            anima,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V2 base models
@@ -1013,6 +1015,7 @@ def set_pretrained_model_name_or_path_input(
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
+        anima = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1021,6 +1024,7 @@ def set_pretrained_model_name_or_path_input(
             sd3,
             flux1,
             hunyuan_image,
+            anima,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V parameterization models
@@ -1034,6 +1038,7 @@ def set_pretrained_model_name_or_path_input(
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
+        anima = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1042,6 +1047,7 @@ def set_pretrained_model_name_or_path_input(
             sd3,
             flux1,
             hunyuan_image,
+            anima,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V1 models
@@ -1053,6 +1059,7 @@ def set_pretrained_model_name_or_path_input(
         sd3 = gr.Checkbox(value=False, visible=False)
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
+        anima = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1061,6 +1068,7 @@ def set_pretrained_model_name_or_path_input(
             sd3,
             flux1,
             hunyuan_image,
+            anima,
         )
 
     # Check if the model_list is set to 'custom'
@@ -1070,6 +1078,7 @@ def set_pretrained_model_name_or_path_input(
     sd3 = gr.Checkbox(visible=True)
     flux1 = gr.Checkbox(visible=True)
     hunyuan_image = gr.Checkbox(visible=True)
+    anima = gr.Checkbox(visible=True)
 
     # Auto-detect model type if safetensors file path is given
     if pretrained_model_name_or_path.lower().endswith(".safetensors"):
@@ -1095,6 +1104,7 @@ def set_pretrained_model_name_or_path_input(
         sd3,
         flux1,
         hunyuan_image,
+        anima,
     )
 
 

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -983,7 +983,8 @@ def set_pretrained_model_name_or_path_input(
 
     Returns:
         tuple: A tuple containing the Dropdown widget, v2 checkbox, v_parameterization checkbox,
-               and sdxl checkbox.
+               sdxl checkbox, sd3 checkbox, flux1 checkbox, hunyuan_image checkbox, and anima
+               checkbox.
     """
     # Check if the given pretrained_model_name_or_path is in the list of SDXL models
     if pretrained_model_name_or_path in SDXL_MODELS:

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -1156,6 +1156,21 @@ def train_model(
             )
             return TRAIN_BUTTON_VISIBLE
 
+    # `network_module` is derived from `LoRA_type` while the training script is selected
+    # from `anima_checkbox`; keep the two in sync so the GUI can't emit a mismatched
+    # command (wrong script paired with the wrong/missing Anima-only args).
+    if anima_checkbox and LoRA_type != "Anima":
+        log.error(
+            "LoRA type must be set to 'Anima' if the Anima model checkbox is checked."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
+    if LoRA_type == "Anima" and not anima_checkbox:
+        log.error(
+            "The Anima model checkbox must be checked when LoRA type is set to 'Anima'."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
     #
     # Validate paths
     #

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -44,6 +44,7 @@ from .class_metadata import MetaData
 from .class_gui_config import KohyaSSGUIConfig
 from .class_flux1 import flux1Training
 from .class_hunyuan_image import hunyuanImageTraining
+from .class_anima import animaTraining
 
 from .dreambooth_folder_creation_gui import (
     gradio_dreambooth_folder_creation_tab,
@@ -341,6 +342,24 @@ def save_configuration(
     hunyuan_text_encoder_cpu,
     hunyuan_vae_chunk_size,
     hunyuan_image_checkbox,
+    # Anima parameters
+    anima_cache_text_encoder_outputs,
+    anima_cache_text_encoder_outputs_to_disk,
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_unsloth_offload_checkpointing,
+    anima_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -647,6 +666,24 @@ def open_configuration(
     hunyuan_text_encoder_cpu,
     hunyuan_vae_chunk_size,
     hunyuan_image_checkbox,
+    # Anima parameters
+    anima_cache_text_encoder_outputs,
+    anima_cache_text_encoder_outputs_to_disk,
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_unsloth_offload_checkpointing,
+    anima_checkbox,
     ##
     training_preset,
 ):
@@ -1064,6 +1101,24 @@ def train_model(
     hunyuan_text_encoder_cpu,
     hunyuan_vae_chunk_size,
     hunyuan_image_checkbox,
+    # Anima parameters
+    anima_cache_text_encoder_outputs,
+    anima_cache_text_encoder_outputs_to_disk,
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_unsloth_offload_checkpointing,
+    anima_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -1349,12 +1404,14 @@ def train_model(
         run_cmd.append(rf"{scriptdir}/sd-scripts/sd3_train_network.py")
     elif hunyuan_image_checkbox:
         run_cmd.append(rf"{scriptdir}/sd-scripts/hunyuan_image_train_network.py")
+    elif anima_checkbox:
+        run_cmd.append(rf"{scriptdir}/sd-scripts/anima_train_network.py")
     else:
         run_cmd.append(rf"{scriptdir}/sd-scripts/train_network.py")
 
     # --train_inpainting is only supported by train_network.py/sdxl_train_network.py
     train_inpainting = train_inpainting and not (
-        flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox
+        flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox or anima_checkbox
     )
     if train_inpainting:
         # Masks are generated randomly per training step from the source
@@ -1482,6 +1539,9 @@ def train_model(
 
     if LoRA_type == "HunyuanImage-2.1":
         network_module = "networks.lora_hunyuan_image"
+
+    if LoRA_type == "Anima":
+        network_module = "networks.lora_anima"
 
     if LoRA_type in ["Kohya LoCon", "Standard"]:
         kohya_lora_var_list = [
@@ -1645,7 +1705,9 @@ def train_model(
     if sd3_checkbox:
         disable_mmap_load_safetensors_value = sd3_disable_mmap_load_safetensors
 
-    vae_value = hunyuan_vae if hunyuan_image_checkbox else vae
+    vae_value = (
+        anima_vae if anima_checkbox else hunyuan_vae if hunyuan_image_checkbox else vae
+    )
 
     config_toml_data = {
         "adaptive_noise_scale": (
@@ -1664,6 +1726,7 @@ def train_model(
             or (flux1_checkbox and flux1_cache_text_encoder_outputs)
             or (sd3_checkbox and sd3_cache_text_encoder_outputs)
             or (hunyuan_image_checkbox and hunyuan_image_cache_text_encoder_outputs)
+            or (anima_checkbox and anima_cache_text_encoder_outputs)
             else None
         ),
         "cache_text_encoder_outputs_to_disk": (
@@ -1674,13 +1737,19 @@ def train_model(
             and sd3_cache_text_encoder_outputs_to_disk
             or hunyuan_image_checkbox
             and hunyuan_image_cache_text_encoder_outputs_to_disk
+            or anima_checkbox
+            and anima_cache_text_encoder_outputs_to_disk
             else None
         ),
         "caption_dropout_every_n_epochs": int(caption_dropout_every_n_epochs),
         "caption_dropout_rate": caption_dropout_rate,
         "caption_extension": caption_extension,
         "clip_l": clip_l_value,
-        "clip_skip": clip_skip if clip_skip != 0 and not hunyuan_image_checkbox else None,
+        "clip_skip": (
+            clip_skip
+            if clip_skip != 0 and not hunyuan_image_checkbox and not anima_checkbox
+            else None
+        ),
         "color_aug": color_aug,
         "dataset_config": dataset_config,
         "debiased_estimation_loss": debiased_estimation_loss,
@@ -1733,7 +1802,7 @@ def train_model(
         "max_timestep": max_timestep if max_timestep != 0 else None,
         "max_token_length": (
             int(max_token_length)
-            if not flux1_checkbox and not hunyuan_image_checkbox
+            if not flux1_checkbox and not hunyuan_image_checkbox and not anima_checkbox
             else None
         ),
         "max_train_epochs": (
@@ -1886,7 +1955,10 @@ def train_model(
         ),
         "blocks_to_swap": (
             blocks_to_swap
-            if flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox
+            if flux1_checkbox
+            or sd3_checkbox
+            or hunyuan_image_checkbox
+            or anima_checkbox
             else None
         ),
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
@@ -1905,9 +1977,13 @@ def train_model(
         "text_encoder": hunyuan_text_encoder if hunyuan_image_checkbox else None,
         "byt5": hunyuan_byt5 if hunyuan_image_checkbox else None,
         "discrete_flow_shift": (
-            float(hunyuan_discrete_flow_shift)
-            if hunyuan_image_checkbox
-            else float(discrete_flow_shift) if flux1_checkbox else None
+            float(anima_discrete_flow_shift)
+            if anima_checkbox
+            else (
+                float(hunyuan_discrete_flow_shift)
+                if hunyuan_image_checkbox
+                else float(discrete_flow_shift) if flux1_checkbox else None
+            )
         ),
         "model_prediction_type": (
             hunyuan_model_prediction_type
@@ -1915,28 +1991,68 @@ def train_model(
             else model_prediction_type if flux1_checkbox else None
         ),
         "timestep_sampling": (
-            hunyuan_timestep_sampling
-            if hunyuan_image_checkbox
-            else timestep_sampling if flux1_checkbox else None
+            anima_timestep_sampling
+            if anima_checkbox
+            else (
+                hunyuan_timestep_sampling
+                if hunyuan_image_checkbox
+                else timestep_sampling if flux1_checkbox else None
+            )
         ),
         "sigmoid_scale": (
-            float(hunyuan_sigmoid_scale) if hunyuan_image_checkbox else None
+            float(anima_sigmoid_scale)
+            if anima_checkbox
+            else float(hunyuan_sigmoid_scale) if hunyuan_image_checkbox else None
         ),
         "attn_mode": (
-            hunyuan_attn_mode
-            if hunyuan_image_checkbox and hunyuan_attn_mode != "torch"
-            else None
+            anima_attn_mode
+            if anima_checkbox and anima_attn_mode != "torch"
+            else (
+                hunyuan_attn_mode
+                if hunyuan_image_checkbox and hunyuan_attn_mode != "torch"
+                else None
+            )
         ),
-        "split_attn": hunyuan_split_attn if hunyuan_image_checkbox else None,
+        "split_attn": (
+            anima_split_attn
+            if anima_checkbox
+            else hunyuan_split_attn if hunyuan_image_checkbox else None
+        ),
         "fp8_scaled": hunyuan_fp8_scaled if hunyuan_image_checkbox else None,
         "fp8_vl": hunyuan_fp8_vl if hunyuan_image_checkbox else None,
         "text_encoder_cpu": (
             hunyuan_text_encoder_cpu if hunyuan_image_checkbox else None
         ),
         "vae_chunk_size": (
-            int(hunyuan_vae_chunk_size)
-            if hunyuan_image_checkbox and hunyuan_vae_chunk_size
+            int(anima_vae_chunk_size)
+            if anima_checkbox and anima_vae_chunk_size
+            else (
+                int(hunyuan_vae_chunk_size)
+                if hunyuan_image_checkbox and hunyuan_vae_chunk_size
+                else None
+            )
+        ),
+        # Anima specific parameters
+        "qwen3": anima_qwen3 if anima_checkbox else None,
+        "llm_adapter_path": (
+            anima_llm_adapter_path
+            if anima_checkbox and anima_llm_adapter_path
             else None
+        ),
+        "t5_tokenizer_path": (
+            anima_t5_tokenizer_path
+            if anima_checkbox and anima_t5_tokenizer_path
+            else None
+        ),
+        "qwen3_max_token_length": (
+            int(anima_qwen3_max_token_length) if anima_checkbox else None
+        ),
+        "t5_max_token_length": (
+            int(anima_t5_max_token_length) if anima_checkbox else None
+        ),
+        "vae_disable_cache": anima_vae_disable_cache if anima_checkbox else None,
+        "unsloth_offload_checkpointing": (
+            anima_unsloth_offload_checkpointing if anima_checkbox else None
         ),
     }
 
@@ -2100,6 +2216,7 @@ def lora_tab(
                     LoRA_type = gr.Dropdown(
                         label="LoRA type",
                         choices=[
+                            "Anima",
                             "Flux1",
                             "Flux1 OFT",
                             "HunyuanImage-2.1",
@@ -2431,6 +2548,7 @@ def lora_tab(
                             "update_params": {
                                 "visible": LoRA_type
                                 in {
+                                    "Anima",
                                     "Flux1",
                                     "Flux1 OFT",
                                     "HunyuanImage-2.1",
@@ -2472,6 +2590,7 @@ def lora_tab(
                             "update_params": {
                                 "visible": LoRA_type
                                 in {
+                                    "Anima",
                                     "Flux1",
                                     "Flux1 OFT",
                                     "HunyuanImage-2.1",
@@ -2487,6 +2606,7 @@ def lora_tab(
                             "update_params": {
                                 "visible": LoRA_type
                                 in {
+                                    "Anima",
                                     "Flux1",
                                     "Flux1 OFT",
                                     "HunyuanImage-2.1",
@@ -2510,6 +2630,7 @@ def lora_tab(
                             "update_params": {
                                 "visible": LoRA_type
                                 in {
+                                    "Anima",
                                     "Flux1",
                                     "Flux1 OFT",
                                     "HunyuanImage-2.1",
@@ -2533,6 +2654,7 @@ def lora_tab(
                             "update_params": {
                                 "visible": LoRA_type
                                 in {
+                                    "Anima",
                                     "Flux1",
                                     "Flux1 OFT",
                                     "HunyuanImage-2.1",
@@ -2882,6 +3004,13 @@ def lora_tab(
                 headless=headless,
                 config=config,
                 hunyuan_image_checkbox=source_model.hunyuan_image_checkbox,
+            )
+
+            # Add Anima Parameters
+            anima_training = animaTraining(
+                headless=headless,
+                config=config,
+                anima_checkbox=source_model.anima_checkbox,
             )
 
             with gr.Accordion(
@@ -3254,6 +3383,24 @@ def lora_tab(
             hunyuan_image_training.text_encoder_cpu,
             hunyuan_image_training.vae_chunk_size,
             source_model.hunyuan_image_checkbox,
+            # Anima parameters
+            anima_training.cache_text_encoder_outputs,
+            anima_training.cache_text_encoder_outputs_to_disk,
+            anima_training.qwen3,
+            anima_training.vae,
+            anima_training.llm_adapter_path,
+            anima_training.t5_tokenizer_path,
+            anima_training.discrete_flow_shift,
+            anima_training.timestep_sampling,
+            anima_training.sigmoid_scale,
+            anima_training.qwen3_max_token_length,
+            anima_training.t5_max_token_length,
+            anima_training.attn_mode,
+            anima_training.split_attn,
+            anima_training.vae_chunk_size,
+            anima_training.vae_disable_cache,
+            anima_training.unsloth_offload_checkpointing,
+            source_model.anima_checkbox,
         ]
 
         configuration.button_open_config.click(

--- a/tests/test_anima_lora_gui.py
+++ b/tests/test_anima_lora_gui.py
@@ -1,0 +1,196 @@
+"""Regression tests for GH issue #3487: Anima LoRA training support in the
+GUI.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import lora_gui
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_toml,
+    mock_executor,
+)
+
+FIXTURE = "test/config/locon-AdamW8bit-toml.json"
+
+NUMERIC_FIXUPS = (
+    "max_train_steps",
+    "max_train_epochs",
+    "num_processes",
+    "num_machines",
+    "gradient_accumulation_steps",
+    "seed",
+    "vae_batch_size",
+    "save_every_n_steps",
+    "save_every_n_epochs",
+    "save_last_n_steps",
+    "save_last_n_steps_state",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "lr_scheduler_num_cycles",
+    "min_bucket_reso",
+    "max_bucket_reso",
+    "bucket_reso_steps",
+    "max_data_loader_n_workers",
+    "keep_tokens",
+    "clip_skip",
+    "max_token_length",
+    "caption_dropout_every_n_epochs",
+    "min_snr_gamma",
+    "min_timestep",
+    "max_timestep",
+    "sample_every_n_steps",
+    "sample_every_n_epochs",
+    "gpu_ids",
+    "main_process_port",
+    "num_cpu_threads_per_process",
+    "t5xxl_max_token_length",
+    "block_lr_zero_threshold",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "t5xxl",
+    "sd3_clip_l",
+    "sd3_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "huggingface_repo_id",
+    "huggingface_token",
+    "huggingface_repo_type",
+    "huggingface_repo_visibility",
+    "huggingface_path_in_repo",
+    "metadata_author",
+    "metadata_description",
+    "metadata_license",
+    "metadata_tags",
+    "metadata_title",
+    "log_with",
+    "log_config",
+    "loss_type",
+    "huber_schedule",
+    "lr_scheduler_type",
+    "dynamo_backend",
+    "dynamo_mode",
+    "extra_accelerate_launch_args",
+    "network_weights",
+    "model_prediction_type",
+    "timestep_sampling",
+    "train_blocks",
+    "weighting_scheme",
+    "in_dims",
+)
+
+ANIMA_OVERRIDES = {
+    "LoRA_type": "Anima",
+    "anima_checkbox": True,
+    "anima_qwen3": "/models/qwen3_0.6b.safetensors",
+    "anima_vae": "/models/qwen_image_vae_fp16.safetensors",
+    "anima_llm_adapter_path": "",
+    "anima_t5_tokenizer_path": "",
+    "anima_discrete_flow_shift": 1.0,
+    "anima_timestep_sampling": "sigmoid",
+    "anima_sigmoid_scale": 1.0,
+    "anima_qwen3_max_token_length": 512,
+    "anima_t5_max_token_length": 512,
+    "anima_attn_mode": "torch",
+    "anima_split_attn": False,
+    "anima_vae_chunk_size": 0,
+    "anima_vae_disable_cache": False,
+    "anima_unsloth_offload_checkpointing": False,
+}
+
+
+class TestAnimaLoraConfigOutput(unittest.TestCase):
+    """End-to-end: train_model(print_only=True) writes a real TOML file we
+    can inspect for the Anima specific keys #3487 requires.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**ANIMA_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_network_module_is_lora_anima(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("network_module"), "networks.lora_anima")
+
+    def test_model_paths_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("qwen3"), "/models/qwen3_0.6b.safetensors")
+        self.assertEqual(config.get("vae"), "/models/qwen_image_vae_fp16.safetensors")
+
+    def test_optional_model_paths_are_omitted_when_blank(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("llm_adapter_path", config)
+        self.assertNotIn("t5_tokenizer_path", config)
+
+    def test_optional_model_paths_are_forwarded_when_set(self):
+        config = self._run_and_load_toml(
+            {
+                "anima_llm_adapter_path": "/models/llm_adapter.safetensors",
+                "anima_t5_tokenizer_path": "/models/t5_tokenizer",
+            }
+        )
+        self.assertEqual(
+            config.get("llm_adapter_path"), "/models/llm_adapter.safetensors"
+        )
+        self.assertEqual(config.get("t5_tokenizer_path"), "/models/t5_tokenizer")
+
+    def test_flow_matching_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("discrete_flow_shift"), 1.0)
+        self.assertEqual(config.get("timestep_sampling"), "sigmoid")
+        self.assertEqual(config.get("sigmoid_scale"), 1.0)
+
+    def test_token_length_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("qwen3_max_token_length"), 512)
+        self.assertEqual(config.get("t5_max_token_length"), 512)
+
+    def test_incompatible_sd_args_are_excluded(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("max_token_length", config)
+        self.assertNotIn("clip_skip", config)
+
+    def test_text_encoder_lora_is_not_forced_off(self):
+        """Unlike HunyuanImage-2.1, Anima supports training the (Qwen3) text
+        encoder LoRA, so network_train_unet_only must not be forced True
+        just because the Anima checkbox is set.
+        """
+        config = self._run_and_load_toml({"text_encoder_lr": 0.0001, "unet_lr": 0.0001})
+        self.assertNotIn("network_train_unet_only", config)
+        self.assertNotIn("network_train_text_encoder_only", config)
+
+    def test_attn_mode_omitted_when_default(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("attn_mode", config)
+
+    def test_attn_mode_forwarded_when_non_default(self):
+        config = self._run_and_load_toml({"anima_attn_mode": "xformers"})
+        self.assertEqual(config.get("attn_mode"), "xformers")
+
+    def test_script_selection_invokes_anima_train_network(self):
+        with patch.object(lora_gui, "print_command_and_toml") as mocked:
+            kwargs = build_train_model_kwargs(
+                lora_gui.train_model,
+                FIXTURE,
+                numeric_fixups=NUMERIC_FIXUPS,
+                string_overrides=STRING_OVERRIDES,
+                overrides=ANIMA_OVERRIDES,
+            )
+            mock_executor(lora_gui)
+            lora_gui.train_model(**kwargs)
+            self.assertTrue(mocked.called)
+            run_cmd = mocked.call_args[0][0]
+            self.assertTrue(any("anima_train_network.py" in part for part in run_cmd))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds base Anima LoRA training support to the GUI's LoRA tab, wrapping `sd-scripts/anima_train_network.py`.
- New `kohya_gui/class_anima.py` (modeled on `class_hunyuan_image.py`/`class_flux1.py`): Qwen3 text encoder path, Qwen-Image VAE path, optional LLM adapter path and T5 tokenizer path, flow-matching params (discrete flow shift, timestep sampling, sigmoid scale), token length limits, attention mode / split attention, VAE chunk size / disable cache, text-encoder-output caching, and unsloth offload checkpointing.
- Wired into `kohya_gui/lora_gui.py`: added "Anima" to the model-type selector and `LoRA_type` dropdown (`network_module = networks.lora_anima`), excludes SD-era args (`clip_skip`, `max_token_length`) that don't apply to Anima, reuses the shared `blocks_to_swap` field.
- `kohya_gui/class_source_model.py` / `kohya_gui/common_gui.py` updated for model-type-aware handling (new `anima_checkbox`), mirroring the HunyuanImage-2.1 precedent (PR #3537).
- New `tests/test_anima_lora_gui.py` (11 tests) exercising the GUI-to-CLI-argument path via `train_model(print_only=True)`.

**Important behavioral difference from HunyuanImage-2.1:** Anima's backend (`anima_train_network.py` / `networks/lora_anima.py`) *does* support training the Qwen3 text encoder LoRA (unlike HunyuanImage-2.1, which forces `network_train_unet_only`). So this PR does **not** force `network_train_unet_only` for Anima — the existing `text_encoder_lr`/`unet_lr`-based logic applies unchanged, matching `docs/anima_train_network.md` section 7.3.

**Out of scope** (tracked under the #3532 tracking issue, each its own sub-issue):
- Fine-tuning support (#3523)
- `--compile`, `--qwen_image_vae_2d`, timestep-visualization flags (#3524 — already partly covered by shared flags from #3535)
- ControlNet-LLLite tab (#3525)
- LyCORIS LoKr/LoHa for Anima (#3528)

**Backend notes for future sub-issues:**
- Anima also accepts the SD3-style `--weighting_scheme`/`--logit_mean`/`--logit_std`/`--mode_scale` loss-weighting options and component-wise learning rates (`--self_attn_lr`, `--cross_attn_lr`, `--mlp_lr`, `--mod_lr`, `--llm_adapter_lr`) — the latter are documented as "primarily used for full fine-tuning", so left for #3523.
- The regex-based module selection / rank control (`network_reg_dims`, `network_reg_lrs`, `exclude_patterns`, `include_patterns`, `train_llm_adapter`) exposed via `--network_args` is not surfaced in the GUI, matching the minimal-surface precedent set by the HunyuanImage-2.1 PR.

## Test plan

- [x] `pytest tests/test_anima_lora_gui.py -v` — 11/11 passed
- [x] `pytest tests/` — 54/54 passed (full suite)
- [x] `pytest test/test_allowed_paths.py` — passed
- [x] Verified `lora_tab()` builds successfully in a `gr.Blocks()` context (no Gradio wiring errors)
- [x] `typos` (installed via pip for this check) reports no new typos introduced
- [x] No type checker configured in this repo (no mypy/pyright config found) — stated explicitly, not silently skipped
- [x] `black --check` clean on all new/touched Anima-related lines

Closes #3487