### PR TITLE
Add FIELD_REGISTRY to lora_gui.py for positional-arg safety (#3543 M1)

### DIFF
--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -64,6 +64,12 @@ huggingface = None
 use_shell = False
 train_state_value = time.time()
 
+# Populated by lora_tab() with the (param_name, component) pairs backing
+# settings_list, in the same order as train_model's/save_configuration's/
+# open_configuration's shared keyword-argument order. Exposed at module level
+# so tests can assert it stays in sync without rebuilding the whole GUI.
+last_built_field_registry = None
+
 document_symbol = "\U0001f4c4"  # 📄
 
 
@@ -778,9 +784,9 @@ def open_configuration(
 
 def get_effective_lr_messages(
     main_lr_val: float,
-    text_encoder_lr_val: float, # Value from the 'Text Encoder learning rate' GUI field
-    unet_lr_val: float,       # Value from the 'Unet learning rate' GUI field
-    t5xxl_lr_val: float       # Value from the 'T5XXL learning rate' GUI field
+    text_encoder_lr_val: float,  # Value from the 'Text Encoder learning rate' GUI field
+    unet_lr_val: float,  # Value from the 'Unet learning rate' GUI field
+    t5xxl_lr_val: float,  # Value from the 'T5XXL learning rate' GUI field
 ) -> list[str]:
     messages = []
     # Format LRs to scientific notation with 2 decimal places for readability
@@ -799,27 +805,31 @@ def get_effective_lr_messages(
     if text_encoder_lr_val != 0.0:
         effective_clip_lr_str = f_te_lr
         clip_lr_source_msg = "(Specific Value)"
-    messages.append(f"  - Text Encoder (Primary/CLIP) Effective LR: {effective_clip_lr_str} {clip_lr_source_msg}")
+    messages.append(
+        f"  - Text Encoder (Primary/CLIP) Effective LR: {effective_clip_lr_str} {clip_lr_source_msg}"
+    )
 
     # --- Text Encoder (T5XXL, if applicable) LR ---
     # Logic based on how text_encoder_lr_list is formed in train_model for sd-scripts:
     # 1. If t5xxl_lr_val is non-zero, it's used for T5.
     # 2. Else, if text_encoder_lr_val (primary TE LR) is non-zero, it's used for T5.
     # 3. Else (both primary TE LR and specific T5XXL LR are zero), T5 uses main_lr_val.
-    effective_t5_lr_str = f_main_lr # Default fallback
+    effective_t5_lr_str = f_main_lr  # Default fallback
     t5_lr_source_msg = "(Fallback to Main LR)"
 
     if t5xxl_lr_val != 0.0:
         effective_t5_lr_str = f_t5_lr
         t5_lr_source_msg = "(Specific T5XXL Value)"
-    elif text_encoder_lr_val != 0.0: # No specific T5 LR, but main TE LR is set
-        effective_t5_lr_str = f_te_lr # T5 inherits from the primary TE LR setting
+    elif text_encoder_lr_val != 0.0:  # No specific T5 LR, but main TE LR is set
+        effective_t5_lr_str = f_te_lr  # T5 inherits from the primary TE LR setting
         t5_lr_source_msg = "(Inherited from Primary TE LR)"
     # If both t5xxl_lr_val and text_encoder_lr_val are 0.0, effective_t5_lr_str remains f_main_lr.
 
     # The message for T5XXL LR is always added for completeness, indicating its potential value.
     # Users should understand it's relevant only if their model architecture uses a T5XXL text encoder.
-    messages.append(f"  - Text Encoder (T5XXL, if applicable) Effective LR: {effective_t5_lr_str} {t5_lr_source_msg}")
+    messages.append(
+        f"  - Text Encoder (T5XXL, if applicable) Effective LR: {effective_t5_lr_str} {t5_lr_source_msg}"
+    )
 
     # --- U-Net LR ---
     # If unet_lr_val (from GUI) is non-zero, it's used. Otherwise, main_lr_val is the fallback.
@@ -828,9 +838,13 @@ def get_effective_lr_messages(
     if unet_lr_val != 0.0:
         effective_unet_lr_str = f_unet_lr
         unet_lr_source_msg = "(Specific Value)"
-    messages.append(f"  - U-Net Effective LR: {effective_unet_lr_str} {unet_lr_source_msg}")
+    messages.append(
+        f"  - U-Net Effective LR: {effective_unet_lr_str} {unet_lr_source_msg}"
+    )
 
-    messages.append("Note: These LRs reflect the GUI's direct settings. Advanced options in sd-scripts (e.g., block LRs, LoRA+) can further modify rates for specific layers.")
+    messages.append(
+        "Note: These LRs reflect the GUI's direct settings. Advanced options in sd-scripts (e.g., block LRs, LoRA+) can further modify rates for specific layers."
+    )
     return messages
 
 
@@ -1711,24 +1725,23 @@ def train_model(
 
     # Log effective learning rate messages
     lr_messages = get_effective_lr_messages(
-        learning_rate_float,
-        text_encoder_lr_float,
-        unet_lr_float,
-        t5xxl_lr_float
+        learning_rate_float, text_encoder_lr_float, unet_lr_float, t5xxl_lr_float
     )
     for message in lr_messages:
         log.info(message)
 
     # Determine the training configuration based on learning rate values
     # Sets flags for training specific components based on the provided learning rates.
-    if learning_rate_float == 0.0 and text_encoder_lr_float == 0.0 and unet_lr_float == 0.0:
+    if (
+        learning_rate_float == 0.0
+        and text_encoder_lr_float == 0.0
+        and unet_lr_float == 0.0
+    ):
         output_message(msg="Please input learning rate values.", headless=headless)
         return TRAIN_BUTTON_VISIBLE
     # Flag to train text encoder only if its learning rate is non-zero and unet's is zero.
     network_train_text_encoder_only = (
-        text_encoder_lr_float != 0
-        and unet_lr_float == 0
-        and not hunyuan_image_checkbox
+        text_encoder_lr_float != 0 and unet_lr_float == 0 and not hunyuan_image_checkbox
     )
     # Flag to train unet only if its learning rate is non-zero and text encoder's is zero.
     network_train_unet_only = (
@@ -2599,7 +2612,7 @@ def lora_tab(
                         inputs=[train_lora_ggpo],
                         outputs=[ggpo_row],
                     )
-                
+
                 # Update the visibility of the train lora ggpo row based on the model type being Flux.1
                 source_model.flux1_checkbox.change(
                     lambda flux1_checkbox: gr.Row(visible=flux1_checkbox),
@@ -3154,7 +3167,7 @@ def lora_tab(
                 "HuggingFace", open=False, elem_classes="huggingface_background"
             ):
                 huggingface = HuggingFace(config=config)
-            
+
             LoRA_type.change(
                 update_LoRA_settings,
                 inputs=[
@@ -3204,285 +3217,348 @@ def lora_tab(
         # Setup gradio tensorboard buttons
         TensorboardManager(headless=headless, logging_dir=folders.logging_dir)
 
-        settings_list = [
-            source_model.pretrained_model_name_or_path,
-            source_model.v2,
-            source_model.v_parameterization,
-            source_model.sdxl_checkbox,
-            source_model.flux1_checkbox,
-            source_model.dataset_config,
-            source_model.save_model_as,
-            source_model.save_precision,
-            source_model.train_data_dir,
-            source_model.output_name,
-            source_model.model_list,
-            source_model.training_comment,
-            folders.logging_dir,
-            folders.reg_data_dir,
-            folders.output_dir,
-            basic_training.max_resolution,
-            basic_training.learning_rate,
-            basic_training.lr_scheduler,
-            basic_training.lr_warmup,
-            basic_training.lr_warmup_steps,
-            basic_training.train_batch_size,
-            basic_training.epoch,
-            basic_training.save_every_n_epochs,
-            basic_training.seed,
-            basic_training.cache_latents,
-            basic_training.cache_latents_to_disk,
-            train_inpainting,
-            basic_training.caption_extension,
-            basic_training.enable_bucket,
-            basic_training.stop_text_encoder_training,
-            basic_training.min_bucket_reso,
-            basic_training.max_bucket_reso,
-            basic_training.max_train_epochs,
-            basic_training.max_train_steps,
-            basic_training.lr_scheduler_num_cycles,
-            basic_training.lr_scheduler_power,
-            basic_training.optimizer,
-            basic_training.optimizer_args,
-            basic_training.lr_scheduler_args,
-            basic_training.lr_scheduler_type,
-            basic_training.max_grad_norm,
-            accelerate_launch.mixed_precision,
-            accelerate_launch.num_cpu_threads_per_process,
-            accelerate_launch.num_processes,
-            accelerate_launch.num_machines,
-            accelerate_launch.multi_gpu,
-            accelerate_launch.gpu_ids,
-            accelerate_launch.main_process_port,
-            accelerate_launch.dynamo_backend,
-            accelerate_launch.dynamo_mode,
-            accelerate_launch.dynamo_use_fullgraph,
-            accelerate_launch.dynamo_use_dynamic,
-            accelerate_launch.extra_accelerate_launch_args,
-            advanced_training.gradient_checkpointing,
-            advanced_training.fp8_base,
-            advanced_training.fp8_base_unet,
-            advanced_training.full_fp16,
-            advanced_training.highvram,
-            advanced_training.lowvram,
-            advanced_training.xformers,
-            advanced_training.shuffle_caption,
-            advanced_training.save_state,
-            advanced_training.save_state_on_train_end,
-            advanced_training.resume,
-            advanced_training.prior_loss_weight,
-            advanced_training.color_aug,
-            advanced_training.flip_aug,
-            advanced_training.masked_loss,
-            advanced_training.clip_skip,
-            advanced_training.gradient_accumulation_steps,
-            advanced_training.mem_eff_attn,
-            advanced_training.max_token_length,
-            advanced_training.max_data_loader_n_workers,
-            advanced_training.keep_tokens,
-            advanced_training.persistent_data_loader_workers,
-            advanced_training.bucket_no_upscale,
-            advanced_training.random_crop,
-            advanced_training.bucket_reso_steps,
-            advanced_training.v_pred_like_loss,
-            advanced_training.caption_dropout_every_n_epochs,
-            advanced_training.caption_dropout_rate,
-            advanced_training.noise_offset_type,
-            advanced_training.noise_offset,
-            advanced_training.noise_offset_random_strength,
-            advanced_training.adaptive_noise_scale,
-            advanced_training.multires_noise_iterations,
-            advanced_training.multires_noise_discount,
-            advanced_training.ip_noise_gamma,
-            advanced_training.ip_noise_gamma_random_strength,
-            advanced_training.additional_parameters,
-            advanced_training.loss_type,
-            advanced_training.huber_schedule,
-            advanced_training.huber_c,
-            advanced_training.huber_scale,
-            advanced_training.vae_batch_size,
-            advanced_training.min_snr_gamma,
-            advanced_training.save_every_n_steps,
-            advanced_training.save_last_n_steps,
-            advanced_training.save_last_n_steps_state,
-            advanced_training.save_last_n_epochs,
-            advanced_training.save_last_n_epochs_state,
-            advanced_training.skip_cache_check,
-            advanced_training.log_with,
-            advanced_training.wandb_api_key,
-            advanced_training.wandb_run_name,
-            advanced_training.log_tracker_name,
-            advanced_training.log_tracker_config,
-            advanced_training.log_config,
-            advanced_training.scale_v_pred_loss_like_noise_pred,
-            advanced_training.full_bf16,
-            advanced_training.min_timestep,
-            advanced_training.max_timestep,
-            advanced_training.vae,
-            advanced_training.weighted_captions,
-            advanced_training.debiased_estimation_loss,
-            sdxl_params.sdxl_cache_text_encoder_outputs,
-            sdxl_params.sdxl_no_half_vae,
-            text_encoder_lr,
-            t5xxl_lr,
-            unet_lr,
-            network_dim,
-            network_weights,
-            dim_from_weights,
-            network_alpha,
-            LoRA_type,
-            factor,
-            bypass_mode,
-            dora_wd,
-            use_cp,
-            use_tucker,
-            use_scalar,
-            rank_dropout_scale,
-            constrain,
-            rescaled,
-            train_norm,
-            decompose_both,
-            train_on_input,
-            conv_dim,
-            conv_alpha,
-            sample.sample_every_n_steps,
-            sample.sample_every_n_epochs,
-            sample.sample_sampler,
-            sample.sample_prompts,
-            down_lr_weight,
-            mid_lr_weight,
-            up_lr_weight,
-            block_lr_zero_threshold,
-            block_dims,
-            block_alphas,
-            conv_block_dims,
-            conv_block_alphas,
-            unit,
-            scale_weight_norms,
-            network_dropout,
-            rank_dropout,
-            module_dropout,
-            LyCORIS_preset,
-            loraplus_lr_ratio,
-            loraplus_text_encoder_lr_ratio,
-            loraplus_unet_lr_ratio,
-            train_lora_ggpo,
-            ggpo_sigma,
-            ggpo_beta,
-            huggingface.huggingface_repo_id,
-            huggingface.huggingface_token,
-            huggingface.huggingface_repo_type,
-            huggingface.huggingface_repo_visibility,
-            huggingface.huggingface_path_in_repo,
-            huggingface.save_state_to_huggingface,
-            huggingface.resume_from_huggingface,
-            huggingface.async_upload,
-            metadata.metadata_author,
-            metadata.metadata_description,
-            metadata.metadata_license,
-            metadata.metadata_tags,
-            metadata.metadata_title,
-            # Flux1 parameters
-            flux1_training.flux1_cache_text_encoder_outputs,
-            flux1_training.flux1_cache_text_encoder_outputs_to_disk,
-            flux1_training.ae,
-            flux1_training.clip_l,
-            flux1_training.t5xxl,
-            flux1_training.discrete_flow_shift,
-            flux1_training.model_prediction_type,
-            flux1_training.timestep_sampling,
-            flux1_training.split_mode,
-            flux1_training.train_blocks,
-            flux1_training.t5xxl_max_token_length,
-            flux1_training.enable_all_linear,
-            flux1_training.guidance_scale,
-            flux1_training.mem_eff_save,
-            flux1_training.apply_t5_attn_mask,
-            flux1_training.split_qkv,
-            flux1_training.train_t5xxl,
-            flux1_training.cpu_offload_checkpointing,
-            advanced_training.blocks_to_swap,
-            flux1_training.single_blocks_to_swap,
-            flux1_training.double_blocks_to_swap,
-            advanced_training.show_timesteps,
-            advanced_training.show_timesteps_resolution,
-            flux1_training.img_attn_dim,
-            flux1_training.img_mlp_dim,
-            flux1_training.img_mod_dim,
-            flux1_training.single_dim,
-            flux1_training.txt_attn_dim,
-            flux1_training.txt_mlp_dim,
-            flux1_training.txt_mod_dim,
-            flux1_training.single_mod_dim,
-            flux1_training.in_dims,
-            flux1_training.train_double_block_indices,
-            flux1_training.train_single_block_indices,
-            # SD3 Parameters
-            sd3_training.sd3_cache_text_encoder_outputs,
-            sd3_training.sd3_cache_text_encoder_outputs_to_disk,
-            sd3_training.sd3_fused_backward_pass,
-            sd3_training.clip_g,
-            sd3_training.clip_g_dropout_rate,
-            sd3_training.clip_l,
-            sd3_training.clip_l_dropout_rate,
-            sd3_training.disable_mmap_load_safetensors,
-            sd3_training.enable_scaled_pos_embed,
-            sd3_training.logit_mean,
-            sd3_training.logit_std,
-            sd3_training.mode_scale,
-            sd3_training.pos_emb_random_crop_rate,
-            sd3_training.save_clip,
-            sd3_training.save_t5xxl,
-            sd3_training.t5_dropout_rate,
-            sd3_training.t5xxl,
-            sd3_training.t5xxl_device,
-            sd3_training.t5xxl_dtype,
-            sd3_training.sd3_text_encoder_batch_size,
-            sd3_training.weighting_scheme,
-            source_model.sd3_checkbox,
-            # HunyuanImage-2.1 parameters
-            hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs,
-            hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs_to_disk,
-            hunyuan_image_training.text_encoder,
-            hunyuan_image_training.byt5,
-            hunyuan_image_training.vae,
-            hunyuan_image_training.discrete_flow_shift,
-            hunyuan_image_training.model_prediction_type,
-            hunyuan_image_training.timestep_sampling,
-            hunyuan_image_training.sigmoid_scale,
-            hunyuan_image_training.attn_mode,
-            hunyuan_image_training.split_attn,
-            hunyuan_image_training.fp8_scaled,
-            hunyuan_image_training.fp8_vl,
-            hunyuan_image_training.text_encoder_cpu,
-            hunyuan_image_training.vae_chunk_size,
-            source_model.hunyuan_image_checkbox,
-            # Anima parameters
-            anima_training.cache_text_encoder_outputs,
-            anima_training.cache_text_encoder_outputs_to_disk,
-            anima_training.qwen3,
-            anima_training.vae,
-            anima_training.llm_adapter_path,
-            anima_training.t5_tokenizer_path,
-            anima_training.discrete_flow_shift,
-            anima_training.timestep_sampling,
-            anima_training.sigmoid_scale,
-            anima_training.qwen3_max_token_length,
-            anima_training.t5_max_token_length,
-            anima_training.attn_mode,
-            anima_training.split_attn,
-            anima_training.vae_chunk_size,
-            anima_training.vae_disable_cache,
-            anima_training.unsloth_offload_checkpointing,
-            anima_training.qwen_image_vae_2d,
-            anima_training.compile,
-            anima_training.torch_compile,
-            anima_training.compile_backend,
-            anima_training.compile_mode,
-            anima_training.compile_dynamic,
-            anima_training.compile_fullgraph,
-            anima_training.compile_cache_size_limit,
-            source_model.anima_checkbox,
+        FIELD_REGISTRY = [
+            (
+                "pretrained_model_name_or_path",
+                source_model.pretrained_model_name_or_path,
+            ),
+            ("v2", source_model.v2),
+            ("v_parameterization", source_model.v_parameterization),
+            ("sdxl", source_model.sdxl_checkbox),
+            ("flux1_checkbox", source_model.flux1_checkbox),
+            ("dataset_config", source_model.dataset_config),
+            ("save_model_as", source_model.save_model_as),
+            ("save_precision", source_model.save_precision),
+            ("train_data_dir", source_model.train_data_dir),
+            ("output_name", source_model.output_name),
+            ("model_list", source_model.model_list),
+            ("training_comment", source_model.training_comment),
+            ("logging_dir", folders.logging_dir),
+            ("reg_data_dir", folders.reg_data_dir),
+            ("output_dir", folders.output_dir),
+            ("max_resolution", basic_training.max_resolution),
+            ("learning_rate", basic_training.learning_rate),
+            ("lr_scheduler", basic_training.lr_scheduler),
+            ("lr_warmup", basic_training.lr_warmup),
+            ("lr_warmup_steps", basic_training.lr_warmup_steps),
+            ("train_batch_size", basic_training.train_batch_size),
+            ("epoch", basic_training.epoch),
+            ("save_every_n_epochs", basic_training.save_every_n_epochs),
+            ("seed", basic_training.seed),
+            ("cache_latents", basic_training.cache_latents),
+            ("cache_latents_to_disk", basic_training.cache_latents_to_disk),
+            ("train_inpainting", train_inpainting),
+            ("caption_extension", basic_training.caption_extension),
+            ("enable_bucket", basic_training.enable_bucket),
+            ("stop_text_encoder_training", basic_training.stop_text_encoder_training),
+            ("min_bucket_reso", basic_training.min_bucket_reso),
+            ("max_bucket_reso", basic_training.max_bucket_reso),
+            ("max_train_epochs", basic_training.max_train_epochs),
+            ("max_train_steps", basic_training.max_train_steps),
+            ("lr_scheduler_num_cycles", basic_training.lr_scheduler_num_cycles),
+            ("lr_scheduler_power", basic_training.lr_scheduler_power),
+            ("optimizer", basic_training.optimizer),
+            ("optimizer_args", basic_training.optimizer_args),
+            ("lr_scheduler_args", basic_training.lr_scheduler_args),
+            ("lr_scheduler_type", basic_training.lr_scheduler_type),
+            ("max_grad_norm", basic_training.max_grad_norm),
+            ("mixed_precision", accelerate_launch.mixed_precision),
+            (
+                "num_cpu_threads_per_process",
+                accelerate_launch.num_cpu_threads_per_process,
+            ),
+            ("num_processes", accelerate_launch.num_processes),
+            ("num_machines", accelerate_launch.num_machines),
+            ("multi_gpu", accelerate_launch.multi_gpu),
+            ("gpu_ids", accelerate_launch.gpu_ids),
+            ("main_process_port", accelerate_launch.main_process_port),
+            ("dynamo_backend", accelerate_launch.dynamo_backend),
+            ("dynamo_mode", accelerate_launch.dynamo_mode),
+            ("dynamo_use_fullgraph", accelerate_launch.dynamo_use_fullgraph),
+            ("dynamo_use_dynamic", accelerate_launch.dynamo_use_dynamic),
+            (
+                "extra_accelerate_launch_args",
+                accelerate_launch.extra_accelerate_launch_args,
+            ),
+            ("gradient_checkpointing", advanced_training.gradient_checkpointing),
+            ("fp8_base", advanced_training.fp8_base),
+            ("fp8_base_unet", advanced_training.fp8_base_unet),
+            ("full_fp16", advanced_training.full_fp16),
+            ("highvram", advanced_training.highvram),
+            ("lowvram", advanced_training.lowvram),
+            ("xformers", advanced_training.xformers),
+            ("shuffle_caption", advanced_training.shuffle_caption),
+            ("save_state", advanced_training.save_state),
+            ("save_state_on_train_end", advanced_training.save_state_on_train_end),
+            ("resume", advanced_training.resume),
+            ("prior_loss_weight", advanced_training.prior_loss_weight),
+            ("color_aug", advanced_training.color_aug),
+            ("flip_aug", advanced_training.flip_aug),
+            ("masked_loss", advanced_training.masked_loss),
+            ("clip_skip", advanced_training.clip_skip),
+            (
+                "gradient_accumulation_steps",
+                advanced_training.gradient_accumulation_steps,
+            ),
+            ("mem_eff_attn", advanced_training.mem_eff_attn),
+            ("max_token_length", advanced_training.max_token_length),
+            ("max_data_loader_n_workers", advanced_training.max_data_loader_n_workers),
+            ("keep_tokens", advanced_training.keep_tokens),
+            (
+                "persistent_data_loader_workers",
+                advanced_training.persistent_data_loader_workers,
+            ),
+            ("bucket_no_upscale", advanced_training.bucket_no_upscale),
+            ("random_crop", advanced_training.random_crop),
+            ("bucket_reso_steps", advanced_training.bucket_reso_steps),
+            ("v_pred_like_loss", advanced_training.v_pred_like_loss),
+            (
+                "caption_dropout_every_n_epochs",
+                advanced_training.caption_dropout_every_n_epochs,
+            ),
+            ("caption_dropout_rate", advanced_training.caption_dropout_rate),
+            ("noise_offset_type", advanced_training.noise_offset_type),
+            ("noise_offset", advanced_training.noise_offset),
+            (
+                "noise_offset_random_strength",
+                advanced_training.noise_offset_random_strength,
+            ),
+            ("adaptive_noise_scale", advanced_training.adaptive_noise_scale),
+            ("multires_noise_iterations", advanced_training.multires_noise_iterations),
+            ("multires_noise_discount", advanced_training.multires_noise_discount),
+            ("ip_noise_gamma", advanced_training.ip_noise_gamma),
+            (
+                "ip_noise_gamma_random_strength",
+                advanced_training.ip_noise_gamma_random_strength,
+            ),
+            ("additional_parameters", advanced_training.additional_parameters),
+            ("loss_type", advanced_training.loss_type),
+            ("huber_schedule", advanced_training.huber_schedule),
+            ("huber_c", advanced_training.huber_c),
+            ("huber_scale", advanced_training.huber_scale),
+            ("vae_batch_size", advanced_training.vae_batch_size),
+            ("min_snr_gamma", advanced_training.min_snr_gamma),
+            ("save_every_n_steps", advanced_training.save_every_n_steps),
+            ("save_last_n_steps", advanced_training.save_last_n_steps),
+            ("save_last_n_steps_state", advanced_training.save_last_n_steps_state),
+            ("save_last_n_epochs", advanced_training.save_last_n_epochs),
+            ("save_last_n_epochs_state", advanced_training.save_last_n_epochs_state),
+            ("skip_cache_check", advanced_training.skip_cache_check),
+            ("log_with", advanced_training.log_with),
+            ("wandb_api_key", advanced_training.wandb_api_key),
+            ("wandb_run_name", advanced_training.wandb_run_name),
+            ("log_tracker_name", advanced_training.log_tracker_name),
+            ("log_tracker_config", advanced_training.log_tracker_config),
+            ("log_config", advanced_training.log_config),
+            (
+                "scale_v_pred_loss_like_noise_pred",
+                advanced_training.scale_v_pred_loss_like_noise_pred,
+            ),
+            ("full_bf16", advanced_training.full_bf16),
+            ("min_timestep", advanced_training.min_timestep),
+            ("max_timestep", advanced_training.max_timestep),
+            ("vae", advanced_training.vae),
+            ("weighted_captions", advanced_training.weighted_captions),
+            ("debiased_estimation_loss", advanced_training.debiased_estimation_loss),
+            (
+                "sdxl_cache_text_encoder_outputs",
+                sdxl_params.sdxl_cache_text_encoder_outputs,
+            ),
+            ("sdxl_no_half_vae", sdxl_params.sdxl_no_half_vae),
+            ("text_encoder_lr", text_encoder_lr),
+            ("t5xxl_lr", t5xxl_lr),
+            ("unet_lr", unet_lr),
+            ("network_dim", network_dim),
+            ("network_weights", network_weights),
+            ("dim_from_weights", dim_from_weights),
+            ("network_alpha", network_alpha),
+            ("LoRA_type", LoRA_type),
+            ("factor", factor),
+            ("bypass_mode", bypass_mode),
+            ("dora_wd", dora_wd),
+            ("use_cp", use_cp),
+            ("use_tucker", use_tucker),
+            ("use_scalar", use_scalar),
+            ("rank_dropout_scale", rank_dropout_scale),
+            ("constrain", constrain),
+            ("rescaled", rescaled),
+            ("train_norm", train_norm),
+            ("decompose_both", decompose_both),
+            ("train_on_input", train_on_input),
+            ("conv_dim", conv_dim),
+            ("conv_alpha", conv_alpha),
+            ("sample_every_n_steps", sample.sample_every_n_steps),
+            ("sample_every_n_epochs", sample.sample_every_n_epochs),
+            ("sample_sampler", sample.sample_sampler),
+            ("sample_prompts", sample.sample_prompts),
+            ("down_lr_weight", down_lr_weight),
+            ("mid_lr_weight", mid_lr_weight),
+            ("up_lr_weight", up_lr_weight),
+            ("block_lr_zero_threshold", block_lr_zero_threshold),
+            ("block_dims", block_dims),
+            ("block_alphas", block_alphas),
+            ("conv_block_dims", conv_block_dims),
+            ("conv_block_alphas", conv_block_alphas),
+            ("unit", unit),
+            ("scale_weight_norms", scale_weight_norms),
+            ("network_dropout", network_dropout),
+            ("rank_dropout", rank_dropout),
+            ("module_dropout", module_dropout),
+            ("LyCORIS_preset", LyCORIS_preset),
+            ("loraplus_lr_ratio", loraplus_lr_ratio),
+            ("loraplus_text_encoder_lr_ratio", loraplus_text_encoder_lr_ratio),
+            ("loraplus_unet_lr_ratio", loraplus_unet_lr_ratio),
+            ("train_lora_ggpo", train_lora_ggpo),
+            ("ggpo_sigma", ggpo_sigma),
+            ("ggpo_beta", ggpo_beta),
+            ("huggingface_repo_id", huggingface.huggingface_repo_id),
+            ("huggingface_token", huggingface.huggingface_token),
+            ("huggingface_repo_type", huggingface.huggingface_repo_type),
+            ("huggingface_repo_visibility", huggingface.huggingface_repo_visibility),
+            ("huggingface_path_in_repo", huggingface.huggingface_path_in_repo),
+            ("save_state_to_huggingface", huggingface.save_state_to_huggingface),
+            ("resume_from_huggingface", huggingface.resume_from_huggingface),
+            ("async_upload", huggingface.async_upload),
+            ("metadata_author", metadata.metadata_author),
+            ("metadata_description", metadata.metadata_description),
+            ("metadata_license", metadata.metadata_license),
+            ("metadata_tags", metadata.metadata_tags),
+            ("metadata_title", metadata.metadata_title),
+            (
+                "flux1_cache_text_encoder_outputs",
+                flux1_training.flux1_cache_text_encoder_outputs,
+            ),
+            (
+                "flux1_cache_text_encoder_outputs_to_disk",
+                flux1_training.flux1_cache_text_encoder_outputs_to_disk,
+            ),
+            ("ae", flux1_training.ae),
+            ("clip_l", flux1_training.clip_l),
+            ("t5xxl", flux1_training.t5xxl),
+            ("discrete_flow_shift", flux1_training.discrete_flow_shift),
+            ("model_prediction_type", flux1_training.model_prediction_type),
+            ("timestep_sampling", flux1_training.timestep_sampling),
+            ("split_mode", flux1_training.split_mode),
+            ("train_blocks", flux1_training.train_blocks),
+            ("t5xxl_max_token_length", flux1_training.t5xxl_max_token_length),
+            ("enable_all_linear", flux1_training.enable_all_linear),
+            ("guidance_scale", flux1_training.guidance_scale),
+            ("mem_eff_save", flux1_training.mem_eff_save),
+            ("apply_t5_attn_mask", flux1_training.apply_t5_attn_mask),
+            ("split_qkv", flux1_training.split_qkv),
+            ("train_t5xxl", flux1_training.train_t5xxl),
+            ("cpu_offload_checkpointing", flux1_training.cpu_offload_checkpointing),
+            ("blocks_to_swap", advanced_training.blocks_to_swap),
+            ("single_blocks_to_swap", flux1_training.single_blocks_to_swap),
+            ("double_blocks_to_swap", flux1_training.double_blocks_to_swap),
+            ("show_timesteps", advanced_training.show_timesteps),
+            ("show_timesteps_resolution", advanced_training.show_timesteps_resolution),
+            ("img_attn_dim", flux1_training.img_attn_dim),
+            ("img_mlp_dim", flux1_training.img_mlp_dim),
+            ("img_mod_dim", flux1_training.img_mod_dim),
+            ("single_dim", flux1_training.single_dim),
+            ("txt_attn_dim", flux1_training.txt_attn_dim),
+            ("txt_mlp_dim", flux1_training.txt_mlp_dim),
+            ("txt_mod_dim", flux1_training.txt_mod_dim),
+            ("single_mod_dim", flux1_training.single_mod_dim),
+            ("in_dims", flux1_training.in_dims),
+            ("train_double_block_indices", flux1_training.train_double_block_indices),
+            ("train_single_block_indices", flux1_training.train_single_block_indices),
+            (
+                "sd3_cache_text_encoder_outputs",
+                sd3_training.sd3_cache_text_encoder_outputs,
+            ),
+            (
+                "sd3_cache_text_encoder_outputs_to_disk",
+                sd3_training.sd3_cache_text_encoder_outputs_to_disk,
+            ),
+            ("sd3_fused_backward_pass", sd3_training.sd3_fused_backward_pass),
+            ("clip_g", sd3_training.clip_g),
+            ("clip_g_dropout_rate", sd3_training.clip_g_dropout_rate),
+            ("sd3_clip_l", sd3_training.clip_l),
+            ("sd3_clip_l_dropout_rate", sd3_training.clip_l_dropout_rate),
+            (
+                "sd3_disable_mmap_load_safetensors",
+                sd3_training.disable_mmap_load_safetensors,
+            ),
+            ("sd3_enable_scaled_pos_embed", sd3_training.enable_scaled_pos_embed),
+            ("logit_mean", sd3_training.logit_mean),
+            ("logit_std", sd3_training.logit_std),
+            ("mode_scale", sd3_training.mode_scale),
+            ("pos_emb_random_crop_rate", sd3_training.pos_emb_random_crop_rate),
+            ("save_clip", sd3_training.save_clip),
+            ("save_t5xxl", sd3_training.save_t5xxl),
+            ("sd3_t5_dropout_rate", sd3_training.t5_dropout_rate),
+            ("sd3_t5xxl", sd3_training.t5xxl),
+            ("t5xxl_device", sd3_training.t5xxl_device),
+            ("t5xxl_dtype", sd3_training.t5xxl_dtype),
+            ("sd3_text_encoder_batch_size", sd3_training.sd3_text_encoder_batch_size),
+            ("weighting_scheme", sd3_training.weighting_scheme),
+            ("sd3_checkbox", source_model.sd3_checkbox),
+            (
+                "hunyuan_image_cache_text_encoder_outputs",
+                hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs,
+            ),
+            (
+                "hunyuan_image_cache_text_encoder_outputs_to_disk",
+                hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs_to_disk,
+            ),
+            ("hunyuan_text_encoder", hunyuan_image_training.text_encoder),
+            ("hunyuan_byt5", hunyuan_image_training.byt5),
+            ("hunyuan_vae", hunyuan_image_training.vae),
+            ("hunyuan_discrete_flow_shift", hunyuan_image_training.discrete_flow_shift),
+            (
+                "hunyuan_model_prediction_type",
+                hunyuan_image_training.model_prediction_type,
+            ),
+            ("hunyuan_timestep_sampling", hunyuan_image_training.timestep_sampling),
+            ("hunyuan_sigmoid_scale", hunyuan_image_training.sigmoid_scale),
+            ("hunyuan_attn_mode", hunyuan_image_training.attn_mode),
+            ("hunyuan_split_attn", hunyuan_image_training.split_attn),
+            ("hunyuan_fp8_scaled", hunyuan_image_training.fp8_scaled),
+            ("hunyuan_fp8_vl", hunyuan_image_training.fp8_vl),
+            ("hunyuan_text_encoder_cpu", hunyuan_image_training.text_encoder_cpu),
+            ("hunyuan_vae_chunk_size", hunyuan_image_training.vae_chunk_size),
+            ("hunyuan_image_checkbox", source_model.hunyuan_image_checkbox),
+            (
+                "anima_cache_text_encoder_outputs",
+                anima_training.cache_text_encoder_outputs,
+            ),
+            (
+                "anima_cache_text_encoder_outputs_to_disk",
+                anima_training.cache_text_encoder_outputs_to_disk,
+            ),
+            ("anima_qwen3", anima_training.qwen3),
+            ("anima_vae", anima_training.vae),
+            ("anima_llm_adapter_path", anima_training.llm_adapter_path),
+            ("anima_t5_tokenizer_path", anima_training.t5_tokenizer_path),
+            ("anima_discrete_flow_shift", anima_training.discrete_flow_shift),
+            ("anima_timestep_sampling", anima_training.timestep_sampling),
+            ("anima_sigmoid_scale", anima_training.sigmoid_scale),
+            ("anima_qwen3_max_token_length", anima_training.qwen3_max_token_length),
+            ("anima_t5_max_token_length", anima_training.t5_max_token_length),
+            ("anima_attn_mode", anima_training.attn_mode),
+            ("anima_split_attn", anima_training.split_attn),
+            ("anima_vae_chunk_size", anima_training.vae_chunk_size),
+            ("anima_vae_disable_cache", anima_training.vae_disable_cache),
+            (
+                "anima_unsloth_offload_checkpointing",
+                anima_training.unsloth_offload_checkpointing,
+            ),
+            ("anima_qwen_image_vae_2d", anima_training.qwen_image_vae_2d),
+            ("anima_compile", anima_training.compile),
+            ("anima_torch_compile", anima_training.torch_compile),
+            ("anima_compile_backend", anima_training.compile_backend),
+            ("anima_compile_mode", anima_training.compile_mode),
+            ("anima_compile_dynamic", anima_training.compile_dynamic),
+            ("anima_compile_fullgraph", anima_training.compile_fullgraph),
+            ("anima_compile_cache_size_limit", anima_training.compile_cache_size_limit),
+            ("anima_checkbox", source_model.anima_checkbox),
         ]
+        settings_list = [comp for _, comp in FIELD_REGISTRY]
+
+        global last_built_field_registry
+        last_built_field_registry = FIELD_REGISTRY
 
         configuration.button_open_config.click(
             open_configuration,

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -1,10 +1,19 @@
 """Regression tests for GH issue #3520: kohya_gui emitting args that
 sd-scripts v0.11.1 silently ignores (LoRA+ ratios, stale `lowvram`).
+
+Also covers GH issue #3543 Milestone 1: `FIELD_REGISTRY` must stay in
+identical relative order with train_model's/save_configuration's/
+open_configuration's shared keyword-argument order (see
+TestLoraGuiFieldRegistry below).
 """
 
+import inspect
 import unittest
 
+import gradio as gr
+
 from kohya_gui import lora_gui
+from kohya_gui.class_gui_config import KohyaSSGUIConfig
 from conftest import (
     build_train_model_kwargs,
     run_train_model_and_load_saved_json,
@@ -204,6 +213,54 @@ class TestLoraTrainInpainting(unittest.TestCase):
         self.assertTrue(config.get("train_inpainting"))
         self.assertFalse(config.get("cache_latents"))
         self.assertFalse(config.get("cache_latents_to_disk"))
+
+
+class TestLoraGuiFieldRegistry(unittest.TestCase):
+    """GH issue #3543 Milestone 1: `FIELD_REGISTRY` (the source `settings_list`
+    is now derived from) must declare its field names in the exact same
+    relative order as train_model's/save_configuration's/open_configuration's
+    shared keyword-argument order, since a positional-order mismatch there
+    silently shifts every subsequent value into the wrong parameter.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with gr.Blocks():
+            lora_gui.lora_tab(headless=True, config=KohyaSSGUIConfig())
+        cls.field_registry = lora_gui.last_built_field_registry
+
+    def test_field_registry_was_built(self):
+        self.assertIsNotNone(self.field_registry)
+        self.assertGreater(len(self.field_registry), 0)
+
+    def test_field_registry_names_are_unique(self):
+        names = [name for name, _ in self.field_registry]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_field_registry_matches_train_model_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        train_model_params = list(inspect.signature(lora_gui.train_model).parameters)
+        # train_model's first two params (headless, print_only) are supplied
+        # separately by the .click() wiring, not via settings_list.
+        self.assertEqual(registry_names, train_model_params[2:])
+
+    def test_field_registry_matches_save_configuration_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        save_config_params = list(
+            inspect.signature(lora_gui.save_configuration).parameters
+        )
+        # save_configuration's first two params (save_as_bool, file_path) are
+        # supplied separately, not via settings_list.
+        self.assertEqual(registry_names, save_config_params[2:])
+
+    def test_field_registry_matches_open_configuration_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        open_config_params = list(
+            inspect.signature(lora_gui.open_configuration).parameters
+        )
+        # open_configuration's first three params (ask_for_file, apply_preset,
+        # file_path) and trailing training_preset are supplied separately.
+        self.assertEqual(registry_names, open_config_params[3:-1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Milestone 1 of #3543. `train_model`, `save_configuration`, `open_configuration` in `lora_gui.py` each take ~275 positional parameters that must stay in *identical relative order* with `settings_list` (the flat list wired to Gradio's `.click(inputs=settings_list, ...)`). Nothing enforces that at the language level today — a field added to one signature but misordered relative to the others silently shifts every subsequent value into the wrong parameter.

This PR introduces `FIELD_REGISTRY: list[tuple[str, gr.Component]]` exactly where `settings_list` used to be built, and derives `settings_list = [comp for _, comp in FIELD_REGISTRY]`. **No wiring change** — every `.click()` call still consumes `settings_list` positionally, unchanged.

- Added `FIELD_REGISTRY` in `kohya_gui/lora_gui.py`, one entry per field, with its real keyword-parameter name paired with the existing Gradio component variable.
- Added a module-level `last_built_field_registry` global (same pattern as the existing `executor`/`huggingface` globals) so tests can introspect the registry `lora_tab()` builds, since `FIELD_REGISTRY` is otherwise a local variable inside that function's closure.
- Added `TestLoraGuiFieldRegistry` to `tests/test_lora_gui.py` (kept to one test file per module per `tests/AGENTS.md`), asserting the registry's declared names match, **in order**, the real parameters of `train_model`, `save_configuration`, and `open_configuration` — this checks positional order, not just set membership, which is the actual hazard the issue describes.

Per the issue's own milestone breakdown, this is Milestone 1 only: registry + parity test, no `.click()` wiring changes. M2 (switch `lora_gui.py`'s wiring to dict-keyed adapters) and M3 (repeat for `leco_gui.py`/`dreambooth_gui.py`/`finetune_gui.py`/`textual_inversion_gui.py`) are follow-ups tracked by #3543.

Part of #3543 — not closing it yet since M2–M4 remain.

## Test plan
- [x] `pytest tests/` — 68 passed (includes 5 new `FIELD_REGISTRY` parity tests plus all pre-existing `test_lora_gui.py`, `test_anima_lora_gui.py`, `test_hunyuan_image_lora_gui.py` tests, unmodified)
- [x] `pytest test/test_allowed_paths.py` — 1 passed
- [x] `black --check kohya_gui/lora_gui.py tests/test_lora_gui.py` — clean
- [x] Verified the parity test fails when a registry entry's name is deliberately mismatched (caught the injected typo before reverting it)