### PR TITLE
fix: address PR #3545 review feedback

### DIFF
--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -3580,6 +3580,11 @@ def lora_tab(
             ask_for_file_comp, apply_preset_comp, output_file_path_comp
         ):
             def _entry(data: dict):
+                output_components = (
+                    [output_file_path_comp]
+                    + settings_list
+                    + [training_preset, convolution_row]
+                )
                 result = open_configuration(
                     ask_for_file=data[ask_for_file_comp],
                     apply_preset=data[apply_preset_comp],
@@ -3587,13 +3592,16 @@ def lora_tab(
                     training_preset=data[training_preset],
                     **_kwargs_from_registry(data),
                 )
+                # Missing config file returns None — emit no-op updates so every
+                # wired output is accounted for (partial {} is not guaranteed).
                 if result is None:
-                    return {}
-                output_components = (
-                    [output_file_path_comp]
-                    + settings_list
-                    + [training_preset, convolution_row]
-                )
+                    return {comp: gr.update() for comp in output_components}
+                if len(result) != len(output_components):
+                    raise ValueError(
+                        f"open_configuration returned {len(result)} values, "
+                        f"expected {len(output_components)} "
+                        f"(FIELD_REGISTRY/signature drift?)"
+                    )
                 return dict(zip(output_components, result))
 
             return _entry

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -355,23 +355,31 @@ class TestLoraGuiDictAdapterWiring(unittest.TestCase):
         kwargs = self._field_kwargs()
         data = self._field_data(kwargs)
 
-        with tempfile.NamedTemporaryFile(
-            suffix=".json", delete=False
-        ) as via_wiring_file:
+        # Close the handle before reopening: Windows locks NamedTemporaryFile
+        # while the with-block holds it open, which fails save_configuration/open.
+        via_wiring_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        via_wiring_path = via_wiring_file.name
+        via_wiring_file.close()
+        try:
             data[self.components["dummy_db_false"]] = False
-            data[self.components["config_file_name"]] = via_wiring_file.name
+            data[self.components["config_file_name"]] = via_wiring_path
             self.entries["save_configuration"](data)
-            with open(via_wiring_file.name, encoding="utf-8") as f:
+            with open(via_wiring_path, encoding="utf-8") as f:
                 via_wiring = json.load(f)
-        os.unlink(via_wiring_file.name)
+        finally:
+            os.unlink(via_wiring_path)
 
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as direct_file:
+        direct_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        direct_path = direct_file.name
+        direct_file.close()
+        try:
             lora_gui.save_configuration(
-                save_as_bool=False, file_path=direct_file.name, **kwargs
+                save_as_bool=False, file_path=direct_path, **kwargs
             )
-            with open(direct_file.name, encoding="utf-8") as f:
+            with open(direct_path, encoding="utf-8") as f:
                 via_direct_call = json.load(f)
-        os.unlink(direct_file.name)
+        finally:
+            os.unlink(direct_path)
 
         self.assertEqual(via_wiring, via_direct_call)
 


### PR DESCRIPTION
## Summary
Follow-up to #3545 addressing Copilot review comments that landed after the original squash-merge window:

- **`open_configuration` adapter** (`lora_gui.py`): on `None` (missing config), return explicit `gr.update()` no-ops for every wired output instead of `{}`; raise `ValueError` if return length drifts from `FIELD_REGISTRY`/outputs.
- **Windows-safe temp files** (`tests/test_lora_gui.py`): close `NamedTemporaryFile` handles before reopening so save/load is not locked on Windows.

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_lora_gui.py` — 17 passed
