### PR TITLE
Add Anima advanced options to GUI (torch.compile, Qwen-Image VAE 2D, timestep viz)

### DIFF
--- a/kohya_gui/class_anima.py
+++ b/kohya_gui/class_anima.py
@@ -179,6 +179,12 @@ class animaTraining:
                         info="Disable internal VAE caching mechanism to reduce memory usage (faster, but differs from official behavior)",
                         interactive=True,
                     )
+                    self.qwen_image_vae_2d = gr.Checkbox(
+                        label="Qwen-Image VAE 2D",
+                        value=self.config.get("anima.qwen_image_vae_2d", False),
+                        info="Use the image-only 2D Qwen-Image VAE (official weights are converted on load). ~2x faster encode/decode and ~1/3 peak VRAM for single-image latent pre-caching; numerically equivalent to the 3D VAE for single images. VAE Disable Cache has no effect with this option, since the 2D VAE has no temporal cache.",
+                        interactive=True,
+                    )
 
                 with gr.Row():
                     self.cache_text_encoder_outputs = gr.Checkbox(
@@ -205,6 +211,78 @@ class animaTraining:
                         info="Offload activations to CPU RAM using async non-blocking transfers (faster than CPU Offload Checkpointing). Cannot be combined with CPU Offload Checkpointing or Blocks to swap.",
                         interactive=True,
                     )
