### PR TITLE
feat: Anima full fine-tune support on Finetune tab (#3523)

### DIFF
--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -40,6 +40,7 @@ from .class_huggingface import HuggingFace
 from .class_metadata import MetaData
 from .class_gui_config import KohyaSSGUIConfig
 from .class_flux1 import flux1Training
+from .class_anima import animaTraining
 
 from .custom_logging import setup_logging
 
@@ -259,6 +260,32 @@ def save_configuration(
     show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
+    # Anima
+    anima_cache_text_encoder_outputs,
+    anima_cache_text_encoder_outputs_to_disk,
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_unsloth_offload_checkpointing,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
+    anima_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -478,6 +505,32 @@ def open_configuration(
     show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
+    # Anima
+    anima_cache_text_encoder_outputs,
+    anima_cache_text_encoder_outputs_to_disk,
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_unsloth_offload_checkpointing,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
+    anima_checkbox,
     training_preset,
 ):
     # Get list of function parameters and values
@@ -703,6 +756,32 @@ def train_model(
     show_timesteps_resolution,
     mem_eff_save,
     apply_t5_attn_mask,
+    # Anima
+    anima_cache_text_encoder_outputs,
+    anima_cache_text_encoder_outputs_to_disk,
+    anima_qwen3,
+    anima_vae,
+    anima_llm_adapter_path,
+    anima_t5_tokenizer_path,
+    anima_discrete_flow_shift,
+    anima_timestep_sampling,
+    anima_sigmoid_scale,
+    anima_qwen3_max_token_length,
+    anima_t5_max_token_length,
+    anima_attn_mode,
+    anima_split_attn,
+    anima_vae_chunk_size,
+    anima_vae_disable_cache,
+    anima_unsloth_offload_checkpointing,
+    anima_qwen_image_vae_2d,
+    anima_compile,
+    anima_torch_compile,
+    anima_compile_backend,
+    anima_compile_mode,
+    anima_compile_dynamic,
+    anima_compile_fullgraph,
+    anima_compile_cache_size_limit,
+    anima_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -724,11 +803,20 @@ def train_model(
 
     log.info(f"Validating lr scheduler arguments...")
     if not validate_args_setting(lr_scheduler_args):
-        return
+        return TRAIN_BUTTON_VISIBLE
 
     log.info(f"Validating optimizer arguments...")
     if not validate_args_setting(optimizer_args):
-        return
+        return TRAIN_BUTTON_VISIBLE
+
+    # Backend mirrors this as a startup assertion (see anima_train.py);
+    # the GUI checkboxes already clear one another on change, but validate again
+    # here in case a saved/edited config re-enables both.
+    if anima_checkbox and anima_compile and anima_torch_compile:
+        log.error(
+            "Per-block Torch Compile and Legacy Torch Compile cannot both be enabled at the same time."
+        )
+        return TRAIN_BUTTON_VISIBLE
 
     if train_dir != "" and not os.path.exists(train_dir):
         os.mkdir(train_dir)
@@ -939,6 +1027,8 @@ def train_model(
         run_cmd.append(rf"{scriptdir}/sd-scripts/sd3_train.py")
     elif flux1_checkbox:
         run_cmd.append(rf"{scriptdir}/sd-scripts/flux_train.py")
+    elif anima_checkbox:
+        run_cmd.append(rf"{scriptdir}/sd-scripts/anima_train.py")
     else:
         run_cmd.append(rf"{scriptdir}/sd-scripts/fine_tune.py")
 
@@ -951,14 +1041,19 @@ def train_model(
         (sdxl_checkbox and sdxl_cache_text_encoder_outputs)
         or (sd3_checkbox and sd3_cache_text_encoder_outputs)
         or (flux1_checkbox and flux1_cache_text_encoder_outputs)
+        or (anima_checkbox and anima_cache_text_encoder_outputs)
     )
     cache_text_encoder_outputs_to_disk = (
-        sd3_checkbox and sd3_cache_text_encoder_outputs_to_disk
-    ) or (flux1_checkbox and flux1_cache_text_encoder_outputs_to_disk)
+        (sd3_checkbox and sd3_cache_text_encoder_outputs_to_disk)
+        or (flux1_checkbox and flux1_cache_text_encoder_outputs_to_disk)
+        or (anima_checkbox and anima_cache_text_encoder_outputs_to_disk)
+    )
     no_half_vae = sdxl_checkbox and sdxl_no_half_vae
 
     # --train_inpainting is only supported by fine_tune.py/sdxl_train.py
-    train_inpainting = train_inpainting and not (sd3_checkbox or flux1_checkbox)
+    train_inpainting = train_inpainting and not (
+        sd3_checkbox or flux1_checkbox or anima_checkbox
+    )
     if train_inpainting:
         # Masks are generated randomly per training step from the source
         # image, so latent caching cannot be used at the same time.
@@ -1003,7 +1098,7 @@ def train_model(
         "caption_dropout_rate": caption_dropout_rate,
         "caption_extension": caption_extension,
         "clip_l": flux1_clip_l if flux1_checkbox else clip_l if sd3_checkbox else None,
-        "clip_skip": clip_skip if clip_skip != 0 else None,
+        "clip_skip": (clip_skip if clip_skip != 0 and not anima_checkbox else None),
         "color_aug": color_aug,
         "dataset_config": dataset_config,
         "dataset_repeats": int(dataset_repeats),
@@ -1059,7 +1154,7 @@ def train_model(
         "masked_loss": masked_loss,
         "max_bucket_reso": int(max_bucket_reso),
         "max_timestep": max_timestep if max_timestep != 0 else None,
-        "max_token_length": int(max_token_length),
+        "max_token_length": (int(max_token_length) if not anima_checkbox else None),
         "max_train_epochs": (
             int(max_train_epochs) if int(max_train_epochs) != 0 else None
         ),
@@ -1131,6 +1226,7 @@ def train_model(
         "v2": v2,
         "v_parameterization": v_parameterization,
         "v_pred_like_loss": v_pred_like_loss if v_pred_like_loss != 0 else None,
+        "vae": anima_vae if anima_checkbox else None,
         "vae_batch_size": vae_batch_size if vae_batch_size != 0 else None,
         "wandb_api_key": wandb_api_key,
         "wandb_run_name": wandb_run_name if wandb_run_name != "" else output_name,
@@ -1159,9 +1255,17 @@ def train_model(
         "ae": ae if flux1_checkbox else None,
         # "clip_l": see previous assignment above for code
         # "t5xxl": see previous assignment above for code
-        "discrete_flow_shift": discrete_flow_shift if flux1_checkbox else None,
+        "discrete_flow_shift": (
+            float(anima_discrete_flow_shift)
+            if anima_checkbox
+            else discrete_flow_shift if flux1_checkbox else None
+        ),
         "model_prediction_type": model_prediction_type if flux1_checkbox else None,
-        "timestep_sampling": timestep_sampling if flux1_checkbox else None,
+        "timestep_sampling": (
+            anima_timestep_sampling
+            if anima_checkbox
+            else timestep_sampling if flux1_checkbox else None
+        ),
         # split_mode/train_blocks are LoRA-only (flux_train_network.py); this
         # tab only ever targets flux_train.py, which does not accept them.
         "split_mode": None,
@@ -1174,21 +1278,80 @@ def train_model(
         "cpu_offload_checkpointing": (
             cpu_offload_checkpointing if flux1_checkbox else None
         ),
-        "blocks_to_swap": blocks_to_swap if flux1_checkbox else None,
+        "blocks_to_swap": (
+            blocks_to_swap if flux1_checkbox or anima_checkbox else None
+        ),
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
         "show_timesteps": (
             show_timesteps
-            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
             else None
         ),
         "show_timesteps_resolution": (
             show_timesteps_resolution
-            if (flux1_checkbox or sd3_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
             else None
         ),
         "mem_eff_save": mem_eff_save if flux1_checkbox else None,
         "apply_t5_attn_mask": apply_t5_attn_mask if flux1_checkbox else None,
+        # Anima specific parameters
+        "sigmoid_scale": (float(anima_sigmoid_scale) if anima_checkbox else None),
+        "attn_mode": (
+            anima_attn_mode if anima_checkbox and anima_attn_mode != "torch" else None
+        ),
+        "split_attn": anima_split_attn if anima_checkbox else None,
+        "vae_chunk_size": (
+            int(anima_vae_chunk_size)
+            if anima_checkbox and anima_vae_chunk_size
+            else None
+        ),
+        "qwen3": anima_qwen3 if anima_checkbox else None,
+        "llm_adapter_path": (
+            anima_llm_adapter_path
+            if anima_checkbox and anima_llm_adapter_path
+            else None
+        ),
+        "t5_tokenizer_path": (
+            anima_t5_tokenizer_path
+            if anima_checkbox and anima_t5_tokenizer_path
+            else None
+        ),
+        "qwen3_max_token_length": (
+            int(anima_qwen3_max_token_length) if anima_checkbox else None
+        ),
+        "t5_max_token_length": (
+            int(anima_t5_max_token_length) if anima_checkbox else None
+        ),
+        "vae_disable_cache": anima_vae_disable_cache if anima_checkbox else None,
+        "unsloth_offload_checkpointing": (
+            anima_unsloth_offload_checkpointing if anima_checkbox else None
+        ),
+        "qwen_image_vae_2d": (anima_qwen_image_vae_2d if anima_checkbox else None),
+        # `--compile` (per-block) and `--torch_compile` (accelerate dynamo) are
+        # mutually exclusive at the backend; the GUI already prevents both
+        # checkboxes from being enabled together (see class_anima.py).
+        "compile": anima_compile if anima_checkbox else None,
+        "torch_compile": anima_torch_compile if anima_checkbox else None,
+        "compile_backend": (
+            anima_compile_backend if anima_checkbox and anima_compile else None
+        ),
+        "compile_mode": (
+            anima_compile_mode if anima_checkbox and anima_compile else None
+        ),
+        "compile_dynamic": (
+            anima_compile_dynamic
+            if anima_checkbox and anima_compile and anima_compile_dynamic != "auto"
+            else None
+        ),
+        "compile_fullgraph": (
+            anima_compile_fullgraph if anima_checkbox and anima_compile else None
+        ),
+        "compile_cache_size_limit": (
+            int(anima_compile_cache_size_limit)
+            if anima_checkbox and anima_compile and anima_compile_cache_size_limit
+            else None
+        ),
     }
 
     # Given dictionary `config_toml_data`
@@ -1407,6 +1570,14 @@ def finetune_tab(
             # Add SD3 Parameters
             sd3_training = sd3Training(
                 headless=headless, config=config, sd3_checkbox=source_model.sd3_checkbox
+            )
+
+            # Add Anima Parameters
+            anima_training = animaTraining(
+                headless=headless,
+                config=config,
+                anima_checkbox=source_model.anima_checkbox,
+                finetuning=True,
             )
 
             with gr.Accordion("Advanced", open=False, elem_id="advanced_tab"):
@@ -1675,6 +1846,43 @@ def finetune_tab(
             ("show_timesteps_resolution", advanced_training.show_timesteps_resolution),
             ("mem_eff_save", flux1_training.mem_eff_save),
             ("apply_t5_attn_mask", flux1_training.apply_t5_attn_mask),
+            (
+                "anima_cache_text_encoder_outputs",
+                anima_training.cache_text_encoder_outputs,
+            ),
+            (
+                "anima_cache_text_encoder_outputs_to_disk",
+                anima_training.cache_text_encoder_outputs_to_disk,
+            ),
+            ("anima_qwen3", anima_training.qwen3),
+            ("anima_vae", anima_training.vae),
+            ("anima_llm_adapter_path", anima_training.llm_adapter_path),
+            ("anima_t5_tokenizer_path", anima_training.t5_tokenizer_path),
+            ("anima_discrete_flow_shift", anima_training.discrete_flow_shift),
+            ("anima_timestep_sampling", anima_training.timestep_sampling),
+            ("anima_sigmoid_scale", anima_training.sigmoid_scale),
+            ("anima_qwen3_max_token_length", anima_training.qwen3_max_token_length),
+            ("anima_t5_max_token_length", anima_training.t5_max_token_length),
+            ("anima_attn_mode", anima_training.attn_mode),
+            ("anima_split_attn", anima_training.split_attn),
+            ("anima_vae_chunk_size", anima_training.vae_chunk_size),
+            ("anima_vae_disable_cache", anima_training.vae_disable_cache),
+            (
+                "anima_unsloth_offload_checkpointing",
+                anima_training.unsloth_offload_checkpointing,
+            ),
+            ("anima_qwen_image_vae_2d", anima_training.qwen_image_vae_2d),
+            ("anima_compile", anima_training.compile),
+            ("anima_torch_compile", anima_training.torch_compile),
+            ("anima_compile_backend", anima_training.compile_backend),
+            ("anima_compile_mode", anima_training.compile_mode),
+            ("anima_compile_dynamic", anima_training.compile_dynamic),
+            ("anima_compile_fullgraph", anima_training.compile_fullgraph),
+            (
+                "anima_compile_cache_size_limit",
+                anima_training.compile_cache_size_limit,
+            ),
+            ("anima_checkbox", source_model.anima_checkbox),
         ]
         settings_list = [comp for _, comp in FIELD_REGISTRY]
 

--- a/tests/test_anima_finetune_gui.py
+++ b/tests/test_anima_finetune_gui.py
@@ -1,0 +1,278 @@
+"""Regression tests for GH issue #3523: Anima full fine-tune support in the
+GUI (finetune tab → anima_train.py).
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import finetune_gui
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_toml,
+    mock_executor,
+)
+
+FIXTURE = "test/config/finetune-AdamW-toml.json"
+
+NUMERIC_FIXUPS = (
+    "lr_warmup_steps",
+    "huber_scale",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "logit_mean",
+    "logit_std",
+    "mode_scale",
+    "sd3_text_encoder_batch_size",
+    "t5xxl_max_token_length",
+    "guidance_scale",
+    "blocks_to_swap",
+    "single_blocks_to_swap",
+    "double_blocks_to_swap",
+    "discrete_flow_shift",
+    "anima_discrete_flow_shift",
+    "anima_sigmoid_scale",
+    "anima_qwen3_max_token_length",
+    "anima_t5_max_token_length",
+    "anima_vae_chunk_size",
+    "anima_compile_cache_size_limit",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "clip_g",
+    "t5xxl",
+    "flux1_clip_l",
+    "flux1_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "log_config",
+    "lr_scheduler_type",
+    "model_prediction_type",
+    "timestep_sampling",
+    "weighting_scheme",
+    "anima_qwen3",
+    "anima_vae",
+    "anima_llm_adapter_path",
+    "anima_t5_tokenizer_path",
+    "anima_timestep_sampling",
+    "anima_attn_mode",
+    "anima_compile_backend",
+    "anima_compile_mode",
+    "anima_compile_dynamic",
+)
+
+ANIMA_OVERRIDES = {
+    "anima_checkbox": True,
+    "anima_qwen3": "/models/qwen3_0.6b.safetensors",
+    "anima_vae": "/models/qwen_image_vae_fp16.safetensors",
+    "anima_llm_adapter_path": "",
+    "anima_t5_tokenizer_path": "",
+    "anima_discrete_flow_shift": 1.0,
+    "anima_timestep_sampling": "sigmoid",
+    "anima_sigmoid_scale": 1.0,
+    "anima_qwen3_max_token_length": 512,
+    "anima_t5_max_token_length": 512,
+    "anima_attn_mode": "torch",
+    "anima_split_attn": False,
+    "anima_vae_chunk_size": 0,
+    "anima_vae_disable_cache": False,
+    "anima_unsloth_offload_checkpointing": False,
+}
+
+
+class TestAnimaFinetuneConfigOutput(unittest.TestCase):
+    """End-to-end: train_model(print_only=True) writes a real TOML file we
+    can inspect for the Anima-specific keys #3523 requires.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**ANIMA_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(finetune_gui, kwargs)
+
+    def test_script_selection_invokes_anima_train(self):
+        with patch.object(finetune_gui, "print_command_and_toml") as mocked:
+            kwargs = build_train_model_kwargs(
+                finetune_gui.train_model,
+                FIXTURE,
+                numeric_fixups=NUMERIC_FIXUPS,
+                string_overrides=STRING_OVERRIDES,
+                overrides=ANIMA_OVERRIDES,
+            )
+            mock_executor(finetune_gui)
+            with patch.object(
+                finetune_gui, "get_executable_path", return_value="accelerate"
+            ):
+                finetune_gui.train_model(**kwargs)
+            self.assertTrue(mocked.called)
+            run_cmd = mocked.call_args[0][0]
+            self.assertTrue(
+                any("anima_train.py" in part for part in run_cmd),
+                f"expected anima_train.py in {run_cmd}",
+            )
+            joined = " ".join(str(p) for p in run_cmd)
+            self.assertNotIn("anima_train_network.py", joined)
+            self.assertNotIn("flux_train.py", joined)
+            self.assertNotIn("fine_tune.py", joined)
+
+    def test_model_paths_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("qwen3"), "/models/qwen3_0.6b.safetensors")
+        self.assertEqual(config.get("vae"), "/models/qwen_image_vae_fp16.safetensors")
+
+    def test_optional_model_paths_are_omitted_when_blank(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("llm_adapter_path", config)
+        self.assertNotIn("t5_tokenizer_path", config)
+
+    def test_optional_model_paths_are_forwarded_when_set(self):
+        config = self._run_and_load_toml(
+            {
+                "anima_llm_adapter_path": "/models/llm_adapter.safetensors",
+                "anima_t5_tokenizer_path": "/models/t5_tokenizer",
+            }
+        )
+        self.assertEqual(
+            config.get("llm_adapter_path"), "/models/llm_adapter.safetensors"
+        )
+        self.assertEqual(config.get("t5_tokenizer_path"), "/models/t5_tokenizer")
+
+    def test_flow_matching_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("discrete_flow_shift"), 1.0)
+        self.assertEqual(config.get("timestep_sampling"), "sigmoid")
+        self.assertEqual(config.get("sigmoid_scale"), 1.0)
+
+    def test_token_length_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("qwen3_max_token_length"), 512)
+        self.assertEqual(config.get("t5_max_token_length"), 512)
+
+    def test_incompatible_sd_args_are_excluded(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("max_token_length", config)
+        self.assertNotIn("clip_skip", config)
+
+    def test_lora_only_args_are_excluded(self):
+        """Full fine-tune must never emit LoRA network keys."""
+        config = self._run_and_load_toml({})
+        self.assertNotIn("network_module", config)
+        self.assertNotIn("network_dim", config)
+        self.assertNotIn("network_alpha", config)
+
+    def test_attn_mode_omitted_when_default(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("attn_mode", config)
+
+    def test_attn_mode_forwarded_when_non_default(self):
+        config = self._run_and_load_toml({"anima_attn_mode": "xformers"})
+        self.assertEqual(config.get("attn_mode"), "xformers")
+
+    def test_train_inpainting_dropped_for_anima_backend(self):
+        config = self._run_and_load_toml({"train_inpainting": True})
+        self.assertNotIn("train_inpainting", config)
+
+    def test_text_encoder_cache_forwarded(self):
+        config = self._run_and_load_toml(
+            {
+                "anima_cache_text_encoder_outputs": True,
+                "anima_cache_text_encoder_outputs_to_disk": True,
+            }
+        )
+        self.assertTrue(config.get("cache_text_encoder_outputs"))
+        self.assertTrue(config.get("cache_text_encoder_outputs_to_disk"))
+
+
+class TestAnimaFinetuneAdvancedOptions(unittest.TestCase):
+    """Advanced Anima options (compile, VAE 2D, timesteps) on the fine-tune tab."""
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**ANIMA_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(finetune_gui, kwargs)
+
+    def test_qwen_image_vae_2d_forwarded_when_enabled(self):
+        config = self._run_and_load_toml({"anima_qwen_image_vae_2d": True})
+        self.assertTrue(config.get("qwen_image_vae_2d"))
+
+    def test_compile_forwarded_with_options(self):
+        config = self._run_and_load_toml(
+            {
+                "anima_compile": True,
+                "anima_compile_backend": "inductor",
+                "anima_compile_mode": "max-autotune",
+                "anima_compile_dynamic": "true",
+                "anima_compile_fullgraph": True,
+                "anima_compile_cache_size_limit": 32,
+            }
+        )
+        self.assertTrue(config.get("compile"))
+        self.assertEqual(config.get("compile_backend"), "inductor")
+        self.assertEqual(config.get("compile_mode"), "max-autotune")
+        self.assertEqual(config.get("compile_dynamic"), "true")
+        self.assertTrue(config.get("compile_fullgraph"))
+        self.assertEqual(config.get("compile_cache_size_limit"), 32)
+
+    def test_compile_options_omitted_when_compile_disabled(self):
+        config = self._run_and_load_toml(
+            {
+                "anima_compile": False,
+                "anima_compile_mode": "max-autotune",
+                "anima_compile_fullgraph": True,
+            }
+        )
+        self.assertNotIn("compile_mode", config)
+        self.assertNotIn("compile_fullgraph", config)
+
+    def test_compile_and_torch_compile_together_blocks_training(self):
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                **ANIMA_OVERRIDES,
+                "anima_compile": True,
+                "anima_torch_compile": True,
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            kwargs = dict(kwargs, output_dir=tmpdir, output_name="testout")
+            mock_executor(finetune_gui)
+            with patch.object(
+                finetune_gui, "get_executable_path", return_value="accelerate"
+            ):
+                finetune_gui.train_model(**kwargs)
+            toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+            self.assertEqual(toml_files, [])
+
+    def test_show_timesteps_forwarded_for_anima(self):
+        config = self._run_and_load_toml(
+            {"show_timesteps": "console", "show_timesteps_resolution": "1024"}
+        )
+        self.assertEqual(config.get("show_timesteps"), "console")
+        self.assertEqual(config.get("show_timesteps_resolution"), "1024")
+
+    def test_blocks_to_swap_forwarded_for_anima(self):
+        config = self._run_and_load_toml({"blocks_to_swap": 8})
+        self.assertEqual(config.get("blocks_to_swap"), 8)
+
+    def test_unsloth_offload_forwarded_when_enabled(self):
+        config = self._run_and_load_toml({"anima_unsloth_offload_checkpointing": True})
+        self.assertTrue(config.get("unsloth_offload_checkpointing"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds Anima as a model family on the **Finetune** tab, reusing `class_anima.py` for model/encoder paths and core flow-matching args (same fields as LoRA Anima).
- Selects `sd-scripts/anima_train.py` when Anima is checked and forwards Anima-specific TOML flags (`qwen3`, `vae`, token lengths, compile options, etc.).
- Drops SD-only / LoRA-only / inpainting args that `anima_train.py` does not accept.
- Regression suite in `tests/test_anima_finetune_gui.py`.

## Test plan
- [x] `pytest tests/test_anima_finetune_gui.py` (19 passed)
- [x] `pytest tests/test_finetune_gui.py tests/test_anima_finetune_gui.py` (33 passed)
- [ ] Manual: Finetune tab → check Anima → fill Qwen3/VAE → Print training command shows `anima_train.py` and correct flags

Closes #3523