### PR TITLE
Apply FIELD_REGISTRY + dict adapters to leco_gui.py (#3543 M3)

### DIFF
--- a/kohya_gui/leco_gui.py
+++ b/kohya_gui/leco_gui.py
@@ -42,6 +42,19 @@ executor = None
 use_shell = False
 train_state_value = time.time()
 
+# Populated by leco_tab() with the (param_name, component) pairs backing
+# settings_list, in the same order as train_model's/save_configuration's/
+# open_configuration's shared keyword-argument order. Exposed at module level
+# so tests can assert it stays in sync without rebuilding the whole GUI.
+last_built_field_registry = None
+
+# Populated by leco_tab() with the dict-keyed adapter callables wired to the
+# train/save/load buttons (GH #3543 M3). Exposed at module level so tests can
+# invoke the real .click()-bound callables directly instead of calling
+# train_model/save_configuration/open_configuration themselves, exercising the
+# same component-identity lookup the Gradio wiring uses.
+last_built_gui_entries = None
+
 document_symbol = "\U0001f4c4"  # 📄
 folder_symbol = "\U0001f4c2"  # 📂
 
@@ -572,6 +585,7 @@ def leco_tab(
     global use_shell, executor
     use_shell = use_shell_flag
 
+    dummy_db_true = gr.Checkbox(value=True, visible=False)
     dummy_db_false = gr.Checkbox(value=False, visible=False)
     dummy_headless = gr.Checkbox(value=headless, visible=False)
 
@@ -1107,93 +1121,179 @@ def leco_tab(
 
         button_print = gr.Button("Print training command")
 
-        settings_list = [
-            pretrained_model_name_or_path,
-            v2,
-            v_parameterization,
-            sdxl,
-            output_dir,
-            output_name,
-            save_model_as,
-            save_precision,
-            training_comment,
-            no_metadata,
-            prompts_file,
-            network_module,
-            network_dim,
-            network_alpha,
-            network_dropout,
-            network_args,
-            network_weights,
-            dim_from_weights,
-            learning_rate,
-            unet_lr,
-            optimizer,
-            optimizer_args,
-            lr_scheduler,
-            lr_scheduler_args,
-            lr_warmup_steps,
-            lr_scheduler_num_cycles,
-            lr_scheduler_power,
-            max_train_steps,
-            max_grad_norm,
-            max_denoising_steps,
-            leco_denoise_guidance_scale,
-            seed,
-            gradient_accumulation_steps,
-            accelerate_launch.mixed_precision,
-            accelerate_launch.num_cpu_threads_per_process,
-            accelerate_launch.num_processes,
-            accelerate_launch.num_machines,
-            accelerate_launch.multi_gpu,
-            accelerate_launch.gpu_ids,
-            accelerate_launch.main_process_port,
-            accelerate_launch.dynamo_backend,
-            accelerate_launch.dynamo_mode,
-            accelerate_launch.dynamo_use_fullgraph,
-            accelerate_launch.dynamo_use_dynamic,
-            accelerate_launch.extra_accelerate_launch_args,
-            gradient_checkpointing,
-            full_fp16,
-            full_bf16,
-            xformers,
-            mem_eff_attn,
-            clip_skip,
-            noise_offset,
-            zero_terminal_snr,
-            min_snr_gamma,
-            save_every_n_steps,
-            save_last_n_steps,
-            save_last_n_steps_state,
-            save_state,
-            save_state_on_train_end,
-            resume,
-            logging_dir,
-            log_with,
-            log_tracker_name,
-            log_tracker_config,
-            log_config,
-            wandb_api_key,
-            wandb_run_name,
+        FIELD_REGISTRY = [
+            ("pretrained_model_name_or_path", pretrained_model_name_or_path),
+            ("v2", v2),
+            ("v_parameterization", v_parameterization),
+            ("sdxl", sdxl),
+            ("output_dir", output_dir),
+            ("output_name", output_name),
+            ("save_model_as", save_model_as),
+            ("save_precision", save_precision),
+            ("training_comment", training_comment),
+            ("no_metadata", no_metadata),
+            ("prompts_file", prompts_file),
+            ("network_module", network_module),
+            ("network_dim", network_dim),
+            ("network_alpha", network_alpha),
+            ("network_dropout", network_dropout),
+            ("network_args", network_args),
+            ("network_weights", network_weights),
+            ("dim_from_weights", dim_from_weights),
+            ("learning_rate", learning_rate),
+            ("unet_lr", unet_lr),
+            ("optimizer", optimizer),
+            ("optimizer_args", optimizer_args),
+            ("lr_scheduler", lr_scheduler),
+            ("lr_scheduler_args", lr_scheduler_args),
+            ("lr_warmup_steps", lr_warmup_steps),
+            ("lr_scheduler_num_cycles", lr_scheduler_num_cycles),
+            ("lr_scheduler_power", lr_scheduler_power),
+            ("max_train_steps", max_train_steps),
+            ("max_grad_norm", max_grad_norm),
+            ("max_denoising_steps", max_denoising_steps),
+            ("leco_denoise_guidance_scale", leco_denoise_guidance_scale),
+            ("seed", seed),
+            ("gradient_accumulation_steps", gradient_accumulation_steps),
+            ("mixed_precision", accelerate_launch.mixed_precision),
+            (
+                "num_cpu_threads_per_process",
+                accelerate_launch.num_cpu_threads_per_process,
+            ),
+            ("num_processes", accelerate_launch.num_processes),
+            ("num_machines", accelerate_launch.num_machines),
+            ("multi_gpu", accelerate_launch.multi_gpu),
+            ("gpu_ids", accelerate_launch.gpu_ids),
+            ("main_process_port", accelerate_launch.main_process_port),
+            ("dynamo_backend", accelerate_launch.dynamo_backend),
+            ("dynamo_mode", accelerate_launch.dynamo_mode),
+            ("dynamo_use_fullgraph", accelerate_launch.dynamo_use_fullgraph),
+            ("dynamo_use_dynamic", accelerate_launch.dynamo_use_dynamic),
+            (
+                "extra_accelerate_launch_args",
+                accelerate_launch.extra_accelerate_launch_args,
+            ),
+            ("gradient_checkpointing", gradient_checkpointing),
+            ("full_fp16", full_fp16),
+            ("full_bf16", full_bf16),
+            ("xformers", xformers),
+            ("mem_eff_attn", mem_eff_attn),
+            ("clip_skip", clip_skip),
+            ("noise_offset", noise_offset),
+            ("zero_terminal_snr", zero_terminal_snr),
+            ("min_snr_gamma", min_snr_gamma),
+            ("save_every_n_steps", save_every_n_steps),
+            ("save_last_n_steps", save_last_n_steps),
+            ("save_last_n_steps_state", save_last_n_steps_state),
+            ("save_state", save_state),
+            ("save_state_on_train_end", save_state_on_train_end),
+            ("resume", resume),
+            ("logging_dir", logging_dir),
+            ("log_with", log_with),
+            ("log_tracker_name", log_tracker_name),
+            ("log_tracker_config", log_tracker_config),
+            ("log_config", log_config),
+            ("wandb_api_key", wandb_api_key),
+            ("wandb_run_name", wandb_run_name),
         ]
+        settings_list = [comp for _, comp in FIELD_REGISTRY]
+
+        global last_built_field_registry
+        last_built_field_registry = FIELD_REGISTRY
+
+        # GH #3543 M3: adapters at the Gradio boundary look up each argument by
+        # component identity (via FIELD_REGISTRY) rather than by position, so a
+        # field added out of order can no longer silently shift every
+        # subsequent value into the wrong parameter. train_model's/
+        # save_configuration's/open_configuration's own signatures and bodies
+        # are untouched; only the .click() wiring below changes.
+        def _kwargs_from_registry(data: dict) -> dict:
+            return {name: data[comp] for name, comp in FIELD_REGISTRY}
+
+        def _make_open_configuration_entry(ask_for_file_comp):
+            def _entry(data: dict):
+                output_components = [configuration.config_file_name] + settings_list
+                result = open_configuration(
+                    ask_for_file=data[ask_for_file_comp],
+                    file_path=data[configuration.config_file_name],
+                    **_kwargs_from_registry(data),
+                )
+                # Missing config file returns None — emit no-op updates so every
+                # wired output is accounted for (partial {} is not guaranteed).
+                if result is None:
+                    return {comp: gr.update() for comp in output_components}
+                if len(result) != len(output_components):
+                    raise ValueError(
+                        f"open_configuration returned {len(result)} values, "
+                        f"expected {len(output_components)} "
+                        f"(FIELD_REGISTRY/signature drift?)"
+                    )
+                return dict(zip(output_components, result))
+
+            return _entry
+
+        def _save_configuration_entry(data: dict):
+            return save_configuration(
+                save_as_bool=data[dummy_db_false],
+                file_path=data[configuration.config_file_name],
+                **_kwargs_from_registry(data),
+            )
+
+        def _make_train_model_entry(print_only_comp):
+            def _entry(data: dict):
+                return train_model(
+                    headless=data[dummy_headless],
+                    print_only=data[print_only_comp],
+                    **_kwargs_from_registry(data),
+                )
+
+            return _entry
+
+        # Open asks for a file (True); Load re-reads the path already in the
+        # config_file_name field (False). Pre-adapter wiring incorrectly used
+        # False for both, so the Open button never opened a file dialog —
+        # align with lora/dreambooth/finetune/TI while converting to adapters.
+        open_config_entry = _make_open_configuration_entry(dummy_db_true)
+        load_config_entry = _make_open_configuration_entry(dummy_db_false)
+        train_model_entry = _make_train_model_entry(dummy_db_false)
+        print_command_entry = _make_train_model_entry(dummy_db_true)
+
+        global last_built_gui_entries
+        last_built_gui_entries = {
+            "open_configuration": open_config_entry,
+            "load_configuration": load_config_entry,
+            "save_configuration": _save_configuration_entry,
+            "train_model": train_model_entry,
+            "print_command": print_command_entry,
+            "components": {
+                "dummy_headless": dummy_headless,
+                "dummy_db_true": dummy_db_true,
+                "dummy_db_false": dummy_db_false,
+                "config_file_name": configuration.config_file_name,
+            },
+        }
 
         configuration.button_open_config.click(
-            open_configuration,
-            inputs=[dummy_db_false, configuration.config_file_name] + settings_list,
-            outputs=[configuration.config_file_name] + settings_list,
+            open_config_entry,
+            inputs=set([dummy_db_true, configuration.config_file_name] + settings_list),
+            outputs=set([configuration.config_file_name] + settings_list),
             show_progress=False,
         )
 
         configuration.button_load_config.click(
-            open_configuration,
-            inputs=[dummy_db_false, configuration.config_file_name] + settings_list,
-            outputs=[configuration.config_file_name] + settings_list,
+            load_config_entry,
+            inputs=set(
+                [dummy_db_false, configuration.config_file_name] + settings_list
+            ),
+            outputs=set([configuration.config_file_name] + settings_list),
             show_progress=False,
         )
 
         configuration.button_save_config.click(
-            save_configuration,
-            inputs=[dummy_db_false, configuration.config_file_name] + settings_list,
+            _save_configuration_entry,
+            inputs=set(
+                [dummy_db_false, configuration.config_file_name] + settings_list
+            ),
             outputs=[configuration.config_file_name],
             show_progress=False,
         )
@@ -1206,8 +1306,8 @@ def leco_tab(
         )
 
         executor.button_run.click(
-            train_model,
-            inputs=[dummy_headless] + [dummy_db_false] + settings_list,
+            train_model_entry,
+            inputs=set([dummy_headless, dummy_db_false] + settings_list),
             outputs=[executor.button_run, executor.button_stop_training, run_state],
             show_progress=False,
         )
@@ -1218,9 +1318,7 @@ def leco_tab(
         )
 
         button_print.click(
-            train_model,
-            inputs=[dummy_headless]
-            + [gr.Checkbox(value=True, visible=False)]
-            + settings_list,
+            print_command_entry,
+            inputs=set([dummy_headless, dummy_db_true] + settings_list),
             show_progress=False,
         )

--- a/kohya_gui/leco_gui.py
+++ b/kohya_gui/leco_gui.py
@@ -1275,25 +1275,21 @@ def leco_tab(
 
         configuration.button_open_config.click(
             open_config_entry,
-            inputs=set([dummy_db_true, configuration.config_file_name] + settings_list),
-            outputs=set([configuration.config_file_name] + settings_list),
+            inputs={dummy_db_true, configuration.config_file_name, *settings_list},
+            outputs={configuration.config_file_name, *settings_list},
             show_progress=False,
         )
 
         configuration.button_load_config.click(
             load_config_entry,
-            inputs=set(
-                [dummy_db_false, configuration.config_file_name] + settings_list
-            ),
-            outputs=set([configuration.config_file_name] + settings_list),
+            inputs={dummy_db_false, configuration.config_file_name, *settings_list},
+            outputs={configuration.config_file_name, *settings_list},
             show_progress=False,
         )
 
         configuration.button_save_config.click(
             _save_configuration_entry,
-            inputs=set(
-                [dummy_db_false, configuration.config_file_name] + settings_list
-            ),
+            inputs={dummy_db_false, configuration.config_file_name, *settings_list},
             outputs=[configuration.config_file_name],
             show_progress=False,
         )
@@ -1307,7 +1303,7 @@ def leco_tab(
 
         executor.button_run.click(
             train_model_entry,
-            inputs=set([dummy_headless, dummy_db_false] + settings_list),
+            inputs={dummy_headless, dummy_db_false, *settings_list},
             outputs=[executor.button_run, executor.button_stop_training, run_state],
             show_progress=False,
         )
@@ -1319,6 +1315,6 @@ def leco_tab(
 
         button_print.click(
             print_command_entry,
-            inputs=set([dummy_headless, dummy_db_true] + settings_list),
+            inputs={dummy_headless, dummy_db_true, *settings_list},
             show_progress=False,
         )

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -3659,54 +3659,60 @@ def lora_tab(
 
         configuration.button_open_config.click(
             open_config_entry,
-            inputs=set(
-                [dummy_db_true, dummy_db_false, configuration.config_file_name]
-                + settings_list
-                + [training_preset]
-            ),
-            outputs=set(
-                [configuration.config_file_name]
-                + settings_list
-                + [training_preset, convolution_row]
-            ),
+            inputs={
+                dummy_db_true,
+                dummy_db_false,
+                configuration.config_file_name,
+                *settings_list,
+                training_preset,
+            },
+            outputs={
+                configuration.config_file_name,
+                *settings_list,
+                training_preset,
+                convolution_row,
+            },
             show_progress=False,
         )
 
         configuration.button_load_config.click(
             load_config_entry,
-            inputs=set(
-                [dummy_db_false, dummy_db_false, configuration.config_file_name]
-                + settings_list
-                + [training_preset]
-            ),
-            outputs=set(
-                [configuration.config_file_name]
-                + settings_list
-                + [training_preset, convolution_row]
-            ),
+            inputs={
+                dummy_db_false,
+                configuration.config_file_name,
+                *settings_list,
+                training_preset,
+            },
+            outputs={
+                configuration.config_file_name,
+                *settings_list,
+                training_preset,
+                convolution_row,
+            },
             show_progress=False,
         )
 
         training_preset.input(
             preset_entry,
-            inputs=set(
-                [dummy_db_false, dummy_db_true, configuration.config_file_name]
-                + settings_list
-                + [training_preset]
-            ),
-            outputs=set(
-                [preset_discard_output]
-                + settings_list
-                + [training_preset, convolution_row]
-            ),
+            inputs={
+                dummy_db_false,
+                dummy_db_true,
+                configuration.config_file_name,
+                *settings_list,
+                training_preset,
+            },
+            outputs={
+                preset_discard_output,
+                *settings_list,
+                training_preset,
+                convolution_row,
+            },
             show_progress=False,
         )
 
         configuration.button_save_config.click(
             _save_configuration_entry,
-            inputs=set(
-                [dummy_db_false, configuration.config_file_name] + settings_list
-            ),
+            inputs={dummy_db_false, configuration.config_file_name, *settings_list},
             outputs=[configuration.config_file_name],
             show_progress=False,
         )
@@ -3720,7 +3726,7 @@ def lora_tab(
 
         executor.button_run.click(
             train_model_entry,
-            inputs=set([dummy_headless, dummy_db_false] + settings_list),
+            inputs={dummy_headless, dummy_db_false, *settings_list},
             outputs=[executor.button_run, executor.button_stop_training, run_state],
             show_progress=False,
         )
@@ -3732,7 +3738,7 @@ def lora_tab(
 
         button_print.click(
             print_command_entry,
-            inputs=set([dummy_headless, dummy_db_true] + settings_list),
+            inputs={dummy_headless, dummy_db_true, *settings_list},
             show_progress=False,
         )
 

--- a/tests/test_leco_gui.py
+++ b/tests/test_leco_gui.py
@@ -1,14 +1,24 @@
-"""Regression tests for GH issue #3526: LECO training support in the GUI."""
+"""Regression tests for GH issue #3526: LECO training support in the GUI.
+
+Also covers GH issue #3543 Milestone 3 (leco_gui.py): `FIELD_REGISTRY` must
+stay in identical relative order with train_model's/save_configuration's/
+open_configuration's shared keyword-argument order, and the train/save/load
+buttons' actual `.click()` callables must look up each argument by component
+identity rather than position.
+"""
 
 import inspect
+import json
 import os
 import tempfile
 import unittest
 from unittest.mock import patch
 
+import gradio as gr
 import toml
 
 from kohya_gui import leco_gui
+from kohya_gui.class_gui_config import KohyaSSGUIConfig
 from conftest import mock_executor
 
 
@@ -101,12 +111,15 @@ def _run_and_load_toml(overrides=None):
     with tempfile.TemporaryDirectory() as tmpdir:
         kwargs = _default_kwargs({**(overrides or {}), "output_dir": tmpdir})
         mock_executor(leco_gui)
-        with patch.object(leco_gui, "print_command_and_toml") as mocked:
-            leco_gui.train_model(**kwargs)
-            run_cmd = mocked.call_args[0][0]
-            tmpfilename = mocked.call_args[0][1]
-            with open(tmpfilename, encoding="utf-8") as f:
-                config = toml.load(f)
+        # train_model aborts if accelerate is missing from PATH; pin a
+        # fake path so the suite doesn't depend on the host environment.
+        with patch.object(leco_gui, "get_executable_path", return_value="accelerate"):
+            with patch.object(leco_gui, "print_command_and_toml") as mocked:
+                leco_gui.train_model(**kwargs)
+                run_cmd = mocked.call_args[0][0]
+                tmpfilename = mocked.call_args[0][1]
+                with open(tmpfilename, encoding="utf-8") as f:
+                    config = toml.load(f)
         return run_cmd, config
 
 
@@ -152,6 +165,198 @@ class TestLecoGuiCommandGeneration(unittest.TestCase):
     def test_save_every_n_steps_is_forwarded(self):
         run_cmd, config = _run_and_load_toml({"save_every_n_steps": 200})
         self.assertEqual(config.get("save_every_n_steps"), 200)
+
+
+class TestLecoGuiFieldRegistry(unittest.TestCase):
+    """GH issue #3543 M3: `FIELD_REGISTRY` (the source `settings_list` is now
+    derived from) must declare its field names in the exact same relative order
+    as train_model's/save_configuration's/open_configuration's shared
+    keyword-argument order.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with gr.Blocks():
+            leco_gui.leco_tab(headless=True, config=KohyaSSGUIConfig())
+        cls.field_registry = leco_gui.last_built_field_registry
+
+    def test_field_registry_was_built(self):
+        self.assertIsNotNone(self.field_registry)
+        self.assertGreater(len(self.field_registry), 0)
+
+    def test_field_registry_names_are_unique(self):
+        names = [name for name, _ in self.field_registry]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_field_registry_matches_train_model_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        train_model_params = list(inspect.signature(leco_gui.train_model).parameters)
+        # train_model's first two params (headless, print_only) are supplied
+        # separately by the .click() wiring, not via settings_list.
+        self.assertEqual(registry_names, train_model_params[2:])
+
+    def test_field_registry_matches_save_configuration_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        save_config_params = list(
+            inspect.signature(leco_gui.save_configuration).parameters
+        )
+        # save_configuration's first two params (save_as_bool, file_path) are
+        # supplied separately, not via settings_list.
+        self.assertEqual(registry_names, save_config_params[2:])
+
+    def test_field_registry_matches_open_configuration_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        open_config_params = list(
+            inspect.signature(leco_gui.open_configuration).parameters
+        )
+        # open_configuration's first two params (ask_for_file, file_path) are
+        # supplied separately; there is no trailing training_preset on LECO.
+        self.assertEqual(registry_names, open_config_params[2:])
+
+
+class TestLecoGuiDictAdapterWiring(unittest.TestCase):
+    """GH issue #3543 M3: the train/save/load buttons' real `.click()` callables
+    must resolve each argument by component identity (a `dict[Component, value]`,
+    keyed off FIELD_REGISTRY) rather than by position.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        with gr.Blocks():
+            leco_gui.leco_tab(headless=True, config=KohyaSSGUIConfig())
+        cls.field_registry = leco_gui.last_built_field_registry
+        cls.entries = leco_gui.last_built_gui_entries
+        cls.components = cls.entries["components"]
+        cls.settings_list = [comp for _, comp in cls.field_registry]
+
+    def _field_data(self, kwargs: dict) -> dict:
+        return {comp: kwargs[name] for name, comp in self.field_registry}
+
+    def _field_kwargs(self, overrides=None):
+        kwargs = _default_kwargs(overrides)
+        kwargs.pop("headless")
+        kwargs.pop("print_only")
+        return kwargs
+
+    def test_train_model_entry_missing_component_raises_keyerror(self):
+        # Proves the wiring fails loudly (KeyError) rather than silently
+        # shifting values — the core hazard #3543 was filed to eliminate.
+        kwargs = self._field_kwargs()
+        data = self._field_data(kwargs)
+        with self.assertRaises(KeyError):
+            self.entries["train_model"](data)
+
+    PATH_DEPENDENT_KEYS = ("output_dir",)
+
+    def test_print_command_entry_matches_direct_train_model_call(self):
+        with patch.object(leco_gui, "get_executable_path", return_value="accelerate"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                kwargs = self._field_kwargs(
+                    {"output_dir": tmpdir, "output_name": "wiring_test"}
+                )
+                data = self._field_data(kwargs)
+                data[self.components["dummy_headless"]] = True
+                data[self.components["dummy_db_true"]] = True
+
+                mock_executor(leco_gui)
+                self.entries["print_command"](data)
+                toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+                self.assertEqual(len(toml_files), 1)
+                with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
+                    via_wiring = toml.load(f)
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                kwargs = self._field_kwargs(
+                    {"output_dir": tmpdir, "output_name": "wiring_test"}
+                )
+                mock_executor(leco_gui)
+                leco_gui.train_model(headless=True, print_only=True, **kwargs)
+                toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+                with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
+                    via_direct_call = toml.load(f)
+
+        for key in self.PATH_DEPENDENT_KEYS:
+            via_wiring.pop(key, None)
+            via_direct_call.pop(key, None)
+        self.assertEqual(via_wiring, via_direct_call)
+
+    def test_save_configuration_entry_matches_direct_call(self):
+        kwargs = self._field_kwargs()
+        data = self._field_data(kwargs)
+
+        via_wiring_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        via_wiring_path = via_wiring_file.name
+        via_wiring_file.close()
+        try:
+            data[self.components["dummy_db_false"]] = False
+            data[self.components["config_file_name"]] = via_wiring_path
+            self.entries["save_configuration"](data)
+            with open(via_wiring_path, encoding="utf-8") as f:
+                via_wiring = json.load(f)
+        finally:
+            os.unlink(via_wiring_path)
+
+        direct_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        direct_path = direct_file.name
+        direct_file.close()
+        try:
+            leco_gui.save_configuration(
+                save_as_bool=False, file_path=direct_path, **kwargs
+            )
+            with open(direct_path, encoding="utf-8") as f:
+                via_direct_call = json.load(f)
+        finally:
+            os.unlink(direct_path)
+
+        self.assertEqual(via_wiring, via_direct_call)
+
+    def test_load_configuration_entry_matches_direct_open_configuration_call(self):
+        # Round-trip a known config through save, then load via the adapter
+        # so we exercise the real component-keyed path without needing a
+        # checked-in LECO fixture JSON.
+        kwargs = self._field_kwargs()
+        config_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
+        config_path = config_file.name
+        config_file.close()
+        try:
+            leco_gui.save_configuration(
+                save_as_bool=False, file_path=config_path, **kwargs
+            )
+
+            data = self._field_data(kwargs)
+            data[self.components["dummy_db_false"]] = False
+            data[self.components["config_file_name"]] = config_path
+
+            result = self.entries["load_configuration"](data)
+
+            direct_result = leco_gui.open_configuration(
+                ask_for_file=False,
+                file_path=config_path,
+                **kwargs,
+            )
+
+            self.assertEqual(
+                result[self.components["config_file_name"]], direct_result[0]
+            )
+            for comp, expected in zip(self.settings_list, direct_result[1:]):
+                self.assertEqual(result[comp], expected)
+        finally:
+            os.unlink(config_path)
+
+    def test_open_configuration_entry_requests_file_dialog(self):
+        # Open must pass ask_for_file=True (unlike Load). The pre-adapter
+        # wiring used False for both; assert the fixed distinction holds.
+        kwargs = self._field_kwargs()
+        data = self._field_data(kwargs)
+        data[self.components["dummy_db_true"]] = True
+        data[self.components["config_file_name"]] = ""
+
+        with patch.object(leco_gui, "get_file_path", return_value="") as mocked_picker:
+            # Empty picker result falls through to original_file_path and
+            # returns a full tuple of current values — no KeyError/None.
+            result = self.entries["open_configuration"](data)
+            mocked_picker.assert_called_once()
+            self.assertEqual(result[self.components["config_file_name"]], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Port the #3543 M1+M2 pattern from `lora_gui.py` to `leco_gui.py` (first M3 file; one PR per remaining module).
- `settings_list` is now derived from a `FIELD_REGISTRY` of `(param_name, component)` pairs; train/save/load/print buttons use dict-keyed Gradio adapters so arguments resolve by component identity, not position.
- Fix pre-existing bug: Open Config now passes `ask_for_file=True` (Load stays `False`). Previously both were wired to `False`, so the Open button never opened a file dialog.
- `train_model` / `save_configuration` / `open_configuration` signatures and bodies are untouched.

## Tests

- Registry parity: field names match `train_model`/`save_configuration`/`open_configuration` keyword order.
- Adapter wiring: print-command TOML and save/load config match direct calls; missing component raises `KeyError`.
- Open vs Load: Open entry invokes the file picker (`ask_for_file=True`).
- Existing LECO command-generation tests kept; mock `accelerate` so the suite does not depend on host PATH.

```
pytest tests/test_leco_gui.py  # 17 passed
```

## Note

Does **not** close #3543 — remaining M3 files are `dreambooth_gui.py`, `finetune_gui.py`, `textual_inversion_gui.py`.

Part of #3543