### PR TITLE
\ Add Anima ControlNet-LLLite training tab\

### DIFF
--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -12,12 +12,14 @@ from kohya_gui.textual_inversion_gui import ti_tab
 from kohya_gui.utilities import utilities_tab
 from kohya_gui.lora_gui import lora_tab
 from kohya_gui.leco_gui import leco_tab
+from kohya_gui.anima_lllite_gui import anima_lllite_tab
 from kohya_gui.class_lora_tab import LoRATools
 from kohya_gui.custom_logging import setup_logging
 from kohya_gui.localization_ext import add_javascript
 
 PYTHON = sys.executable
 project_dir = os.path.dirname(os.path.abspath(__file__))
+
 
 # Function to read file content, suppressing any FileNotFoundError
 def read_file_content(file_path):
@@ -26,13 +28,16 @@ def read_file_content(file_path):
             return file.read()
     return ""
 
+
 # Function to initialize the Gradio UI interface
 def initialize_ui_interface(config, headless, use_shell, release_info, readme_content):
     # Load custom CSS if available
     css = read_file_content("./assets/style.css")
 
     # Create the main Gradio Blocks interface
-    ui_interface = gr.Blocks(css=css, title=f"Kohya_ss GUI {release_info}", theme=gr.themes.Default())
+    ui_interface = gr.Blocks(
+        css=css, title=f"Kohya_ss GUI {release_info}", theme=gr.themes.Default()
+    )
     with ui_interface:
         # Create tabs for different functionalities
         with gr.Tab("Dreambooth"):
@@ -41,11 +46,15 @@ def initialize_ui_interface(config, headless, use_shell, release_info, readme_co
                 reg_data_dir_input,
                 output_dir_input,
                 logging_dir_input,
-            ) = dreambooth_tab(headless=headless, config=config, use_shell_flag=use_shell)
+            ) = dreambooth_tab(
+                headless=headless, config=config, use_shell_flag=use_shell
+            )
         with gr.Tab("LoRA"):
             lora_tab(headless=headless, config=config, use_shell_flag=use_shell)
         with gr.Tab("LECO"):
             leco_tab(headless=headless, config=config, use_shell_flag=use_shell)
+        with gr.Tab("Anima LLLite"):
+            anima_lllite_tab(headless=headless, config=config, use_shell_flag=use_shell)
         with gr.Tab("Textual Inversion"):
             ti_tab(headless=headless, config=config, use_shell_flag=use_shell)
         with gr.Tab("Finetuning"):
@@ -73,6 +82,7 @@ def initialize_ui_interface(config, headless, use_shell, release_info, readme_co
 
     return ui_interface
 
+
 # Function to configure and launch the UI
 def UI(**kwargs):
     # Add custom JavaScript if specified
@@ -89,52 +99,104 @@ def UI(**kwargs):
         log.info(f"Loaded default GUI values from '{kwargs.get('config')}'...")
 
     # Determine if shell should be used for running external commands
-    use_shell = not kwargs.get("do_not_use_shell", False) and config.get("settings.use_shell", True)
+    use_shell = not kwargs.get("do_not_use_shell", False) and config.get(
+        "settings.use_shell", True
+    )
     if use_shell:
         log.info("Using shell=True when running external commands...")
 
     # Initialize the Gradio UI interface
-    ui_interface = initialize_ui_interface(config, kwargs.get("headless", False), use_shell, release_info, readme_content)
+    ui_interface = initialize_ui_interface(
+        config, kwargs.get("headless", False), use_shell, release_info, readme_content
+    )
 
     # Construct launch parameters using dictionary comprehension
     launch_params = {
         "server_name": kwargs.get("listen"),
-        "auth": (kwargs["username"], kwargs["password"]) if kwargs.get("username") and kwargs.get("password") else None,
-        "server_port": kwargs.get("server_port", 0) if kwargs.get("server_port", 0) > 0 else None,
+        "auth": (
+            (kwargs["username"], kwargs["password"])
+            if kwargs.get("username") and kwargs.get("password")
+            else None
+        ),
+        "server_port": (
+            kwargs.get("server_port", 0) if kwargs.get("server_port", 0) > 0 else None
+        ),
         "inbrowser": kwargs.get("inbrowser", False),
-        "share": False if kwargs.get("do_not_share", False) else kwargs.get("share", False),
+        "share": (
+            False if kwargs.get("do_not_share", False) else kwargs.get("share", False)
+        ),
         "root_path": kwargs.get("root_path", None),
         "debug": kwargs.get("debug", False),
         "allowed_paths": config.allowed_paths,
     }
-  
+
     # This line filters out any key-value pairs from `launch_params` where the value is `None`, ensuring only valid parameters are passed to the `launch` function.
     launch_params = {k: v for k, v in launch_params.items() if v is not None}
 
     # Launch the Gradio interface with the specified parameters
     ui_interface.launch(**launch_params)
 
+
 # Function to initialize argument parser for command-line arguments
 def initialize_arg_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--config", type=str, default="./config.toml", help="Path to the toml config file for interface defaults")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="./config.toml",
+        help="Path to the toml config file for interface defaults",
+    )
     parser.add_argument("--debug", action="store_true", help="Debug on")
-    parser.add_argument("--listen", type=str, default="127.0.0.1", help="IP to listen on for connections to Gradio")
-    parser.add_argument("--username", type=str, default="", help="Username for authentication")
-    parser.add_argument("--password", type=str, default="", help="Password for authentication")
-    parser.add_argument("--server_port", type=int, default=0, help="Port to run the server listener on")
+    parser.add_argument(
+        "--listen",
+        type=str,
+        default="127.0.0.1",
+        help="IP to listen on for connections to Gradio",
+    )
+    parser.add_argument(
+        "--username", type=str, default="", help="Username for authentication"
+    )
+    parser.add_argument(
+        "--password", type=str, default="", help="Password for authentication"
+    )
+    parser.add_argument(
+        "--server_port", type=int, default=0, help="Port to run the server listener on"
+    )
     parser.add_argument("--inbrowser", action="store_true", help="Open in browser")
     parser.add_argument("--share", action="store_true", help="Share the gradio UI")
-    parser.add_argument("--headless", action="store_true", help="Is the server headless")
-    parser.add_argument("--language", type=str, default=None, help="Set custom language")
+    parser.add_argument(
+        "--headless", action="store_true", help="Is the server headless"
+    )
+    parser.add_argument(
+        "--language", type=str, default=None, help="Set custom language"
+    )
     parser.add_argument("--use-ipex", action="store_true", help="Use IPEX environment")
     parser.add_argument("--use-rocm", action="store_true", help="Use ROCm environment")
-    parser.add_argument("--do_not_use_shell", action="store_true", help="Enforce not to use shell=True when running external commands")
-    parser.add_argument("--do_not_share", action="store_true", help="Do not share the gradio UI")
-    parser.add_argument("--requirements", type=str, default=None, help="requirements file to use for validation")
-    parser.add_argument("--root_path", type=str, default=None, help="`root_path` for Gradio to enable reverse proxy support. e.g. /kohya_ss")
-    parser.add_argument("--noverify", action="store_true", help="Disable requirements verification")
+    parser.add_argument(
+        "--do_not_use_shell",
+        action="store_true",
+        help="Enforce not to use shell=True when running external commands",
+    )
+    parser.add_argument(
+        "--do_not_share", action="store_true", help="Do not share the gradio UI"
+    )
+    parser.add_argument(
+        "--requirements",
+        type=str,
+        default=None,
+        help="requirements file to use for validation",
+    )
+    parser.add_argument(
+        "--root_path",
+        type=str,
+        default=None,
+        help="`root_path` for Gradio to enable reverse proxy support. e.g. /kohya_ss",
+    )
+    parser.add_argument(
+        "--noverify", action="store_true", help="Disable requirements verification"
+    )
     return parser
+
 
 if __name__ == "__main__":
     # Initialize argument parser and parse arguments
@@ -149,11 +211,14 @@ if __name__ == "__main__":
         log.warning("Skipping requirements verification.")
     else:
         # Run the validation command to verify requirements
-        validation_command = [PYTHON, os.path.join(project_dir, "setup", "validate_requirements.py")]
-        
+        validation_command = [
+            PYTHON,
+            os.path.join(project_dir, "setup", "validate_requirements.py"),
+        ]
+
         if args.requirements is not None:
             validation_command.append(f"--requirements={args.requirements}")
-            
+
         subprocess.run(validation_command, check=True)
 
     # Launch the UI with the provided arguments