+
+                with gr.Row():
+                    self.compile = gr.Checkbox(
+                        label="Per-block Torch Compile",
+                        value=self.config.get("anima.compile", False),
+                        info="Enable per-block torch.compile for the DiT (requires Triton). ~20% speedup. Mutually exclusive with Legacy Torch Compile below.",
+                        interactive=True,
+                    )
+                    self.torch_compile = gr.Checkbox(
+                        label="Legacy Torch Compile (accelerate dynamo)",
+                        value=self.config.get("anima.torch_compile", False),
+                        info="Use the legacy accelerate-dynamo torch.compile path instead of the per-block one. Mutually exclusive with Per-block Torch Compile above.",
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.compile_backend = gr.Textbox(
+                        label="Compile Backend",
+                        value=self.config.get("anima.compile_backend", "inductor"),
+                        info="torch.compile backend for Per-block Torch Compile",
+                        interactive=True,
+                    )
+                    self.compile_mode = gr.Dropdown(
+                        label="Compile Mode",
+                        choices=[
+                            "default",
+                            "reduce-overhead",
+                            "max-autotune",
+                            "max-autotune-no-cudagraphs",
+                        ],
+                        value=self.config.get("anima.compile_mode", "default"),
+                        info="torch.compile mode for Per-block Torch Compile (default recommended for training)",
+                        interactive=True,
+                    )
+                    self.compile_dynamic = gr.Dropdown(
+                        label="Compile Dynamic Shapes",
+                        choices=["auto", "true", "false"],
+                        value=self.config.get("anima.compile_dynamic", "auto"),
+                        info="Dynamic shapes mode for Per-block Torch Compile. On Windows, 'true' requires the Visual Studio 2022 C++ compiler.",
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.compile_fullgraph = gr.Checkbox(
+                        label="Compile Fullgraph",
+                        value=self.config.get("anima.compile_fullgraph", False),
+                        info="Enable fullgraph mode for Per-block Torch Compile. Cannot be used with Split Attention.",
+                        interactive=True,
+                    )
+                    self.compile_cache_size_limit = gr.Number(
+                        label="Compile Cache Size Limit",
+                        value=self.config.get("anima.compile_cache_size_limit", 0),
+                        info="torch._dynamo.config.cache_size_limit for Per-block Torch Compile. 0 uses the PyTorch default; 32 is recommended for multi-resolution datasets.",
+                        minimum=0,
+                        maximum=1024,
+                        step=1,
+                        interactive=True,
+                    )
+
+                # `--compile` (per-block) and `--torch_compile` (accelerate dynamo) are
+                # mutually exclusive at the backend (see anima_train_network.py's own
+                # assertion); mirror that here so the GUI can't emit a rejected command.
+                self.compile.change(
+                    lambda enabled: gr.update(value=False) if enabled else gr.update(),
+                    inputs=[self.compile],
+                    outputs=[self.torch_compile],
+                )
+                self.torch_compile.change(
+                    lambda enabled: gr.update(value=False) if enabled else gr.update(),
+                    inputs=[self.torch_compile],
+                    outputs=[self.compile],
+                )
 
                 self.anima_checkbox.change(
                     lambda anima_checkbox: gr.Accordion(visible=anima_checkbox),

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -359,6 +359,14 @@ def save_configuration(
     anima_vae_chunk_size,
     anima_vae_disable_cache,
     anima_unsloth_offload_checkpointing,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
     anima_checkbox,
 ):
     # Get list of function parameters and values
@@ -683,6 +691,14 @@ def open_configuration(
     anima_vae_chunk_size,
     anima_vae_disable_cache,
     anima_unsloth_offload_checkpointing,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
     anima_checkbox,
     ##
     training_preset,
@@ -1118,6 +1134,14 @@ def train_model(
     anima_vae_chunk_size,
     anima_vae_disable_cache,
     anima_unsloth_offload_checkpointing,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
     anima_checkbox,
 ):
     # Get list of function parameters and values
@@ -1168,6 +1192,15 @@ def train_model(
     if LoRA_type == "Anima" and not anima_checkbox:
         log.error(
             "The Anima model checkbox must be checked when LoRA type is set to 'Anima'."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
+    # Backend mirrors this as a startup assertion (see anima_train_network.py);
+    # the GUI checkboxes already clear one another on change, but validate again
+    # here in case a saved/edited config re-enables both.
+    if anima_checkbox and anima_compile and anima_torch_compile:
+        log.error(
+            "Per-block Torch Compile and Legacy Torch Compile cannot both be enabled at the same time."
         )
         return TRAIN_BUTTON_VISIBLE
 
@@ -1980,12 +2013,12 @@ def train_model(
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
         "show_timesteps": (
             show_timesteps
-            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
             else None
         ),
         "show_timesteps_resolution": (
             show_timesteps_resolution
-            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
             else None
         ),
         # HunyuanImage-2.1 specific parameters
@@ -2068,6 +2101,31 @@ def train_model(
         "vae_disable_cache": anima_vae_disable_cache if anima_checkbox else None,
         "unsloth_offload_checkpointing": (
             anima_unsloth_offload_checkpointing if anima_checkbox else None
+        ),
+        "qwen_image_vae_2d": (anima_qwen_image_vae_2d if anima_checkbox else None),
+        # `--compile` (per-block) and `--torch_compile` (accelerate dynamo) are
+        # mutually exclusive at the backend; the GUI already prevents both
+        # checkboxes from being enabled together (see class_anima.py).
+        "compile": anima_compile if anima_checkbox else None,
+        "torch_compile": anima_torch_compile if anima_checkbox else None,
+        "compile_backend": (
+            anima_compile_backend if anima_checkbox and anima_compile else None
+        ),
+        "compile_mode": (
+            anima_compile_mode if anima_checkbox and anima_compile else None
+        ),
+        "compile_dynamic": (
+            anima_compile_dynamic
+            if anima_checkbox and anima_compile and anima_compile_dynamic != "auto"
+            else None
+        ),
+        "compile_fullgraph": (
+            anima_compile_fullgraph if anima_checkbox and anima_compile else None
+        ),
+        "compile_cache_size_limit": (
+            int(anima_compile_cache_size_limit)
+            if anima_checkbox and anima_compile and anima_compile_cache_size_limit
+            else None
         ),
     }
 
@@ -3415,6 +3473,14 @@ def lora_tab(
             anima_training.vae_chunk_size,
             anima_training.vae_disable_cache,
             anima_training.unsloth_offload_checkpointing,
+            anima_training.qwen_image_vae_2d,
+            anima_training.compile,
+            anima_training.torch_compile,
+            anima_training.compile_backend,
+            anima_training.compile_mode,
+            anima_training.compile_dynamic,
+            anima_training.compile_fullgraph,
+            anima_training.compile_cache_size_limit,
             source_model.anima_checkbox,
         ]
 

--- a/tests/test_anima_lora_gui.py
+++ b/tests/test_anima_lora_gui.py
@@ -1,7 +1,10 @@
 """Regression tests for GH issue #3487: Anima LoRA training support in the
-GUI.
+GUI, and GH issue #3524: Anima advanced options (torch.compile,
+Qwen-Image VAE 2D, timestep visualization).
 """
 
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -190,6 +193,109 @@ class TestAnimaLoraConfigOutput(unittest.TestCase):
             self.assertTrue(mocked.called)
             run_cmd = mocked.call_args[0][0]
             self.assertTrue(any("anima_train_network.py" in part for part in run_cmd))
+
+
+class TestAnimaAdvancedOptions(unittest.TestCase):
+    """GH issue #3524: --compile (per-block torch.compile), --qwen_image_vae_2d,
+    and shared timestep-visualization flags.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**ANIMA_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_qwen_image_vae_2d_omitted_by_default(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("qwen_image_vae_2d", config)
+
+    def test_qwen_image_vae_2d_forwarded_when_enabled(self):
+        config = self._run_and_load_toml({"anima_qwen_image_vae_2d": True})
+        self.assertTrue(config.get("qwen_image_vae_2d"))
+
+    def test_compile_omitted_by_default(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("compile", config)
+        self.assertNotIn("torch_compile", config)
+
+    def test_compile_forwarded_with_options(self):
+        config = self._run_and_load_toml(
+            {
+                "anima_compile": True,
+                "anima_compile_backend": "inductor",
+                "anima_compile_mode": "max-autotune",
+                "anima_compile_dynamic": "true",
+                "anima_compile_fullgraph": True,
+                "anima_compile_cache_size_limit": 32,
+            }
+        )
+        self.assertTrue(config.get("compile"))
+        self.assertEqual(config.get("compile_backend"), "inductor")
+        self.assertEqual(config.get("compile_mode"), "max-autotune")
+        self.assertEqual(config.get("compile_dynamic"), "true")
+        self.assertTrue(config.get("compile_fullgraph"))
+        self.assertEqual(config.get("compile_cache_size_limit"), 32)
+
+    def test_compile_options_omitted_when_compile_disabled(self):
+        """`--compile_*` sub-options are only meaningful once `--compile` is on."""
+        config = self._run_and_load_toml(
+            {
+                "anima_compile": False,
+                "anima_compile_mode": "max-autotune",
+                "anima_compile_fullgraph": True,
+            }
+        )
+        self.assertNotIn("compile_mode", config)
+        self.assertNotIn("compile_fullgraph", config)
+
+    def test_compile_dynamic_auto_is_omitted(self):
+        config = self._run_and_load_toml(
+            {"anima_compile": True, "anima_compile_dynamic": "auto"}
+        )
+        self.assertNotIn("compile_dynamic", config)
+
+    def test_torch_compile_forwarded_when_enabled(self):
+        config = self._run_and_load_toml({"anima_torch_compile": True})
+        self.assertTrue(config.get("torch_compile"))
+
+    def test_compile_and_torch_compile_together_blocks_training(self):
+        """Mirrors the backend's own startup assertion: --compile and
+        --torch_compile are mutually exclusive. The GUI checkboxes clear one
+        another on change, but a saved/edited config could still set both, so
+        train_model() must refuse to emit a command in that case.
+        """
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                **ANIMA_OVERRIDES,
+                "anima_compile": True,
+                "anima_torch_compile": True,
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            kwargs = dict(kwargs, output_dir=tmpdir, output_name="testout")
+            mock_executor(lora_gui)
+            lora_gui.train_model(**kwargs)
+            toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+            self.assertEqual(toml_files, [])
+
+    def test_show_timesteps_forwarded_for_anima(self):
+        """`--show_timesteps` is shared across model families (FLUX/SD3/Anima);
+        it must not be dropped just because the Anima checkbox is set.
+        """
+        config = self._run_and_load_toml(
+            {"show_timesteps": "console", "show_timesteps_resolution": "1024"}
+        )
+        self.assertEqual(config.get("show_timesteps"), "console")
+        self.assertEqual(config.get("show_timesteps_resolution"), "1024")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extends `kohya_gui/class_anima.py` (from #3541) with three v0.11.1-era Anima additions from sd-scripts:
  - Per-block `--compile` (torch.compile) with `--compile_backend`, `--compile_mode`, `--compile_dynamic`, `--compile_fullgraph`, `--compile_cache_size_limit` ([sd-scripts PR #2379](https://github.com/kohya-ss/sd-scripts/pull/2379)).
  - Legacy `--torch_compile` (accelerate dynamo) checkbox, mutually exclusive with `--compile` — enforced both client-side (checkboxes clear one another) and server-side (train_model validation), mirroring the backend's own startup assertion.
  - `--qwen_image_vae_2d` checkbox ([sd-scripts PR #2382](https://github.com/kohya-ss/sd-scripts/pull/2382)).
- Timestep sampling visualization (`--show_timesteps` / `--show_timesteps_resolution`) turned out to already be shared with FLUX/SD3 in `class_advanced_training.py` ([sd-scripts PR #2384](https://github.com/kohya-ss/sd-scripts/pull/2384)), so it's gated to include the Anima checkbox rather than duplicated, per the issue's own fallback note.
- No sd-scripts submodule changes.

## Test plan
- [x] `python -m pytest tests/` — 63 passed (20 in `tests/test_anima_lora_gui.py`, including new coverage for `--compile`/`--torch_compile` mutual exclusion, `--qwen_image_vae_2d`, and shared timestep-viz gating)
- [x] `black --check` on all touched files
- [x] Smoke-built the `animaTraining` Gradio component standalone to confirm new widgets are exposed

Closes #3524