### PR TITLE
Switch lora_gui.py train/save/load/preset wiring to dict-keyed adapters (#3543 M2)

### DIFF
--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -70,6 +70,13 @@ train_state_value = time.time()
 # so tests can assert it stays in sync without rebuilding the whole GUI.
 last_built_field_registry = None
 
+# Populated by lora_tab() with the dict-keyed adapter callables wired to the
+# train/save/load/preset buttons (GH #3543 M2). Exposed at module level so
+# tests can invoke the real .click()-bound callables directly instead of
+# calling train_model/save_configuration/open_configuration themselves,
+# exercising the same component-identity lookup the Gradio wiring uses.
+last_built_gui_entries = None
+
 document_symbol = "\U0001f4c4"  # 📄
 
 
@@ -3560,42 +3567,138 @@ def lora_tab(
         global last_built_field_registry
         last_built_field_registry = FIELD_REGISTRY
 
+        # GH #3543 M2: adapters at the Gradio boundary look up each argument by
+        # component identity (via FIELD_REGISTRY) rather than by position, so a
+        # field added out of order can no longer silently shift every
+        # subsequent value into the wrong parameter. train_model's/
+        # save_configuration's/open_configuration's own signatures and bodies
+        # are untouched; only the .click()/.input() wiring below changes.
+        def _kwargs_from_registry(data: dict) -> dict:
+            return {name: data[comp] for name, comp in FIELD_REGISTRY}
+
+        def _make_open_configuration_entry(
+            ask_for_file_comp, apply_preset_comp, output_file_path_comp
+        ):
+            def _entry(data: dict):
+                result = open_configuration(
+                    ask_for_file=data[ask_for_file_comp],
+                    apply_preset=data[apply_preset_comp],
+                    file_path=data[configuration.config_file_name],
+                    training_preset=data[training_preset],
+                    **_kwargs_from_registry(data),
+                )
+                if result is None:
+                    return {}
+                output_components = (
+                    [output_file_path_comp]
+                    + settings_list
+                    + [training_preset, convolution_row]
+                )
+                return dict(zip(output_components, result))
+
+            return _entry
+
+        def _save_configuration_entry(data: dict):
+            return save_configuration(
+                save_as_bool=data[dummy_db_false],
+                file_path=data[configuration.config_file_name],
+                **_kwargs_from_registry(data),
+            )
+
+        def _make_train_model_entry(print_only_comp):
+            def _entry(data: dict):
+                return train_model(
+                    headless=data[dummy_headless],
+                    print_only=data[print_only_comp],
+                    **_kwargs_from_registry(data),
+                )
+
+            return _entry
+
+        # Discarded on preset selection: the visible config_file_name field
+        # must not be overwritten just because a preset was applied.
+        preset_discard_output = gr.Textbox(visible=False)
+
+        open_config_entry = _make_open_configuration_entry(
+            dummy_db_true, dummy_db_false, configuration.config_file_name
+        )
+        load_config_entry = _make_open_configuration_entry(
+            dummy_db_false, dummy_db_false, configuration.config_file_name
+        )
+        preset_entry = _make_open_configuration_entry(
+            dummy_db_false, dummy_db_true, preset_discard_output
+        )
+        train_model_entry = _make_train_model_entry(dummy_db_false)
+        print_command_entry = _make_train_model_entry(dummy_db_true)
+
+        global last_built_gui_entries
+        last_built_gui_entries = {
+            "open_configuration": open_config_entry,
+            "load_configuration": load_config_entry,
+            "apply_preset": preset_entry,
+            "save_configuration": _save_configuration_entry,
+            "train_model": train_model_entry,
+            "print_command": print_command_entry,
+            "components": {
+                "dummy_headless": dummy_headless,
+                "dummy_db_true": dummy_db_true,
+                "dummy_db_false": dummy_db_false,
+                "config_file_name": configuration.config_file_name,
+                "training_preset": training_preset,
+                "convolution_row": convolution_row,
+            },
+        }
+
         configuration.button_open_config.click(
-            open_configuration,
-            inputs=[dummy_db_true, dummy_db_false, configuration.config_file_name]
-            + settings_list
-            + [training_preset],
-            outputs=[configuration.config_file_name]
-            + settings_list
-            + [training_preset, convolution_row],
+            open_config_entry,
+            inputs=set(
+                [dummy_db_true, dummy_db_false, configuration.config_file_name]
+                + settings_list
+                + [training_preset]
+            ),
+            outputs=set(
+                [configuration.config_file_name]
+                + settings_list
+                + [training_preset, convolution_row]
+            ),
             show_progress=False,
         )
 
         configuration.button_load_config.click(
-            open_configuration,
-            inputs=[dummy_db_false, dummy_db_false, configuration.config_file_name]
-            + settings_list
-            + [training_preset],
-            outputs=[configuration.config_file_name]
-            + settings_list
-            + [training_preset, convolution_row],
+            load_config_entry,
+            inputs=set(
+                [dummy_db_false, dummy_db_false, configuration.config_file_name]
+                + settings_list
+                + [training_preset]
+            ),
+            outputs=set(
+                [configuration.config_file_name]
+                + settings_list
+                + [training_preset, convolution_row]
+            ),
             show_progress=False,
         )
 
         training_preset.input(
-            open_configuration,
-            inputs=[dummy_db_false, dummy_db_true, configuration.config_file_name]
-            + settings_list
-            + [training_preset],
-            outputs=[gr.Textbox(visible=False)]
-            + settings_list
-            + [training_preset, convolution_row],
+            preset_entry,
+            inputs=set(
+                [dummy_db_false, dummy_db_true, configuration.config_file_name]
+                + settings_list
+                + [training_preset]
+            ),
+            outputs=set(
+                [preset_discard_output]
+                + settings_list
+                + [training_preset, convolution_row]
+            ),
             show_progress=False,
         )
 
         configuration.button_save_config.click(
-            save_configuration,
-            inputs=[dummy_db_false, configuration.config_file_name] + settings_list,
+            _save_configuration_entry,
+            inputs=set(
+                [dummy_db_false, configuration.config_file_name] + settings_list
+            ),
             outputs=[configuration.config_file_name],
             show_progress=False,
         )
@@ -3608,8 +3711,8 @@ def lora_tab(
         )
 
         executor.button_run.click(
-            train_model,
-            inputs=[dummy_headless] + [dummy_db_false] + settings_list,
+            train_model_entry,
+            inputs=set([dummy_headless, dummy_db_false] + settings_list),
             outputs=[executor.button_run, executor.button_stop_training, run_state],
             show_progress=False,
         )
@@ -3620,8 +3723,8 @@ def lora_tab(
         )
 
         button_print.click(
-            train_model,
-            inputs=[dummy_headless] + [dummy_db_true] + settings_list,
+            print_command_entry,
+            inputs=set([dummy_headless, dummy_db_true] + settings_list),
             show_progress=False,
         )
 

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -4,18 +4,26 @@ sd-scripts v0.11.1 silently ignores (LoRA+ ratios, stale `lowvram`).
 Also covers GH issue #3543 Milestone 1: `FIELD_REGISTRY` must stay in
 identical relative order with train_model's/save_configuration's/
 open_configuration's shared keyword-argument order (see
-TestLoraGuiFieldRegistry below).
+TestLoraGuiFieldRegistry below), and Milestone 2: the train/save/load/
+preset buttons' actual `.click()`/`.input()` callables must look up each
+argument by component identity rather than position (see
+TestLoraGuiDictAdapterWiring below).
 """
 
 import inspect
+import json
+import os
+import tempfile
 import unittest
 
 import gradio as gr
+import toml
 
 from kohya_gui import lora_gui
 from kohya_gui.class_gui_config import KohyaSSGUIConfig
 from conftest import (
     build_train_model_kwargs,
+    mock_executor,
     run_train_model_and_load_saved_json,
     run_train_model_and_load_toml,
 )
@@ -261,6 +269,136 @@ class TestLoraGuiFieldRegistry(unittest.TestCase):
         # open_configuration's first three params (ask_for_file, apply_preset,
         # file_path) and trailing training_preset are supplied separately.
         self.assertEqual(registry_names, open_config_params[3:-1])
+
+
+class TestLoraGuiDictAdapterWiring(unittest.TestCase):
+    """GH issue #3543 Milestone 2: the train/save/load/preset buttons' real
+    `.click()`/`.input()` callables must resolve each argument by component
+    identity (a `dict[Component, value]`, keyed off FIELD_REGISTRY) rather
+    than by position. These tests call the actual bound callables exposed via
+    `last_built_gui_entries` -- the same objects Gradio invokes -- instead of
+    calling train_model/save_configuration/open_configuration directly, so
+    they exercise the wiring itself, not just the underlying functions.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with gr.Blocks():
+            lora_gui.lora_tab(headless=True, config=KohyaSSGUIConfig())
+        cls.field_registry = lora_gui.last_built_field_registry
+        cls.entries = lora_gui.last_built_gui_entries
+        cls.components = cls.entries["components"]
+        cls.settings_list = [comp for _, comp in cls.field_registry]
+
+    def _field_data(self, kwargs: dict) -> dict:
+        return {comp: kwargs[name] for name, comp in self.field_registry}
+
+    def _field_kwargs(self, overrides=None):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides=overrides,
+        )
+        kwargs.pop("headless")
+        kwargs.pop("print_only")
+        return kwargs
+
+    def test_train_model_entry_missing_component_raises_keyerror(self):
+        # Proves the wiring fails loudly (KeyError) rather than silently
+        # shifting values, the core hazard #3543 was filed to eliminate.
+        # `_field_data` never populates the dummy headless/print_only
+        # components, so calling the entry without adding them back exercises
+        # exactly that failure mode.
+        kwargs = self._field_kwargs()
+        data = self._field_data(kwargs)
+        with self.assertRaises(KeyError):
+            self.entries["train_model"](data)
+
+    # Keys whose value embeds the scratch output_dir path, so a fresh tmpdir
+    # per call makes them differ trivially -- not what this test verifies.
+    PATH_DEPENDENT_KEYS = ("output_dir", "sample_prompts")
+
+    def test_print_command_entry_matches_direct_train_model_call(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            kwargs = self._field_kwargs(
+                {"output_dir": tmpdir, "output_name": "wiring_test"}
+            )
+            data = self._field_data(kwargs)
+            data[self.components["dummy_headless"]] = True
+            data[self.components["dummy_db_true"]] = True
+
+            mock_executor(lora_gui)
+            self.entries["print_command"](data)
+            toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+            self.assertEqual(len(toml_files), 1)
+            with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
+                via_wiring = toml.load(f)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            kwargs = self._field_kwargs(
+                {"output_dir": tmpdir, "output_name": "wiring_test"}
+            )
+            mock_executor(lora_gui)
+            lora_gui.train_model(headless=True, print_only=True, **kwargs)
+            toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+            with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
+                via_direct_call = toml.load(f)
+
+        for key in self.PATH_DEPENDENT_KEYS:
+            via_wiring.pop(key, None)
+            via_direct_call.pop(key, None)
+        self.assertEqual(via_wiring, via_direct_call)
+
+    def test_save_configuration_entry_matches_direct_call(self):
+        kwargs = self._field_kwargs()
+        data = self._field_data(kwargs)
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".json", delete=False
+        ) as via_wiring_file:
+            data[self.components["dummy_db_false"]] = False
+            data[self.components["config_file_name"]] = via_wiring_file.name
+            self.entries["save_configuration"](data)
+            with open(via_wiring_file.name, encoding="utf-8") as f:
+                via_wiring = json.load(f)
+        os.unlink(via_wiring_file.name)
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as direct_file:
+            lora_gui.save_configuration(
+                save_as_bool=False, file_path=direct_file.name, **kwargs
+            )
+            with open(direct_file.name, encoding="utf-8") as f:
+                via_direct_call = json.load(f)
+        os.unlink(direct_file.name)
+
+        self.assertEqual(via_wiring, via_direct_call)
+
+    def test_load_configuration_entry_matches_direct_open_configuration_call(self):
+        kwargs = self._field_kwargs()
+        data = self._field_data(kwargs)
+        data[self.components["dummy_db_false"]] = False
+        data[self.components["config_file_name"]] = FIXTURE
+        data[self.components["training_preset"]] = "none"
+
+        result = self.entries["load_configuration"](data)
+
+        direct_result = lora_gui.open_configuration(
+            ask_for_file=False,
+            apply_preset=False,
+            file_path=FIXTURE,
+            training_preset="none",
+            **kwargs,
+        )
+
+        # direct_result is [file_path, *settings_list-ordered values,
+        # training_preset, convolution_row]; compare everything but the
+        # trailing gr.Row visibility object (not equality-comparable).
+        self.assertEqual(result[self.components["config_file_name"]], direct_result[0])
+        for comp, expected in zip(self.settings_list, direct_result[1:-2]):
+            self.assertEqual(result[comp], expected)
+        self.assertEqual(result[self.components["training_preset"]], direct_result[-2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replaces the positional `.click()`/`.input()` wiring for the LoRA tab's Train, Print training command, Save config, Load config, and Load preset buttons with dict-keyed adapters, per the M2 scope in #3543.
- Each adapter looks up its arguments by component identity via `FIELD_REGISTRY` (introduced in M1, #3544) rather than by list position, using Gradio's native `set()`-based `inputs`/`outputs` support (confirmed compatible with the pinned `gradio>=5.34.1` by reading `gradio/blocks.py`'s dependency-registration code directly: a `set` triggers `inputs_as_dict=True`, and `set` outputs are matched by component id via `convert_component_dict_to_list`, independent of declaration order).
- `open_configuration`'s return-side hazard (its `tuple(values)` had to positionally match `outputs=`) is fixed the same way: its adapter zips the function's ordered return values against known output components into a dict before handing them to Gradio.
- `train_model`, `save_configuration`, `open_configuration` themselves are untouched — same signatures, same bodies.

## Test plan
- [x] `pytest tests/` — 72 passed (13 pre-existing lora_gui tests unmodified + 4 new `TestLoraGuiDictAdapterWiring` tests exercising the real bound adapter callables end-to-end, not just the underlying functions)
- [x] New tests cover: print/train parity against direct `train_model` calls, save_configuration parity, load_configuration (open_configuration) parity, and a KeyError-on-missing-component safety check
- [x] `black kohya_gui/lora_gui.py tests/test_lora_gui.py` — clean
- [x] Manual browser smoke test in the LoRA tab: Train (print command), Save config, Load config, and Load preset all verified working by the repo owner

Part of #3543 (M2 of 4). M3 (repeat for leco_gui.py/dreambooth_gui.py/finetune_gui.py/textual_inversion_gui.py) and optional M4 remain.