--- a/kohya_gui/anima_lllite_gui.py
+++ b/kohya_gui/anima_lllite_gui.py
@@ -1,0 +1,1654 @@
+"""Anima ControlNet-LLLite training tab (GH issue #3525).
+
+Wraps sd-scripts/anima_train_control_net_lllite.py. The backend is experimental
+and asserts if blocks_to_swap / cpu_offload_checkpointing /
+unsloth_offload_checkpointing / deepspeed / fused_backward_pass are enabled —
+those options are intentionally not exposed here.
+"""
+
+import json
+import os
+import time
+import toml
+
+from datetime import datetime
+
+import gradio as gr
+
+from .class_accelerate_launch import AccelerateLaunch
+from .class_anima import animaTraining
+from .class_command_executor import CommandExecutor
+from .class_configuration_file import ConfigurationFile
+from .class_gui_config import KohyaSSGUIConfig
+from .class_source_model import default_models
+from .common_gui import (
+    SaveConfigFile,
+    check_if_model_exist,
+    create_refresh_button,
+    get_any_file_path,
+    get_executable_path,
+    get_file_path,
+    get_folder_path,
+    get_saveasfile_path,
+    list_dirs,
+    list_files,
+    print_command_and_toml,
+    run_cmd_advanced_training,
+    scriptdir,
+    setup_environment,
+    update_my_data,
+    validate_args_setting,
+    validate_file_path,
+    validate_folder_path,
+    validate_model_path,
+    validate_toml_file,
+)
+from .custom_logging import setup_logging
+
+log = setup_logging()
+
+executor = None
+
+use_shell = False
+train_state_value = time.time()
+
+# Populated by anima_lllite_tab() with the (param_name, component) pairs backing
+# settings_list, in the same order as train_model's/save_configuration's/
+# open_configuration's shared keyword-argument order.
+last_built_field_registry = None
+
+# Populated by anima_lllite_tab() with the dict-keyed adapter callables wired
+# to the train/save/load buttons (GH #3543 M3).
+last_built_gui_entries = None
+
+document_symbol = "\U0001f4c4"  # 📄
+folder_symbol = "\U0001f4c2"  # 📂
+
+# Presets and atomic target-layer choices from
+# sd-scripts/networks/control_net_lllite_anima.py (documented surface).
+LLLITE_TARGET_LAYER_CHOICES = [
+    "self_attn_q",
+    "self_attn_qkv",
+    "self_attn_qkv_cross_q",
+    "self_attn_q_pre",
+    "self_attn_kv_pre",
+    "cross_attn_q_pre",
+    "mlp_fc1_pre",
+    "self_attn_q_pre,mlp_fc1_pre",
+    "self_attn_q_pre,self_attn_kv_pre,mlp_fc1_pre",
+    "self_attn_q_pre,self_attn_kv_pre,cross_attn_q_pre,mlp_fc1_pre",
+]
+
+
+def save_configuration(
+    save_as_bool,
+    file_path,
+    # model section
+    pretrained_model_name_or_path,
+    output_dir,
+    output_name,
+    save_model_as,
+    save_precision,
+    training_comment,
+    no_metadata,
+    # dataset section
+    train_data_dir,
+    conditioning_data_dir,
+    dataset_config,
+    resolution,
+    enable_bucket,
+    min_bucket_reso,
+    max_bucket_reso,
+    train_batch_size,
+    max_train_epochs,
+    max_train_steps,
+    caption_extension,
+    cache_latents,
+    cache_latents_to_disk,
+    cache_text_encoder_outputs,
+    cache_text_encoder_outputs_to_disk,
+    seed,
+    gradient_accumulation_steps,
+    # anima section
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
+    # lllite section
+    cond_emb_dim,
+    lllite_mlp_dim,
+    lllite_target_layers,
+    lllite_cond_dim,
+    lllite_cond_resblocks,
+    lllite_use_aspp,
+    lllite_dropout,
+    lllite_multiplier,
+    network_weights,
+    lllite_cond_in_channels,
+    lllite_inpaint_masked_input,
+    # training section
+    learning_rate,
+    optimizer,
+    optimizer_args,
+    lr_scheduler,
+    lr_scheduler_args,
+    lr_warmup_steps,
+    lr_scheduler_num_cycles,
+    lr_scheduler_power,
+    max_grad_norm,
+    gradient_checkpointing,
+    full_fp16,
+    full_bf16,
+    # accelerate launch section
+    mixed_precision,
+    num_cpu_threads_per_process,
+    num_processes,
+    num_machines,
+    multi_gpu,
+    gpu_ids,
+    main_process_port,
+    dynamo_backend,
+    dynamo_mode,
+    dynamo_use_fullgraph,
+    dynamo_use_dynamic,
+    extra_accelerate_launch_args,
+    # save / logging section
+    save_every_n_epochs,
+    save_every_n_steps,
+    save_last_n_steps,
+    save_last_n_steps_state,
+    save_state,
+    save_state_on_train_end,
+    resume,
+    logging_dir,
+    log_with,
+    log_tracker_name,
+    log_tracker_config,
+    log_config,
+    wandb_api_key,
+    wandb_run_name,
+    show_timesteps,
+    show_timesteps_resolution,
+):
+    parameters = list(locals().items())
+
+    original_file_path = file_path
+
+    if save_as_bool:
+        log.info("Save as...")
+        file_path = get_saveasfile_path(file_path)
+    else:
+        log.info("Save...")
+        if file_path is None or file_path == "":
+            file_path = get_saveasfile_path(file_path)
+
+    if file_path is None or file_path == "":
+        return original_file_path
+
+    SaveConfigFile(
+        parameters=parameters,
+        file_path=file_path,
+        exclusion=["file_path", "save_as", "save_as_bool"],
+    )
+
+    log.info(f"Config saved to {file_path}")
+
+    return file_path
+
+
+def open_configuration(
+    ask_for_file,
+    file_path,
+    # model section
+    pretrained_model_name_or_path,
+    output_dir,
+    output_name,
+    save_model_as,
+    save_precision,
+    training_comment,
+    no_metadata,
+    # dataset section
+    train_data_dir,
+    conditioning_data_dir,
+    dataset_config,
+    resolution,
+    enable_bucket,
+    min_bucket_reso,
+    max_bucket_reso,
+    train_batch_size,
+    max_train_epochs,
+    max_train_steps,
+    caption_extension,
+    cache_latents,
+    cache_latents_to_disk,
+    cache_text_encoder_outputs,
+    cache_text_encoder_outputs_to_disk,
+    seed,
+    gradient_accumulation_steps,
+    # anima section
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
+    # lllite section
+    cond_emb_dim,
+    lllite_mlp_dim,
+    lllite_target_layers,
+    lllite_cond_dim,
+    lllite_cond_resblocks,
+    lllite_use_aspp,
+    lllite_dropout,
+    lllite_multiplier,
+    network_weights,
+    lllite_cond_in_channels,
+    lllite_inpaint_masked_input,
+    # training section
+    learning_rate,
+    optimizer,
+    optimizer_args,
+    lr_scheduler,
+    lr_scheduler_args,
+    lr_warmup_steps,
+    lr_scheduler_num_cycles,
+    lr_scheduler_power,
+    max_grad_norm,
+    gradient_checkpointing,
+    full_fp16,
+    full_bf16,
+    # accelerate launch section
+    mixed_precision,
+    num_cpu_threads_per_process,
+    num_processes,
+    num_machines,
+    multi_gpu,
+    gpu_ids,
+    main_process_port,
+    dynamo_backend,
+    dynamo_mode,
+    dynamo_use_fullgraph,
+    dynamo_use_dynamic,
+    extra_accelerate_launch_args,
+    # save / logging section
+    save_every_n_epochs,
+    save_every_n_steps,
+    save_last_n_steps,
+    save_last_n_steps_state,
+    save_state,
+    save_state_on_train_end,
+    resume,
+    logging_dir,
+    log_with,
+    log_tracker_name,
+    log_tracker_config,
+    log_config,
+    wandb_api_key,
+    wandb_run_name,
+    show_timesteps,
+    show_timesteps_resolution,
+):
+    parameters = list(locals().items())
+
+    original_file_path = file_path
+
+    if ask_for_file:
+        file_path = get_file_path(file_path)
+
+    if not file_path == "" and not file_path == None:
+        if not os.path.isfile(file_path):
+            log.error(f"Config file {file_path} does not exist.")
+            return
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            my_data = json.load(f)
+            log.info("Loading config...")
+
+            my_data = update_my_data(my_data)
+    else:
+        file_path = original_file_path
+        my_data = {}
+
+    values = [file_path]
+    for key, value in parameters:
+        if not key in ["ask_for_file", "file_path"]:
+            json_value = my_data.get(key)
+            values.append(json_value if json_value is not None else value)
+
+    return tuple(values)
+
+
+def train_model(
+    headless,
+    print_only,
+    # model section
+    pretrained_model_name_or_path,
+    output_dir,
+    output_name,
+    save_model_as,
+    save_precision,
+    training_comment,
+    no_metadata,
+    # dataset section
+    train_data_dir,
+    conditioning_data_dir,
+    dataset_config,
+    resolution,
+    enable_bucket,
+    min_bucket_reso,
+    max_bucket_reso,
+    train_batch_size,
+    max_train_epochs,
+    max_train_steps,
+    caption_extension,
+    cache_latents,
+    cache_latents_to_disk,
+    cache_text_encoder_outputs,
+    cache_text_encoder_outputs_to_disk,
+    seed,
+    gradient_accumulation_steps,
+    # anima section
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
+    # lllite section
+    cond_emb_dim,
+    lllite_mlp_dim,
+    lllite_target_layers,
+    lllite_cond_dim,
+    lllite_cond_resblocks,
+    lllite_use_aspp,
+    lllite_dropout,
+    lllite_multiplier,
+    network_weights,
+    lllite_cond_in_channels,
+    lllite_inpaint_masked_input,
+    # training section
+    learning_rate,
+    optimizer,
+    optimizer_args,
+    lr_scheduler,
+    lr_scheduler_args,
+    lr_warmup_steps,
+    lr_scheduler_num_cycles,
+    lr_scheduler_power,
+    max_grad_norm,
+    gradient_checkpointing,
+    full_fp16,
+    full_bf16,
+    # accelerate launch section
+    mixed_precision,
+    num_cpu_threads_per_process,
+    num_processes,
+    num_machines,
+    multi_gpu,
+    gpu_ids,
+    main_process_port,
+    dynamo_backend,
+    dynamo_mode,
+    dynamo_use_fullgraph,
+    dynamo_use_dynamic,
+    extra_accelerate_launch_args,
+    # save / logging section
+    save_every_n_epochs,
+    save_every_n_steps,
+    save_last_n_steps,
+    save_last_n_steps_state,
+    save_state,
+    save_state_on_train_end,
+    resume,
+    logging_dir,
+    log_with,
+    log_tracker_name,
+    log_tracker_config,
+    log_config,
+    wandb_api_key,
+    wandb_run_name,
+    show_timesteps,
+    show_timesteps_resolution,
+):
+    parameters = list(locals().items())
+    global train_state_value
+
+    TRAIN_BUTTON_VISIBLE = [
+        gr.Button(visible=True),
+        gr.Button(visible=False or headless),
+        gr.Textbox(value=train_state_value),
+    ]
+
+    if executor.is_running():
+        log.error("Training is already running. Can't start another training session.")
+        return TRAIN_BUTTON_VISIBLE
+
+    log.info("Start training Anima ControlNet-LLLite ...")
+
+    log.info("Validating lr scheduler arguments...")
+    if not validate_args_setting(lr_scheduler_args):
+        return TRAIN_BUTTON_VISIBLE
+
+    log.info("Validating optimizer arguments...")
+    if not validate_args_setting(optimizer_args):
+        return TRAIN_BUTTON_VISIBLE
+
+    # Backend asserts if both compile paths are set (anima_train_control_net_lllite.py).
+    if anima_compile and anima_torch_compile:
+        log.error(
+            "Per-block Torch Compile and Legacy Torch Compile cannot both be "
+            "enabled at the same time."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
+    #
+    # Validate paths / required fields
+    #
+
+    if dataset_config:
+        if not validate_toml_file(dataset_config):
+            return TRAIN_BUTTON_VISIBLE
+    else:
+        if train_data_dir == "":
+            log.error(
+                "Train data dir is required when Dataset config is not set "
+                "(ControlNet-format dataset: image + conditioning image)."
+            )
+            return TRAIN_BUTTON_VISIBLE
+        if conditioning_data_dir == "":
+            log.error(
+                "Conditioning data dir is required when Dataset config is not set. "
+                "See docs/train_lllite_README.md#preparing-the-dataset."
+            )
+            return TRAIN_BUTTON_VISIBLE
+        if not validate_folder_path(train_data_dir):
+            return TRAIN_BUTTON_VISIBLE
+        if not validate_folder_path(conditioning_data_dir):
+            return TRAIN_BUTTON_VISIBLE
+
+    if anima_qwen3 == "" or anima_vae == "":
+        log.error(
+            "Anima Qwen3 path and VAE path are required for ControlNet-LLLite training."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_model_path(pretrained_model_name_or_path):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_model_path(anima_qwen3):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_model_path(anima_vae):
+        return TRAIN_BUTTON_VISIBLE
+
+    if anima_llm_adapter_path and not validate_model_path(anima_llm_adapter_path):
+        return TRAIN_BUTTON_VISIBLE
+
+    if anima_t5_tokenizer_path and not validate_folder_path(anima_t5_tokenizer_path):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_file_path(log_tracker_config):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_folder_path(
+        logging_dir, can_be_written_to=True, create_if_not_exists=True
+    ):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_file_path(network_weights):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_folder_path(
+        output_dir, can_be_written_to=True, create_if_not_exists=True
+    ):
+        return TRAIN_BUTTON_VISIBLE
+
+    if not validate_folder_path(resume):
+        return TRAIN_BUTTON_VISIBLE
+
+    #
+    # End of path validation
+    #
+
+    if output_dir != "":
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+    if not print_only and check_if_model_exist(
+        output_name, output_dir, save_model_as, headless=headless
+    ):
+        return TRAIN_BUTTON_VISIBLE
+
+    accelerate_path = get_executable_path("accelerate")
+    if accelerate_path == "":
+        log.error("accelerate not found")
+        return TRAIN_BUTTON_VISIBLE
+
+    run_cmd = [rf"{accelerate_path}", "launch"]
+
+    run_cmd = AccelerateLaunch.run_cmd(
+        run_cmd=run_cmd,
+        dynamo_backend=dynamo_backend,
+        dynamo_mode=dynamo_mode,
+        dynamo_use_fullgraph=dynamo_use_fullgraph,
+        dynamo_use_dynamic=dynamo_use_dynamic,
+        num_processes=num_processes,
+        num_machines=num_machines,
+        multi_gpu=multi_gpu,
+        gpu_ids=gpu_ids,
+        main_process_port=main_process_port,
+        num_cpu_threads_per_process=num_cpu_threads_per_process,
+        mixed_precision=mixed_precision,
+        extra_accelerate_launch_args=extra_accelerate_launch_args,
+    )
+
+    run_cmd.append(rf"{scriptdir}/sd-scripts/anima_train_control_net_lllite.py")
+
+    # Resolution may be "1024" or "1024,1024"
+    resolution_value = resolution
+    if isinstance(resolution, (int, float)):
+        resolution_value = str(int(resolution))
+
+    config_toml_data = {
+        "pretrained_model_name_or_path": pretrained_model_name_or_path,
+        "output_dir": output_dir,
+        "output_name": output_name,
+        "save_model_as": save_model_as,
+        "save_precision": save_precision,
+        "training_comment": training_comment,
+        "no_metadata": no_metadata,
+        "dataset_config": dataset_config if dataset_config else None,
+        "train_data_dir": train_data_dir if not dataset_config else None,
+        "conditioning_data_dir": (
+            conditioning_data_dir if not dataset_config else None
+        ),
+        "resolution": resolution_value,
+        "enable_bucket": enable_bucket,
+        "min_bucket_reso": int(min_bucket_reso) if enable_bucket else None,
+        "max_bucket_reso": int(max_bucket_reso) if enable_bucket else None,
+        "train_batch_size": int(train_batch_size),
+        "max_train_epochs": (
+            int(max_train_epochs) if int(max_train_epochs) != 0 else None
+        ),
+        "max_train_steps": (
+            int(max_train_steps) if int(max_train_steps) != 0 else None
+        ),
+        "caption_extension": caption_extension,
+        "cache_latents": cache_latents,
+        "cache_latents_to_disk": cache_latents_to_disk,
+        "cache_text_encoder_outputs": cache_text_encoder_outputs,
+        "cache_text_encoder_outputs_to_disk": cache_text_encoder_outputs_to_disk,
+        "seed": int(seed) if int(seed) != 0 else None,
+        "gradient_accumulation_steps": int(gradient_accumulation_steps),
+        # Anima
+        "qwen3": anima_qwen3,
+        "vae": anima_vae,
+        "llm_adapter_path": anima_llm_adapter_path if anima_llm_adapter_path else None,
+        "t5_tokenizer_path": (
+            anima_t5_tokenizer_path if anima_t5_tokenizer_path else None
+        ),
+        "discrete_flow_shift": float(anima_discrete_flow_shift),
+        "timestep_sampling": anima_timestep_sampling,
+        "sigmoid_scale": float(anima_sigmoid_scale),
+        "qwen3_max_token_length": int(anima_qwen3_max_token_length),
+        "t5_max_token_length": int(anima_t5_max_token_length),
+        "attn_mode": anima_attn_mode if anima_attn_mode != "torch" else None,
+        "split_attn": anima_split_attn,
+        "vae_chunk_size": (int(anima_vae_chunk_size) if anima_vae_chunk_size else None),
+        "vae_disable_cache": anima_vae_disable_cache,
+        "qwen_image_vae_2d": anima_qwen_image_vae_2d,
+        "compile": anima_compile,
+        "torch_compile": anima_torch_compile,
+        "compile_backend": anima_compile_backend if anima_compile else None,
+        "compile_mode": anima_compile_mode if anima_compile else None,
+        "compile_dynamic": (
+            anima_compile_dynamic
+            if anima_compile and anima_compile_dynamic != "auto"
+            else None
+        ),
+        "compile_fullgraph": anima_compile_fullgraph if anima_compile else None,
+        "compile_cache_size_limit": (
+            int(anima_compile_cache_size_limit)
+            if anima_compile and anima_compile_cache_size_limit
+            else None
+        ),
+        # LLLite-specific (never emit unsupported MVP offload flags)
+        "cond_emb_dim": int(cond_emb_dim),
+        "lllite_mlp_dim": int(lllite_mlp_dim),
+        "lllite_target_layers": lllite_target_layers,
+        "lllite_cond_dim": int(lllite_cond_dim),
+        "lllite_cond_resblocks": int(lllite_cond_resblocks),
+        "lllite_use_aspp": lllite_use_aspp,
+        "lllite_dropout": (
+            float(lllite_dropout) if lllite_dropout not in ("", None, 0) else None
+        ),
+        "lllite_multiplier": float(lllite_multiplier),
+        "network_weights": network_weights if network_weights else None,
+        "lllite_cond_in_channels": int(lllite_cond_in_channels),
+        "lllite_inpaint_masked_input": lllite_inpaint_masked_input,
+        # Training
+        "learning_rate": learning_rate,
+        "optimizer_type": optimizer,
+        "optimizer_args": (
+            str(optimizer_args).replace('"', "").split()
+            if optimizer_args not in ("", [], None)
+            else None
+        ),
+        "lr_scheduler": lr_scheduler,
+        "lr_scheduler_args": (
+            str(lr_scheduler_args).replace('"', "").split()
+            if lr_scheduler_args not in ("", [], None)
+            else None
+        ),
+        "lr_warmup_steps": lr_warmup_steps,
+        "lr_scheduler_num_cycles": (
+            int(lr_scheduler_num_cycles) if lr_scheduler_num_cycles != "" else None
+        ),
+        "lr_scheduler_power": lr_scheduler_power,
+        "max_grad_norm": max_grad_norm,
+        "gradient_checkpointing": gradient_checkpointing,
+        "full_fp16": full_fp16,
+        "full_bf16": full_bf16,
+        "mixed_precision": mixed_precision,
+        "save_every_n_epochs": (
+            int(save_every_n_epochs) if int(save_every_n_epochs) != 0 else None
+        ),
+        "save_every_n_steps": (
+            int(save_every_n_steps) if int(save_every_n_steps) != 0 else None
+        ),
+        "save_last_n_steps": (
+            int(save_last_n_steps) if int(save_last_n_steps) != 0 else None
+        ),
+        "save_last_n_steps_state": (
+            int(save_last_n_steps_state) if int(save_last_n_steps_state) != 0 else None
+        ),
+        "save_state": save_state,
+        "save_state_on_train_end": save_state_on_train_end,
+        "resume": resume,
+        "logging_dir": logging_dir,
+        "log_with": log_with,
+        "log_tracker_name": log_tracker_name,
+        "log_tracker_config": log_tracker_config,
+        "log_config": log_config,
+        "wandb_api_key": wandb_api_key,
+        "wandb_run_name": wandb_run_name if wandb_run_name != "" else output_name,
+        "show_timesteps": show_timesteps if show_timesteps else None,
+        "show_timesteps_resolution": (
+            show_timesteps_resolution if show_timesteps else None
+        ),
+    }
+
+    # Remove empty / False / None values so flags like lllite_use_aspp only
+    # appear when enabled.
+    config_toml_data = {
+        key: value
+        for key, value in config_toml_data.items()
+        if value not in ["", False, None]
+    }
+
+    config_toml_data = dict(sorted(config_toml_data.items()))
+
+    current_datetime = datetime.now()
+    formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
+    tmpfilename = os.path.join(
+        output_dir, f"config_anima_lllite-{formatted_datetime}.toml"
+    )
+
+    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
+        toml.dump(config_toml_data, toml_file)
+
+        if not os.path.exists(toml_file.name):
+            log.error(f"Failed to write TOML file: {toml_file.name}")
+
+    run_cmd.append("--config_file")
+    run_cmd.append(rf"{tmpfilename}")
+
+    run_cmd = run_cmd_advanced_training(run_cmd=run_cmd)
+
+    if print_only:
+        print_command_and_toml(run_cmd, tmpfilename)
+    else:
+        current_datetime = datetime.now()
+        formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
+        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+
+        log.info(f"Saving training config to {file_path}...")
+
+        SaveConfigFile(
+            parameters=parameters,
+            file_path=file_path,
+            exclusion=["file_path", "save_as", "headless", "print_only"],
+        )
+
+        env = setup_environment()
+
+        executor.execute_command(run_cmd=run_cmd, env=env)
+
+        train_state_value = time.time()
+
+        return (
+            gr.Button(visible=False or headless),
+            gr.Button(visible=True),
+            gr.Textbox(value=train_state_value),
+        )
+
+
+def anima_lllite_tab(
+    headless=False,
+    config: KohyaSSGUIConfig = {},
+    use_shell_flag: bool = False,
+):
+    global use_shell, executor
+    use_shell = use_shell_flag
+
+    dummy_db_true = gr.Checkbox(value=True, visible=False)
+    dummy_db_false = gr.Checkbox(value=False, visible=False)
+    dummy_headless = gr.Checkbox(value=headless, visible=False)
+    # animaTraining accordion is always shown on this dedicated tab.
+    anima_always_on = gr.Checkbox(value=True, visible=False)
+
+    current_models_dir = config.get(
+        "model.models_dir", os.path.join(scriptdir, "models")
+    )
+    current_train_data_dir = config.get(
+        "model.train_data_dir", os.path.join(scriptdir, "data")
+    )
+    current_cond_data_dir = config.get(
+        "anima_lllite.conditioning_data_dir",
+        os.path.join(scriptdir, "data", "conditioning"),
+    )
+    current_dataset_config_dir = config.get(
+        "model.dataset_config", os.path.join(scriptdir, "dataset_config")
+    )
+
+    def list_models(path):
+        nonlocal current_models_dir
+        current_models_dir = path if os.path.isdir(path) else os.path.dirname(path)
+        return default_models + list(
+            list_files(path, exts=[".ckpt", ".safetensors"], all=True)
+        )
+
+    def list_train_data_dirs(path):
+        nonlocal current_train_data_dir
+        current_train_data_dir = path if not path == "" else "."
+        return list(list_dirs(current_train_data_dir))
+
+    def list_cond_data_dirs(path):
+        nonlocal current_cond_data_dir
+        current_cond_data_dir = path if not path == "" else "."
+        return list(list_dirs(current_cond_data_dir))
+
+    def list_dataset_config_dirs(path):
+        nonlocal current_dataset_config_dir
+        current_dataset_config_dir = path if not path == "" else "."
+        return list(list_files(current_dataset_config_dir, exts=[".toml"], all=True))
+
+    model_checkpoints = list(
+        list_files(current_models_dir, exts=[".ckpt", ".safetensors"], all=True)
+    )
+
+    with gr.Tab("Training"), gr.Column(variant="compact"):
+        gr.Markdown(
+            "Train an Anima **ControlNet-LLLite** adapter "
+            "(`anima_train_control_net_lllite.py`). Requires a ControlNet-format "
+            "dataset (training image + conditioning image with matching basenames). "
+            "See `sd-scripts/docs/anima_train_control_net_lllite.md` and "
+            "`docs/train_lllite_README.md#preparing-the-dataset`. "
+            "**Experimental:** blocks-to-swap, CPU/Unsloth offload checkpointing, "
+            "DeepSpeed, and fused backward pass are not supported and are not "
+            "exposed in this tab."
+        )
+
+        with gr.Accordion("Configuration", open=False):
+            configuration = ConfigurationFile(headless=headless, config=config)
+
+        with gr.Accordion("Accelerate launch", open=False), gr.Column():
+            accelerate_launch = AccelerateLaunch(config=config)
+
+        with gr.Accordion("Model", open=True):
+            with gr.Column(), gr.Group():
+                model_ext = gr.Textbox(value="*.safetensors *.ckpt", visible=False)
+                model_ext_name = gr.Textbox(value="Model types", visible=False)
+
+                with gr.Row():
+                    pretrained_model_name_or_path = gr.Dropdown(
+                        label="Pretrained model name or path (Anima DiT)",
+                        choices=default_models + model_checkpoints,
+                        value=config.get(
+                            "model.pretrained_model_name_or_path",
+                            "",
+                        ),
+                        allow_custom_value=True,
+                        min_width=100,
+                    )
+                    create_refresh_button(
+                        pretrained_model_name_or_path,
+                        lambda: None,
+                        lambda: {"choices": list_models(current_models_dir)},
+                        "open_folder_small",
+                    )
+                    pretrained_model_name_or_path_file = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        elem_classes=["tool"],
+                        visible=(not headless),
+                    )
+                    pretrained_model_name_or_path_file.click(
+                        get_file_path,
+                        inputs=[
+                            pretrained_model_name_or_path,
+                            model_ext,
+                            model_ext_name,
+                        ],
+                        outputs=pretrained_model_name_or_path,
+                        show_progress=False,
+                    )
+                    pretrained_model_name_or_path_folder = gr.Button(
+                        folder_symbol,
+                        elem_id="open_folder_small",
+                        elem_classes=["tool"],
+                        visible=(not headless),
+                    )
+                    pretrained_model_name_or_path_folder.click(
+                        get_folder_path,
+                        inputs=pretrained_model_name_or_path,
+                        outputs=pretrained_model_name_or_path,
+                        show_progress=False,
+                    )
+
+                with gr.Row():
+                    output_dir = gr.Textbox(
+                        label="Output directory",
+                        placeholder="Directory to output the trained LLLite model",
+                        value=config.get(
+                            "model.output_dir", os.path.join(scriptdir, "outputs")
+                        ),
+                        interactive=True,
+                    )
+                    output_dir_button = gr.Button(
+                        folder_symbol,
+                        elem_id="open_folder_small",
+                        elem_classes=["tool"],
+                        visible=(not headless),
+                    )
+                    output_dir_button.click(
+                        get_folder_path,
+                        outputs=output_dir,
+                        show_progress=False,
+                    )
+                    output_name = gr.Textbox(
+                        label="Trained model output name",
+                        placeholder="(Name of the model to output)",
+                        value=config.get("model.output_name", "last"),
+                        interactive=True,
+                    )
+                    training_comment = gr.Textbox(
+                        label="Training comment",
+                        placeholder="(Optional) Add training comment to be included in metadata",
+                        value=config.get("model.training_comment", ""),
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    save_model_as = gr.Radio(
+                        ["ckpt", "safetensors"],
+                        label="Save trained model as",
+                        value=config.get("model.save_model_as", "safetensors"),
+                    )
+                    save_precision = gr.Radio(
+                        ["float", "fp16", "bf16"],
+                        label="Save precision",
+                        value=config.get("model.save_precision", "bf16"),
+                    )
+                    no_metadata = gr.Checkbox(
+                        label="No metadata",
+                        value=config.get("model.no_metadata", False),
+                        info="Do not save metadata in output model",
+                    )
+
+        # Anima model paths / flow-matching options (always visible on this tab).
+        # Unsloth offload is hidden: unsupported by anima_train_control_net_lllite.
+        anima_training = animaTraining(
+            headless=headless,
+            config=config,
+            anima_checkbox=anima_always_on,
+            always_visible=True,
+            show_unsloth_offload_checkpointing=False,
+        )
+
+        with gr.Accordion("ControlNet dataset", open=True), gr.Group():
+            gr.Markdown(
+                "Provide either a dataset TOML (`conditioning_data_dir` per subset) "
+                "or folder pair: training images + conditioning images with matching "
+                "basenames. Same layout as SDXL ControlNet-LLLite."
+            )
+            with gr.Row():
+                train_data_dir = gr.Dropdown(
+                    label="Image folder (training images)",
+                    choices=[""] + list(list_dirs(current_train_data_dir)),
+                    value=config.get("model.train_data_dir", ""),
+                    interactive=True,
+                    allow_custom_value=True,
+                )
+                create_refresh_button(
+                    train_data_dir,
+                    lambda: None,
+                    lambda: {
+                        "choices": [""] + list_train_data_dirs(current_train_data_dir)
+                    },
+                    "open_folder_small",
+                )
+                train_data_dir_folder = gr.Button(
+                    folder_symbol,
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=(not headless),
+                )
+                train_data_dir_folder.click(
+                    get_folder_path,
+                    outputs=train_data_dir,
+                    show_progress=False,
+                )
+
+                conditioning_data_dir = gr.Dropdown(
+                    label="Conditioning image folder",
+                    choices=[""] + list(list_dirs(current_cond_data_dir)),
+                    value=config.get("anima_lllite.conditioning_data_dir", ""),
+                    interactive=True,
+                    allow_custom_value=True,
+                    info="Conditioning images (canny, lineart, depth, …) with the same basenames as training images",
+                )
+                create_refresh_button(
+                    conditioning_data_dir,
+                    lambda: None,
+                    lambda: {
+                        "choices": [""] + list_cond_data_dirs(current_cond_data_dir)
+                    },
+                    "open_folder_small",
+                )
+                conditioning_data_dir_folder = gr.Button(
+                    folder_symbol,
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=(not headless),
+                )
+                conditioning_data_dir_folder.click(
+                    get_folder_path,
+                    outputs=conditioning_data_dir,
+                    show_progress=False,
+                )
+
+            with gr.Row():
+                dataset_config = gr.Dropdown(
+                    label="Dataset config (TOML)",
+                    choices=[""]
+                    + list(
+                        list_files(current_dataset_config_dir, exts=[".toml"], all=True)
+                    ),
+                    value=config.get("model.dataset_config", ""),
+                    interactive=True,
+                    allow_custom_value=True,
+                    info="When set, train/conditioning folder fields above are ignored",
+                )
+                create_refresh_button(
+                    dataset_config,
+                    lambda: None,
+                    lambda: {
+                        "choices": [""]
+                        + list_dataset_config_dirs(current_dataset_config_dir)
+                    },
+                    "open_folder_small",
+                )
+                dataset_config_file = gr.Button(
+                    document_symbol,
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=(not headless),
+                )
+                dataset_config_file.click(
+                    get_file_path,
+                    inputs=[
+                        dataset_config,
+                        gr.Textbox(value="*.toml", visible=False),
+                        gr.Textbox(value="Dataset config TOML", visible=False),
+                    ],
+                    outputs=dataset_config,
+                    show_progress=False,
+                )
+
+            with gr.Row():
+                resolution = gr.Textbox(
+                    label="Resolution",
+                    value=config.get("anima_lllite.resolution", "1024"),
+                    info='e.g. "1024" or "1024,1024"',
+                    interactive=True,
+                )
+                enable_bucket = gr.Checkbox(
+                    label="Enable buckets",
+                    value=config.get("anima_lllite.enable_bucket", True),
+                )
+                min_bucket_reso = gr.Number(
+                    label="Min bucket resolution",
+                    value=config.get("anima_lllite.min_bucket_reso", 256),
+                    precision=0,
+                )
+                max_bucket_reso = gr.Number(
+                    label="Max bucket resolution",
+                    value=config.get("anima_lllite.max_bucket_reso", 2048),
+                    precision=0,
+                )
+
+            with gr.Row():
+                train_batch_size = gr.Slider(
+                    label="Train batch size",
+                    value=config.get("anima_lllite.train_batch_size", 1),
+                    minimum=1,
+                    maximum=64,
+                    step=1,
+                )
+                max_train_epochs = gr.Number(
+                    label="Max train epochs",
+                    value=config.get("anima_lllite.max_train_epochs", 10),
+                    precision=0,
+                    info="0 leaves steps-based training if Max train steps is set",
+                )
+                max_train_steps = gr.Number(
+                    label="Max train steps",
+                    value=config.get("anima_lllite.max_train_steps", 0),
+                    precision=0,
+                    info="0 uses epochs only",
+                )
+                caption_extension = gr.Textbox(
+                    label="Caption extension",
+                    value=config.get("anima_lllite.caption_extension", ".txt"),
+                    interactive=True,
+                )
+
+            with gr.Row():
+                cache_latents = gr.Checkbox(
+                    label="Cache latents",
+                    value=config.get("anima_lllite.cache_latents", True),
+                )
+                cache_latents_to_disk = gr.Checkbox(
+                    label="Cache latents to disk",
+                    value=config.get("anima_lllite.cache_latents_to_disk", False),
+                )
+                # Text-encoder cache checkboxes live on the Anima accordion
+                # (animaTraining); wired via FIELD_REGISTRY below.
+
+            with gr.Row():
+                seed = gr.Number(
+                    label="Seed",
+                    value=config.get("anima_lllite.seed", 0),
+                    precision=0,
+                    info="0 lets sd-scripts pick a random seed",
+                )
+                gradient_accumulation_steps = gr.Slider(
+                    label="Gradient accumulate steps",
+                    value=config.get("anima_lllite.gradient_accumulation_steps", 1),
+                    minimum=1,
+                    maximum=120,
+                    step=1,
+                )
+
+        with gr.Accordion("LLLite parameters", open=True), gr.Group():
+            gr.Markdown(
+                "Parameters unique to Anima ControlNet-LLLite. "
+                "`target_layers` accepts a preset name or comma-separated atomic "
+                "specifiers (including `mlp_fc1_pre`). Optional ASPP tail via "
+                "`lllite_use_aspp`."
+            )
+            with gr.Row():
+                cond_emb_dim = gr.Number(
+                    label="Conditioning embedding dim",
+                    value=config.get("anima_lllite.cond_emb_dim", 32),
+                    precision=0,
+                    info="--cond_emb_dim (shared cond_emb width)",
+                )
+                lllite_mlp_dim = gr.Number(
+                    label="LLLite MLP dim",
+                    value=config.get("anima_lllite.lllite_mlp_dim", 64),
+                    precision=0,
+                    info="--lllite_mlp_dim (LoRA-rank-like hidden dim)",
+                )
+                lllite_cond_dim = gr.Number(
+                    label="LLLite cond trunk dim",
+                    value=config.get("anima_lllite.lllite_cond_dim", 64),
+                    precision=0,
+                    info="--lllite_cond_dim (conditioning1 internal width)",
+                )
+                lllite_cond_resblocks = gr.Number(
+                    label="LLLite cond ResBlocks",
+                    value=config.get("anima_lllite.lllite_cond_resblocks", 1),
+                    precision=0,
+                    info="--lllite_cond_resblocks",
+                )
+            with gr.Row():
+                lllite_target_layers = gr.Dropdown(
+                    label="Target layers",
+                    choices=LLLITE_TARGET_LAYER_CHOICES,
+                    value=config.get(
+                        "anima_lllite.lllite_target_layers", "self_attn_q"
+                    ),
+                    allow_custom_value=True,
+                    info="Preset or comma-separated atomic specifiers (e.g. self_attn_q_pre,mlp_fc1_pre)",
+                    interactive=True,
+                )
+                lllite_use_aspp = gr.Checkbox(
+                    label="Use ASPP",
+                    value=config.get("anima_lllite.lllite_use_aspp", False),
+                    info="--lllite_use_aspp: multi-scale ASPP tail on conditioning1",
+                )
+                lllite_dropout = gr.Number(
+                    label="LLLite dropout",
+                    value=config.get("anima_lllite.lllite_dropout", 0),
+                    info="0 disables; otherwise mid-output dropout rate",
+                )
+                lllite_multiplier = gr.Number(
+                    label="LLLite multiplier",
+                    value=config.get("anima_lllite.lllite_multiplier", 1.0),
+                    info="Do not set to 0 (disables LLLite during training)",
+                )
+            with gr.Row():
+                network_weights = gr.Textbox(
+                    label="Network weights (resume LLLite)",
+                    placeholder="(Optional) Path to pretrained LLLite .safetensors",
+                    value=config.get("anima_lllite.network_weights", ""),
+                    interactive=True,
+                )
+                network_weights_file = gr.Button(
+                    document_symbol,
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=(not headless),
+                )
+                network_weights_file.click(
+                    get_any_file_path,
+                    inputs=[network_weights],
+                    outputs=network_weights,
+                    show_progress=False,
+                )
+                lllite_cond_in_channels = gr.Dropdown(
+                    label="Cond in channels",
+                    choices=[3, 4],
+                    value=config.get("anima_lllite.lllite_cond_in_channels", 3),
+                    info="3=RGB control; 4=inpainting (RGB+mask)",
+                    interactive=True,
+                )
+                lllite_inpaint_masked_input = gr.Checkbox(
+                    label="Inpaint masked input",
+                    value=config.get("anima_lllite.lllite_inpaint_masked_input", False),
+                    info="Zero RGB inside mask before concat (only with cond in channels=4)",
+                )
+
+        with gr.Accordion("Training parameters", open=True), gr.Group():
+            with gr.Row():
+                learning_rate = gr.Number(
+                    label="Learning rate",
+                    value=config.get("training.learning_rate", 5e-5),
+                    minimum=0,
+                    maximum=1,
+                )
+                optimizer = gr.Dropdown(
+                    label="Optimizer",
+                    choices=[
+                        "AdamW",
+                        "AdamW8bit",
+                        "PagedAdamW",
+                        "PagedAdamW8bit",
+                        "PagedAdamW32bit",
+                        "Lion8bit",
+                        "PagedLion8bit",
+                        "Lion",
+                        "SGDNesterov",
+                        "SGDNesterov8bit",
+                        "AdaFactor",
+                    ],
+                    value=config.get("training.optimizer", "AdamW8bit"),
+                    interactive=True,
+                )
+                optimizer_args = gr.Textbox(
+                    label="Optimizer extra arguments",
+                    placeholder="(Optional) eg: weight_decay=0.01 betas=0.9,0.999",
+                    value=config.get("training.optimizer_args", ""),
+                    interactive=True,
+                )
+            with gr.Row():
+                lr_scheduler = gr.Dropdown(
+                    label="LR Scheduler",
+                    choices=[
+                        "constant",
+                        "constant_with_warmup",
+                        "cosine",
+                        "cosine_with_restarts",
+                        "linear",
+                        "polynomial",
+                    ],
+                    value=config.get("training.lr_scheduler", "constant"),
+                    interactive=True,
+                )
+                lr_warmup_steps = gr.Number(
+                    label="LR warmup steps",
+                    value=config.get("training.lr_warmup_steps", 0),
+                    precision=0,
+                )
+                lr_scheduler_num_cycles = gr.Number(
+                    label="LR number of cycles",
+                    value=config.get("training.lr_scheduler_num_cycles", ""),
+                    info="Only used with cosine_with_restarts scheduler",
+                )
+                lr_scheduler_power = gr.Number(
+                    label="LR power",
+                    value=config.get("training.lr_scheduler_power", 1),
+                    info="Only used with polynomial scheduler",
+                )
+            with gr.Row():
+                lr_scheduler_args = gr.Textbox(
+                    label="LR Scheduler extra arguments",
+                    placeholder="(Optional) eg: T_max=100",
+                    value=config.get("training.lr_scheduler_args", ""),
+                    interactive=True,
+                )
+                max_grad_norm = gr.Number(
+                    label="Max grad norm",
+                    value=config.get("training.max_grad_norm", 1.0),
+                    info="0 disables gradient clipping",
+                )
+                gradient_checkpointing = gr.Checkbox(
+                    label="Gradient checkpointing",
+                    value=config.get("advanced.gradient_checkpointing", True),
+                )
+                full_fp16 = gr.Checkbox(
+                    label="Full fp16 training",
+                    value=config.get("advanced.full_fp16", False),
+                )
+                full_bf16 = gr.Checkbox(
+                    label="Full bf16 training",
+                    value=config.get("advanced.full_bf16", False),
+                )
+
+            with gr.Row():
+                show_timesteps = gr.Dropdown(
+                    label="Show timesteps",
+                    choices=["", "console", "image"],
+                    value=config.get("anima_lllite.show_timesteps", ""),
+                    info="Visualize timestep sampling then exit (does not train)",
+                )
+                show_timesteps_resolution = gr.Textbox(
+                    label="Show timesteps resolution",
+                    value=config.get("anima_lllite.show_timesteps_resolution", "1024"),
+                    interactive=True,
+                )
+
+        with gr.Accordion("Save, resume and logging", open=False), gr.Group():
+            with gr.Row():
+                save_every_n_epochs = gr.Number(
+                    label="Save every N epochs",
+                    value=config.get("save.save_every_n_epochs", 1),
+                    precision=0,
+                )
+                save_every_n_steps = gr.Number(
+                    label="Save every N steps",
+                    value=config.get("save.save_every_n_steps", 0),
+                    precision=0,
+                )
+                save_last_n_steps = gr.Number(
+                    label="Save last N steps",
+                    value=config.get("save.save_last_n_steps", 0),
+                    precision=0,
+                )
+                save_last_n_steps_state = gr.Number(
+                    label="Save last N steps state",
+                    value=config.get("save.save_last_n_steps_state", 0),
+                    precision=0,
+                )
+            with gr.Row():
+                save_state = gr.Checkbox(
+                    label="Save state",
+                    value=config.get("save.save_state", False),
+                )
+                save_state_on_train_end = gr.Checkbox(
+                    label="Save state on train end",
+                    value=config.get("save.save_state_on_train_end", False),
+                )
+                resume = gr.Textbox(
+                    label="Resume from saved state",
+                    placeholder="(Optional) path to a saved training state to resume from",
+                    value=config.get("save.resume", ""),
+                    interactive=True,
+                )
+                resume_button = gr.Button(
+                    folder_symbol,
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=(not headless),
+                )
+                resume_button.click(
+                    get_folder_path,
+                    outputs=resume,
+                    show_progress=False,
+                )
+            with gr.Row():
+                logging_dir = gr.Textbox(
+                    label="Logging directory",
+                    placeholder="(Optional) directory to output TensorBoard logs",
+                    value=config.get("save.logging_dir", ""),
+                    interactive=True,
+                )
+                logging_dir_button = gr.Button(
+                    folder_symbol,
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=(not headless),
+                )
+                logging_dir_button.click(
+                    get_folder_path,
+                    outputs=logging_dir,
+                    show_progress=False,
+                )
+                log_with = gr.Dropdown(
+                    label="Logging tool",
+                    choices=["", "tensorboard", "wandb", "all"],
+                    value=config.get("save.log_with", ""),
+                )
+            with gr.Row():
+                log_tracker_name = gr.Textbox(
+                    label="Log tracker name",
+                    value=config.get("save.log_tracker_name", ""),
+                    interactive=True,
+                )
+                log_tracker_config = gr.Textbox(
+                    label="Log tracker config",
+                    value=config.get("save.log_tracker_config", ""),
+                    interactive=True,
+                )
+                log_config = gr.Checkbox(
+                    label="Log training configuration",
+                    value=config.get("save.log_config", False),
+                )
+            with gr.Row():
+                wandb_api_key = gr.Textbox(
+                    label="WANDB API Key",
+                    value=config.get("save.wandb_api_key", ""),
+                    interactive=True,
+                )
+                wandb_run_name = gr.Textbox(
+                    label="WANDB run name",
+                    value=config.get("save.wandb_run_name", ""),
+                    interactive=True,
+                )
+
+        executor = CommandExecutor(headless=headless)
+
+        button_print = gr.Button("Print training command")
+
+        FIELD_REGISTRY = [
+            ("pretrained_model_name_or_path", pretrained_model_name_or_path),
+            ("output_dir", output_dir),
+            ("output_name", output_name),
+            ("save_model_as", save_model_as),
+            ("save_precision", save_precision),
+            ("training_comment", training_comment),
+            ("no_metadata", no_metadata),
+            ("train_data_dir", train_data_dir),
+            ("conditioning_data_dir", conditioning_data_dir),
+            ("dataset_config", dataset_config),
+            ("resolution", resolution),
+            ("enable_bucket", enable_bucket),
+            ("min_bucket_reso", min_bucket_reso),
+            ("max_bucket_reso", max_bucket_reso),
+            ("train_batch_size", train_batch_size),
+            ("max_train_epochs", max_train_epochs),
+            ("max_train_steps", max_train_steps),
+            ("caption_extension", caption_extension),
+            ("cache_latents", cache_latents),
+            ("cache_latents_to_disk", cache_latents_to_disk),
+            (
+                "cache_text_encoder_outputs",
+                anima_training.cache_text_encoder_outputs,
+            ),
+            (
+                "cache_text_encoder_outputs_to_disk",
+                anima_training.cache_text_encoder_outputs_to_disk,
+            ),
+            ("seed", seed),
+            ("gradient_accumulation_steps", gradient_accumulation_steps),
+            ("anima_qwen3", anima_training.qwen3),
+            ("anima_vae", anima_training.vae),
+            ("anima_llm_adapter_path", anima_training.llm_adapter_path),
+            ("anima_t5_tokenizer_path", anima_training.t5_tokenizer_path),
+            ("anima_discrete_flow_shift", anima_training.discrete_flow_shift),
+            ("anima_timestep_sampling", anima_training.timestep_sampling),
+            ("anima_sigmoid_scale", anima_training.sigmoid_scale),
+            ("anima_qwen3_max_token_length", anima_training.qwen3_max_token_length),
+            ("anima_t5_max_token_length", anima_training.t5_max_token_length),
+            ("anima_attn_mode", anima_training.attn_mode),
+            ("anima_split_attn", anima_training.split_attn),
+            ("anima_vae_chunk_size", anima_training.vae_chunk_size),
+            ("anima_vae_disable_cache", anima_training.vae_disable_cache),
+            ("anima_qwen_image_vae_2d", anima_training.qwen_image_vae_2d),
+            ("anima_compile", anima_training.compile),
+            ("anima_torch_compile", anima_training.torch_compile),
+            ("anima_compile_backend", anima_training.compile_backend),
+            ("anima_compile_mode", anima_training.compile_mode),
+            ("anima_compile_dynamic", anima_training.compile_dynamic),
+            ("anima_compile_fullgraph", anima_training.compile_fullgraph),
+            (
+                "anima_compile_cache_size_limit",
+                anima_training.compile_cache_size_limit,
+            ),
+            ("cond_emb_dim", cond_emb_dim),
+            ("lllite_mlp_dim", lllite_mlp_dim),
+            ("lllite_target_layers", lllite_target_layers),
+            ("lllite_cond_dim", lllite_cond_dim),
+            ("lllite_cond_resblocks", lllite_cond_resblocks),
+            ("lllite_use_aspp", lllite_use_aspp),
+            ("lllite_dropout", lllite_dropout),
+            ("lllite_multiplier", lllite_multiplier),
+            ("network_weights", network_weights),
+            ("lllite_cond_in_channels", lllite_cond_in_channels),
+            ("lllite_inpaint_masked_input", lllite_inpaint_masked_input),
+            ("learning_rate", learning_rate),
+            ("optimizer", optimizer),
+            ("optimizer_args", optimizer_args),
+            ("lr_scheduler", lr_scheduler),
+            ("lr_scheduler_args", lr_scheduler_args),
+            ("lr_warmup_steps", lr_warmup_steps),
+            ("lr_scheduler_num_cycles", lr_scheduler_num_cycles),
+            ("lr_scheduler_power", lr_scheduler_power),
+            ("max_grad_norm", max_grad_norm),
+            ("gradient_checkpointing", gradient_checkpointing),
+            ("full_fp16", full_fp16),
+            ("full_bf16", full_bf16),
+            ("mixed_precision", accelerate_launch.mixed_precision),
+            (
+                "num_cpu_threads_per_process",
+                accelerate_launch.num_cpu_threads_per_process,
+            ),
+            ("num_processes", accelerate_launch.num_processes),
+            ("num_machines", accelerate_launch.num_machines),
+            ("multi_gpu", accelerate_launch.multi_gpu),
+            ("gpu_ids", accelerate_launch.gpu_ids),
+            ("main_process_port", accelerate_launch.main_process_port),
+            ("dynamo_backend", accelerate_launch.dynamo_backend),
+            ("dynamo_mode", accelerate_launch.dynamo_mode),
+            ("dynamo_use_fullgraph", accelerate_launch.dynamo_use_fullgraph),
+            ("dynamo_use_dynamic", accelerate_launch.dynamo_use_dynamic),
+            (
+                "extra_accelerate_launch_args",
+                accelerate_launch.extra_accelerate_launch_args,
+            ),
+            ("save_every_n_epochs", save_every_n_epochs),
+            ("save_every_n_steps", save_every_n_steps),
+            ("save_last_n_steps", save_last_n_steps),
+            ("save_last_n_steps_state", save_last_n_steps_state),
+            ("save_state", save_state),
+            ("save_state_on_train_end", save_state_on_train_end),
+            ("resume", resume),
+            ("logging_dir", logging_dir),
+            ("log_with", log_with),
+            ("log_tracker_name", log_tracker_name),
+            ("log_tracker_config", log_tracker_config),
+            ("log_config", log_config),
+            ("wandb_api_key", wandb_api_key),
+            ("wandb_run_name", wandb_run_name),
+            ("show_timesteps", show_timesteps),
+            ("show_timesteps_resolution", show_timesteps_resolution),
+        ]
+        settings_list = [comp for _, comp in FIELD_REGISTRY]
+
+        global last_built_field_registry
+        last_built_field_registry = FIELD_REGISTRY
+
+        def _kwargs_from_registry(data: dict) -> dict:
+            return {name: data[comp] for name, comp in FIELD_REGISTRY}
+
+        def _make_open_configuration_entry(ask_for_file_comp):
+            def _entry(data: dict):
+                output_components = [configuration.config_file_name] + settings_list
+                result = open_configuration(
+                    ask_for_file=data[ask_for_file_comp],
+                    file_path=data[configuration.config_file_name],
+                    **_kwargs_from_registry(data),
+                )
+                if result is None:
+                    return {comp: gr.update() for comp in output_components}
+                if len(result) != len(output_components):
+                    raise ValueError(
+                        f"open_configuration returned {len(result)} values, "
+                        f"expected {len(output_components)} "
+                        f"(FIELD_REGISTRY/signature drift?)"
+                    )
+                return dict(zip(output_components, result))
+
+            return _entry
+
+        def _save_configuration_entry(data: dict):
+            return save_configuration(
+                save_as_bool=data[dummy_db_false],
+                file_path=data[configuration.config_file_name],
+                **_kwargs_from_registry(data),
+            )
+
+        def _make_train_model_entry(print_only_comp):
+            def _entry(data: dict):
+                return train_model(
+                    headless=data[dummy_headless],
+                    print_only=data[print_only_comp],
+                    **_kwargs_from_registry(data),
+                )
+
+            return _entry
+
+        open_config_entry = _make_open_configuration_entry(dummy_db_true)
+        load_config_entry = _make_open_configuration_entry(dummy_db_false)
+        train_model_entry = _make_train_model_entry(dummy_db_false)
+        print_command_entry = _make_train_model_entry(dummy_db_true)
+
+        global last_built_gui_entries
+        last_built_gui_entries = {
+            "open_configuration": open_config_entry,
+            "load_configuration": load_config_entry,
+            "save_configuration": _save_configuration_entry,
+            "train_model": train_model_entry,
+            "print_command": print_command_entry,
+            "components": {
+                "dummy_headless": dummy_headless,
+                "dummy_db_true": dummy_db_true,
+                "dummy_db_false": dummy_db_false,
+                "config_file_name": configuration.config_file_name,
+            },
+        }
+
+        configuration.button_open_config.click(
+            open_config_entry,
+            inputs={dummy_db_true, configuration.config_file_name, *settings_list},
+            outputs={configuration.config_file_name, *settings_list},
+            show_progress=False,
+        )
+
+        configuration.button_load_config.click(
+            load_config_entry,
+            inputs={dummy_db_false, configuration.config_file_name, *settings_list},
+            outputs={configuration.config_file_name, *settings_list},
+            show_progress=False,
+        )
+
+        configuration.button_save_config.click(
+            _save_configuration_entry,
+            inputs={dummy_db_false, configuration.config_file_name, *settings_list},
+            outputs=[configuration.config_file_name],
+            show_progress=False,
+        )
+
+        run_state = gr.Textbox(value=train_state_value, visible=False)
+
+        run_state.change(
+            fn=executor.wait_for_training_to_end,
+            outputs=[executor.button_run, executor.button_stop_training],
+        )
+
+        executor.button_run.click(
+            train_model_entry,
+            inputs={dummy_headless, dummy_db_false, *settings_list},
+            outputs=[executor.button_run, executor.button_stop_training, run_state],
+            show_progress=False,
+        )
+
+        executor.button_stop_training.click(
+            executor.kill_command,
+            outputs=[executor.button_run, executor.button_stop_training],
+        )
+
+        button_print.click(
+            print_command_entry,
+            inputs={dummy_headless, dummy_db_true, *settings_list},
+            show_progress=False,
+        )

--- a/kohya_gui/class_anima.py
+++ b/kohya_gui/class_anima.py
@@ -14,17 +14,21 @@ class animaTraining:
         training_type: str = "",
         config: dict = {},
         anima_checkbox: gr.Checkbox = False,
+        always_visible: bool = False,
+        show_unsloth_offload_checkpointing: bool = True,
     ) -> None:
         self.headless = headless
         self.finetuning = finetuning
         self.training_type = training_type
         self.config = config
         self.anima_checkbox = anima_checkbox
+        self.always_visible = always_visible
+        self.show_unsloth_offload_checkpointing = show_unsloth_offload_checkpointing
 
         with gr.Accordion(
             "Anima",
             open=True,
-            visible=False,
+            visible=always_visible,
             elem_classes=["anima_background"],
         ) as anima_accordion:
             with gr.Group():
@@ -203,6 +207,8 @@ class animaTraining:
                         info="Cache text encoder outputs to disk. Automatically enables Cache Text Encoder Outputs.",
                         interactive=True,
                     )
+                    # Anima ControlNet-LLLite asserts if this is set (MVP); hide
+                    # it when the caller is a dedicated LLLite tab.
                     self.unsloth_offload_checkpointing = gr.Checkbox(
                         label="Unsloth Offload Checkpointing",
                         value=self.config.get(
@@ -210,6 +216,7 @@ class animaTraining:
                         ),
                         info="Offload activations to CPU RAM using async non-blocking transfers (faster than CPU Offload Checkpointing). Cannot be combined with CPU Offload Checkpointing or Blocks to swap.",
                         interactive=True,
+                        visible=show_unsloth_offload_checkpointing,
                     )
 
                 with gr.Row():
@@ -284,8 +291,9 @@ class animaTraining:
                     outputs=[self.compile],
                 )
 
-                self.anima_checkbox.change(
-                    lambda anima_checkbox: gr.Accordion(visible=anima_checkbox),
-                    inputs=[self.anima_checkbox],
-                    outputs=[anima_accordion],
-                )
+                if not always_visible:
+                    self.anima_checkbox.change(
+                        lambda anima_checkbox: gr.Accordion(visible=anima_checkbox),
+                        inputs=[self.anima_checkbox],
+                        outputs=[anima_accordion],
+                    )

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -1632,7 +1632,7 @@ def finetune_tab(
             # train_model lists sd3_fused_backward_pass immediately after the
             # cache flags; the pre-registry settings_list had fused later (after
             # batch size). Pair each name with its true widget so dict adapters
-            # do not re-create the old positional mis-wiring.
+            # do not re-create the old positional wiring bug.
             ("sd3_fused_backward_pass", sd3_training.sd3_fused_backward_pass),
             ("clip_g", sd3_training.clip_g),
             ("clip_l", sd3_training.clip_l),

--- a/tests/test_anima_lllite_gui.py
+++ b/tests/test_anima_lllite_gui.py
@@ -1,0 +1,414 @@
+"""Regression tests for GH issue #3525: Anima ControlNet-LLLite training tab.
+
+Covers command generation against anima_train_control_net_lllite.py, LLLite-
+specific args (target_layers, lllite_use_aspp, conditioning dataset), and the
+FIELD_REGISTRY / dict-adapter wiring pattern (GH #3543).
+"""
+
+import inspect
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import gradio as gr
+import toml
+
+from kohya_gui import anima_lllite_gui
+from kohya_gui.class_gui_config import KohyaSSGUIConfig
+from conftest import mock_executor
+
+
+def _default_kwargs(overrides=None):
+    sig = inspect.signature(anima_lllite_gui.train_model)
+    params = [p for p in sig.parameters if p not in ("headless", "print_only")]
+
+    defaults = {
+        "pretrained_model_name_or_path": "/models/anima_dit.safetensors",
+        "output_dir": "",
+        "output_name": "test_anima_lllite",
+        "save_model_as": "safetensors",
+        "save_precision": "bf16",
+        "training_comment": "",
+        "no_metadata": False,
+        "train_data_dir": "/data/train",
+        "conditioning_data_dir": "/data/cond",
+        "dataset_config": "",
+        "resolution": "1024",
+        "enable_bucket": True,
+        "min_bucket_reso": 256,
+        "max_bucket_reso": 2048,
+        "train_batch_size": 1,
+        "max_train_epochs": 10,
+        "max_train_steps": 0,
+        "caption_extension": ".txt",
+        "cache_latents": True,
+        "cache_latents_to_disk": False,
+        "cache_text_encoder_outputs": True,
+        "cache_text_encoder_outputs_to_disk": False,
+        "seed": 0,
+        "gradient_accumulation_steps": 1,
+        "anima_qwen3": "/models/qwen3_0.6b.safetensors",
+        "anima_vae": "/models/qwen_image_vae_fp16.safetensors",
+        "anima_llm_adapter_path": "",
+        "anima_t5_tokenizer_path": "",
+        "anima_discrete_flow_shift": 3.0,
+        "anima_timestep_sampling": "shift",
+        "anima_sigmoid_scale": 1.0,
+        "anima_qwen3_max_token_length": 512,
+        "anima_t5_max_token_length": 512,
+        "anima_attn_mode": "torch",
+        "anima_split_attn": False,
+        "anima_vae_chunk_size": 64,
+        "anima_vae_disable_cache": True,
+        "anima_qwen_image_vae_2d": False,
+        "anima_compile": False,
+        "anima_torch_compile": False,
+        "anima_compile_backend": "inductor",
+        "anima_compile_mode": "default",
+        "anima_compile_dynamic": "auto",
+        "anima_compile_fullgraph": False,
+        "anima_compile_cache_size_limit": 0,
+        "cond_emb_dim": 32,
+        "lllite_mlp_dim": 64,
+        "lllite_target_layers": "self_attn_q",
+        "lllite_cond_dim": 64,
+        "lllite_cond_resblocks": 1,
+        "lllite_use_aspp": False,
+        "lllite_dropout": 0,
+        "lllite_multiplier": 1.0,
+        "network_weights": "",
+        "lllite_cond_in_channels": 3,
+        "lllite_inpaint_masked_input": False,
+        "learning_rate": 5e-5,
+        "optimizer": "AdamW8bit",
+        "optimizer_args": "",
+        "lr_scheduler": "constant",
+        "lr_scheduler_args": "",
+        "lr_warmup_steps": 0,
+        "lr_scheduler_num_cycles": "",
+        "lr_scheduler_power": 1,
+        "max_grad_norm": 1.0,
+        "gradient_checkpointing": True,
+        "full_fp16": False,
+        "full_bf16": False,
+        "mixed_precision": "bf16",
+        "num_cpu_threads_per_process": 1,
+        "num_processes": 1,
+        "num_machines": 1,
+        "multi_gpu": False,
+        "gpu_ids": "",
+        "main_process_port": 0,
+        "dynamo_backend": "no",
+        "dynamo_mode": "default",
+        "dynamo_use_fullgraph": False,
+        "dynamo_use_dynamic": False,
+        "extra_accelerate_launch_args": "",
+        "save_every_n_epochs": 1,
+        "save_every_n_steps": 0,
+        "save_last_n_steps": 0,
+        "save_last_n_steps_state": 0,
+        "save_state": False,
+        "save_state_on_train_end": False,
+        "resume": "",
+        "logging_dir": "",
+        "log_with": "",
+        "log_tracker_name": "",
+        "log_tracker_config": "",
+        "log_config": False,
+        "wandb_api_key": "",
+        "wandb_run_name": "",
+        "show_timesteps": "",
+        "show_timesteps_resolution": "1024",
+    }
+
+    missing = [p for p in params if p not in defaults]
+    assert not missing, f"_default_kwargs is missing params: {missing}"
+
+    kwargs = {p: defaults[p] for p in params}
+    kwargs["headless"] = True
+    kwargs["print_only"] = True
+    if overrides:
+        kwargs.update(overrides)
+    return kwargs
+
+
+def _make_path_fixtures(tmpdir):
+    """Create placeholder model files and dataset dirs so path validation passes."""
+    models = os.path.join(tmpdir, "models")
+    train = os.path.join(tmpdir, "train")
+    cond = os.path.join(tmpdir, "cond")
+    os.makedirs(models, exist_ok=True)
+    os.makedirs(train, exist_ok=True)
+    os.makedirs(cond, exist_ok=True)
+
+    dit = os.path.join(models, "anima_dit.safetensors")
+    qwen3 = os.path.join(models, "qwen3_0.6b.safetensors")
+    vae = os.path.join(models, "qwen_image_vae_fp16.safetensors")
+    for path in (dit, qwen3, vae):
+        with open(path, "wb") as f:
+            f.write(b"0")
+
+    return {
+        "pretrained_model_name_or_path": dit,
+        "anima_qwen3": qwen3,
+        "anima_vae": vae,
+        "train_data_dir": train,
+        "conditioning_data_dir": cond,
+        "output_dir": os.path.join(tmpdir, "out"),
+    }
+
+
+def _run_and_load_toml(overrides=None):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path_defaults = _make_path_fixtures(tmpdir)
+        os.makedirs(path_defaults["output_dir"], exist_ok=True)
+        kwargs = _default_kwargs({**path_defaults, **(overrides or {})})
+        # If a test overrides dataset_config only, keep real conditioning
+        # paths unless the override explicitly blanks them.
+        mock_executor(anima_lllite_gui)
+        with patch.object(
+            anima_lllite_gui, "get_executable_path", return_value="accelerate"
+        ):
+            with patch.object(anima_lllite_gui, "print_command_and_toml") as mocked:
+                anima_lllite_gui.train_model(**kwargs)
+                assert mocked.called, "train_model did not emit a command"
+                run_cmd = mocked.call_args[0][0]
+                tmpfilename = mocked.call_args[0][1]
+                with open(tmpfilename, encoding="utf-8") as f:
+                    config = toml.load(f)
+        return run_cmd, config, path_defaults
+
+
+class TestAnimaLlliteCommandGeneration(unittest.TestCase):
+    def test_invokes_anima_train_control_net_lllite(self):
+        run_cmd, _config, _paths = _run_and_load_toml({})
+        self.assertTrue(
+            any("anima_train_control_net_lllite.py" in part for part in run_cmd)
+        )
+
+    def test_does_not_invoke_lora_or_sdxl_lllite_scripts(self):
+        run_cmd, _config, _paths = _run_and_load_toml({})
+        joined = " ".join(run_cmd)
+        self.assertNotIn("anima_train_network.py", joined)
+        self.assertNotIn("sdxl_train_control_net_lllite.py", joined)
+
+    def test_conditioning_dataset_paths_are_forwarded(self):
+        _run_cmd, config, paths = _run_and_load_toml({})
+        self.assertEqual(config.get("train_data_dir"), paths["train_data_dir"])
+        self.assertEqual(
+            config.get("conditioning_data_dir"), paths["conditioning_data_dir"]
+        )
+
+    def test_dataset_config_skips_folder_args(self):
+        _run_cmd, config, _paths = _run_and_load_toml(
+            {
+                "dataset_config": "test/config/dataset.toml",
+                "train_data_dir": "/ignored/train",
+                "conditioning_data_dir": "/ignored/cond",
+            }
+        )
+        self.assertEqual(config.get("dataset_config"), "test/config/dataset.toml")
+        self.assertNotIn("train_data_dir", config)
+        self.assertNotIn("conditioning_data_dir", config)
+
+    def test_missing_dataset_aborts_training(self):
+        mock_executor(anima_lllite_gui)
+        with patch.object(anima_lllite_gui, "print_command_and_toml") as mocked:
+            with patch.object(
+                anima_lllite_gui, "get_executable_path", return_value="accelerate"
+            ):
+                kwargs = _default_kwargs(
+                    {
+                        "train_data_dir": "",
+                        "conditioning_data_dir": "",
+                        "dataset_config": "",
+                    }
+                )
+                anima_lllite_gui.train_model(**kwargs)
+                mocked.assert_not_called()
+
+    def test_missing_conditioning_dir_aborts_without_dataset_config(self):
+        mock_executor(anima_lllite_gui)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            train = os.path.join(tmpdir, "train")
+            os.makedirs(train)
+            with patch.object(anima_lllite_gui, "print_command_and_toml") as mocked:
+                with patch.object(
+                    anima_lllite_gui, "get_executable_path", return_value="accelerate"
+                ):
+                    kwargs = _default_kwargs(
+                        {
+                            "train_data_dir": train,
+                            "conditioning_data_dir": "",
+                            "dataset_config": "",
+                        }
+                    )
+                    anima_lllite_gui.train_model(**kwargs)
+                    mocked.assert_not_called()
+
+    def test_lllite_target_layers_are_forwarded(self):
+        _run_cmd, config, _paths = _run_and_load_toml(
+            {"lllite_target_layers": "self_attn_q_pre,mlp_fc1_pre"}
+        )
+        self.assertEqual(
+            config.get("lllite_target_layers"), "self_attn_q_pre,mlp_fc1_pre"
+        )
+
+    def test_lllite_use_aspp_forwarded_when_enabled(self):
+        _run_cmd, config, _paths = _run_and_load_toml({"lllite_use_aspp": True})
+        self.assertTrue(config.get("lllite_use_aspp"))
+
+    def test_lllite_use_aspp_omitted_when_disabled(self):
+        _run_cmd, config, _paths = _run_and_load_toml({"lllite_use_aspp": False})
+        self.assertNotIn("lllite_use_aspp", config)
+
+    def test_lllite_dims_are_forwarded(self):
+        _run_cmd, config, _paths = _run_and_load_toml(
+            {
+                "cond_emb_dim": 48,
+                "lllite_mlp_dim": 96,
+                "lllite_cond_dim": 80,
+                "lllite_cond_resblocks": 2,
+                "lllite_multiplier": 0.5,
+            }
+        )
+        self.assertEqual(config.get("cond_emb_dim"), 48)
+        self.assertEqual(config.get("lllite_mlp_dim"), 96)
+        self.assertEqual(config.get("lllite_cond_dim"), 80)
+        self.assertEqual(config.get("lllite_cond_resblocks"), 2)
+        self.assertEqual(config.get("lllite_multiplier"), 0.5)
+
+    def test_inpaint_cond_channels_and_mask_flag(self):
+        _run_cmd, config, _paths = _run_and_load_toml(
+            {
+                "lllite_cond_in_channels": 4,
+                "lllite_inpaint_masked_input": True,
+            }
+        )
+        self.assertEqual(config.get("lllite_cond_in_channels"), 4)
+        self.assertTrue(config.get("lllite_inpaint_masked_input"))
+
+    def test_anima_model_paths_are_forwarded(self):
+        _run_cmd, config, paths = _run_and_load_toml({})
+        self.assertEqual(config.get("qwen3"), paths["anima_qwen3"])
+        self.assertEqual(config.get("vae"), paths["anima_vae"])
+        self.assertEqual(
+            config.get("pretrained_model_name_or_path"),
+            paths["pretrained_model_name_or_path"],
+        )
+
+    def test_optional_anima_paths_omitted_when_blank(self):
+        _run_cmd, config, _paths = _run_and_load_toml({})
+        self.assertNotIn("llm_adapter_path", config)
+        self.assertNotIn("t5_tokenizer_path", config)
+
+    def test_flow_matching_params_are_forwarded(self):
+        _run_cmd, config, _paths = _run_and_load_toml({})
+        self.assertEqual(config.get("discrete_flow_shift"), 3.0)
+        self.assertEqual(config.get("timestep_sampling"), "shift")
+        self.assertEqual(config.get("sigmoid_scale"), 1.0)
+
+    def test_unsupported_mvp_flags_are_never_emitted(self):
+        """Backend asserts if these are set; the GUI must not write them."""
+        _run_cmd, config, _paths = _run_and_load_toml({})
+        for key in (
+            "blocks_to_swap",
+            "cpu_offload_checkpointing",
+            "unsloth_offload_checkpointing",
+            "deepspeed",
+            "fused_backward_pass",
+        ):
+            self.assertNotIn(key, config)
+
+    def test_compile_and_torch_compile_together_blocks_training(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_defaults = _make_path_fixtures(tmpdir)
+            mock_executor(anima_lllite_gui)
+            with patch.object(anima_lllite_gui, "print_command_and_toml") as mocked:
+                with patch.object(
+                    anima_lllite_gui, "get_executable_path", return_value="accelerate"
+                ):
+                    kwargs = _default_kwargs(
+                        {
+                            **path_defaults,
+                            "anima_compile": True,
+                            "anima_torch_compile": True,
+                        }
+                    )
+                    anima_lllite_gui.train_model(**kwargs)
+                    mocked.assert_not_called()
+
+    def test_missing_anima_model_paths_abort(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_defaults = _make_path_fixtures(tmpdir)
+            mock_executor(anima_lllite_gui)
+            with patch.object(anima_lllite_gui, "print_command_and_toml") as mocked:
+                with patch.object(
+                    anima_lllite_gui, "get_executable_path", return_value="accelerate"
+                ):
+                    kwargs = _default_kwargs(
+                        {
+                            **path_defaults,
+                            "anima_qwen3": "",
+                            "anima_vae": "",
+                        }
+                    )
+                    anima_lllite_gui.train_model(**kwargs)
+                    mocked.assert_not_called()
+
+
+class TestAnimaLlliteFieldRegistry(unittest.TestCase):
+    """FIELD_REGISTRY must stay aligned with train_model/save/open signatures."""
+
+    @classmethod
+    def setUpClass(cls):
+        with gr.Blocks():
+            anima_lllite_gui.anima_lllite_tab(headless=True, config=KohyaSSGUIConfig())
+        cls.field_registry = anima_lllite_gui.last_built_field_registry
+
+    def test_field_registry_was_built(self):
+        self.assertIsNotNone(self.field_registry)
+        self.assertGreater(len(self.field_registry), 0)
+
+    def test_field_registry_names_are_unique(self):
+        names = [name for name, _ in self.field_registry]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_field_registry_matches_train_model_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        train_model_params = list(
+            inspect.signature(anima_lllite_gui.train_model).parameters
+        )
+        self.assertEqual(registry_names, train_model_params[2:])
+
+    def test_field_registry_matches_save_configuration_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        save_config_params = list(
+            inspect.signature(anima_lllite_gui.save_configuration).parameters
+        )
+        # save_configuration's first two params are save_as_bool, file_path
+        self.assertEqual(registry_names, save_config_params[2:])
+
+    def test_field_registry_matches_open_configuration_signature(self):
+        registry_names = [name for name, _ in self.field_registry]
+        open_config_params = list(
+            inspect.signature(anima_lllite_gui.open_configuration).parameters
+        )
+        # open_configuration's first two params are ask_for_file, file_path
+        self.assertEqual(registry_names, open_config_params[2:])
+
+    def test_unsupported_mvp_widgets_are_not_in_registry(self):
+        names = {name for name, _ in self.field_registry}
+        for forbidden in (
+            "blocks_to_swap",
+            "cpu_offload_checkpointing",
+            "unsloth_offload_checkpointing",
+            "deepspeed",
+            "fused_backward_pass",
+        ):
+            self.assertNotIn(forbidden, names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_finetune_gui.py
+++ b/tests/test_finetune_gui.py
@@ -201,7 +201,7 @@ class TestFinetuneGuiFieldRegistry(unittest.TestCase):
         self.assertEqual(registry_names, open_config_params[3:-1])
 
     def test_sd3_registry_names_map_to_matching_widget_labels(self):
-        # Regression for the finetune SD3 mis-association: the old settings_list
+        # Regression for the finetune SD3 field association bug: the old settings_list
         # ordered clip_g before sd3_fused_backward_pass while train_model's
         # signature has fused first. Pairing by index then labeled fused as
         # "CLIP-G Path". Assert labels match the intended widgets.


### PR DESCRIPTION
## Summary

- Adds a dedicated **Anima LLLite** tab (`kohya_gui/anima_lllite_gui.py`) that launches `sd-scripts/anima_train_control_net_lllite.py`.
- Exposes ControlNet-format dataset config (`train_data_dir` + `conditioning_data_dir`, or dataset TOML), `lllite_target_layers` (including `mlp_fc1_pre`), and `--lllite_use_aspp`.
- Does **not** expose unsupported MVP options (`blocks_to_swap`, `cpu_offload_checkpointing`, `unsloth_offload_checkpointing`, `deepspeed`, `fused_backward_pass`).
- Reuses `animaTraining` with `always_visible` and hides Unsloth offload for this tab.

Closes #3525

## Test plan

- [x] `pytest tests/test_anima_lllite_gui.py` (23 tests)
- [x] Full `pytest tests/` — new tests pass; 3 pre-existing LoRA failures from missing `accelerate` on PATH (unrelated)
- [ ] Manual smoke: open Anima LLLite tab, set model/dataset/LLLite options, Print training command, confirm `anima_train_control_net_lllite.py` and key args appear
