### PR TITLE
fix: find accelerate when venv is not activated

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -23,7 +23,7 @@ log = setup_logging()
 folder_symbol = "\U0001f4c2"  # 📂
 refresh_symbol = "\U0001f504"  # 🔄
 save_style_symbol = "\U0001f4be"  # 💾
-document_symbol = "\U0001F4C4"  # 📄
+document_symbol = "\U0001f4c4"  # 📄
 
 scriptdir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -67,25 +67,38 @@ ENV_EXCLUSION = ["COLAB_GPU", "RUNPOD_POD_ID"]
 
 def get_executable_path(executable_name: str = None) -> str:
     """
-    Retrieve and sanitize the path to an executable in the system's PATH.
+    Resolve a console-script executable for the current environment.
+
+    Prefers ``PATH`` (``shutil.which``). When that fails — common when the
+    venv interpreter is invoked directly without activation, so
+    ``.venv/Scripts`` / ``.venv/bin`` is not on ``PATH`` — falls back to the
+    scripts directory of ``sys.prefix`` (the active interpreter's env).
 
     Args:
-    executable_name (str): The name of the executable to find.
+        executable_name: Bare name of the executable (e.g. ``"accelerate"``).
 
     Returns:
-    str: The full, sanitized path to the executable if found, otherwise an empty string.
+        Full path to the executable if found, otherwise an empty string.
     """
-    if executable_name:
-        executable_path = shutil.which(executable_name)
-        if executable_path:
-            # Replace backslashes with forward slashes on Windows
-            # if os.name == "nt":
-            #     executable_path = executable_path.replace("\\", "/")
-            return executable_path
-        else:
-            return ""  # Return empty string if the executable is not found
-    else:
-        return ""  # Return empty string if no executable name is provided
+    if not executable_name:
+        return ""
+
+    executable_path = shutil.which(executable_name)
+    if executable_path:
+        return executable_path
+
+    # Fallback: entry points installed into this interpreter's environment.
+    scripts_dir = os.path.join(sys.prefix, "Scripts" if os.name == "nt" else "bin")
+    candidates = [executable_name]
+    if os.name == "nt" and not os.path.splitext(executable_name)[1]:
+        candidates = [executable_name + ext for ext in (".exe", ".cmd", ".bat")]
+
+    for name in candidates:
+        candidate = os.path.join(scripts_dir, name)
+        if os.path.isfile(candidate):
+            return candidate
+
+    return ""
 
 
 def calculate_max_train_steps(
@@ -356,10 +369,7 @@ def update_my_data(my_data):
                 # Handle the case where the string is not a valid float
                 my_data[key] = int(1)
 
-    for key in [
-        "max_train_steps",
-        "caption_dropout_every_n_epochs"
-    ]:
+    for key in ["max_train_steps", "caption_dropout_every_n_epochs"]:
         value = my_data.get(key)
         if value is not None:
             try:
@@ -1088,7 +1098,7 @@ def set_pretrained_model_name_or_path_input(
         sdxl = gr.Checkbox(value=detect.Is_SDXL(), visible=True)
         sd3 = gr.Checkbox(value=detect.Is_SD3(), visible=True)
         flux1 = gr.Checkbox(value=detect.Is_FLUX1(), visible=True)
-        #TODO: v_parameterization
+        # TODO: v_parameterization
 
     # If a refresh method is provided, use it to update the choices for the Dropdown widget
     if refresh_method is not None:

--- a/tests/test_anima_lora_gui.py
+++ b/tests/test_anima_lora_gui.py
@@ -189,7 +189,10 @@ class TestAnimaLoraConfigOutput(unittest.TestCase):
                 overrides=ANIMA_OVERRIDES,
             )
             mock_executor(lora_gui)
-            lora_gui.train_model(**kwargs)
+            with patch.object(
+                lora_gui, "get_executable_path", return_value="accelerate"
+            ):
+                lora_gui.train_model(**kwargs)
             self.assertTrue(mocked.called)
             run_cmd = mocked.call_args[0][0]
             self.assertTrue(any("anima_train_network.py" in part for part in run_cmd))

--- a/tests/test_get_executable_path.py
+++ b/tests/test_get_executable_path.py
@@ -1,0 +1,52 @@
+"""Regression for get_executable_path venv fallback.
+
+When the venv Python is run without activation, PATH does not include
+Scripts/bin, so shutil.which alone misses console scripts (e.g. accelerate)
+that are installed in the environment. get_executable_path must still find
+them under sys.prefix.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from kohya_gui.common_gui import get_executable_path
+
+
+class TestGetExecutablePath(unittest.TestCase):
+    def test_empty_name_returns_empty(self):
+        self.assertEqual(get_executable_path(None), "")
+        self.assertEqual(get_executable_path(""), "")
+
+    def test_which_hit_is_preferred(self):
+        with patch("kohya_gui.common_gui.shutil.which", return_value="/usr/bin/fake"):
+            self.assertEqual(get_executable_path("fake"), "/usr/bin/fake")
+
+    def test_venv_scripts_fallback_when_not_on_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scripts_name = "Scripts" if os.name == "nt" else "bin"
+            scripts_dir = os.path.join(tmpdir, scripts_name)
+            os.makedirs(scripts_dir)
+            exe_name = "acceltool.exe" if os.name == "nt" else "acceltool"
+            tool_path = os.path.join(scripts_dir, exe_name)
+            with open(tool_path, "w", encoding="utf-8") as f:
+                f.write("")
+
+            with patch("kohya_gui.common_gui.shutil.which", return_value=None):
+                with patch.object(sys, "prefix", tmpdir):
+                    # Callers pass the bare name without extension.
+                    found = get_executable_path("acceltool")
+            self.assertEqual(found, tool_path)
+
+    def test_missing_executable_returns_empty(self):
+        with patch("kohya_gui.common_gui.shutil.which", return_value=None):
+            with patch.object(sys, "prefix", tempfile.gettempdir()):
+                self.assertEqual(
+                    get_executable_path("definitely-not-installed-xyz"), ""
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hunyuan_image_lora_gui.py
+++ b/tests/test_hunyuan_image_lora_gui.py
@@ -158,7 +158,10 @@ class TestHunyuanImageLoraConfigOutput(unittest.TestCase):
                 overrides=HUNYUAN_OVERRIDES,
             )
             mock_executor(lora_gui)
-            lora_gui.train_model(**kwargs)
+            with patch.object(
+                lora_gui, "get_executable_path", return_value="accelerate"
+            ):
+                lora_gui.train_model(**kwargs)
             self.assertTrue(mocked.called)
             run_cmd = mocked.call_args[0][0]
             self.assertTrue(

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -15,6 +15,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import gradio as gr
 import toml
@@ -321,30 +322,33 @@ class TestLoraGuiDictAdapterWiring(unittest.TestCase):
     PATH_DEPENDENT_KEYS = ("output_dir", "sample_prompts")
 
     def test_print_command_entry_matches_direct_train_model_call(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            kwargs = self._field_kwargs(
-                {"output_dir": tmpdir, "output_name": "wiring_test"}
-            )
-            data = self._field_data(kwargs)
-            data[self.components["dummy_headless"]] = True
-            data[self.components["dummy_db_true"]] = True
+        # Isolate from host PATH / accelerate install (same pattern as
+        # finetune/dreambooth dict-adapter wiring tests).
+        with patch.object(lora_gui, "get_executable_path", return_value="accelerate"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                kwargs = self._field_kwargs(
+                    {"output_dir": tmpdir, "output_name": "wiring_test"}
+                )
+                data = self._field_data(kwargs)
+                data[self.components["dummy_headless"]] = True
+                data[self.components["dummy_db_true"]] = True
 
-            mock_executor(lora_gui)
-            self.entries["print_command"](data)
-            toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
-            self.assertEqual(len(toml_files), 1)
-            with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
-                via_wiring = toml.load(f)
+                mock_executor(lora_gui)
+                self.entries["print_command"](data)
+                toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+                self.assertEqual(len(toml_files), 1)
+                with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
+                    via_wiring = toml.load(f)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            kwargs = self._field_kwargs(
-                {"output_dir": tmpdir, "output_name": "wiring_test"}
-            )
-            mock_executor(lora_gui)
-            lora_gui.train_model(headless=True, print_only=True, **kwargs)
-            toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
-            with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
-                via_direct_call = toml.load(f)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                kwargs = self._field_kwargs(
+                    {"output_dir": tmpdir, "output_name": "wiring_test"}
+                )
+                mock_executor(lora_gui)
+                lora_gui.train_model(headless=True, print_only=True, **kwargs)
+                toml_files = [f for f in os.listdir(tmpdir) if f.endswith(".toml")]
+                with open(os.path.join(tmpdir, toml_files[0]), encoding="utf-8") as f:
+                    via_direct_call = toml.load(f)
 
         for key in self.PATH_DEPENDENT_KEYS:
             via_wiring.pop(key, None)


### PR DESCRIPTION
## Summary
- **Root cause:** `accelerate` *is* installed; `get_executable_path` only used `shutil.which` (PATH). Running `.venv\Scripts\python.exe` without activation / `uv run` does not put Scripts on PATH, so training aborted with \"accelerate not found\".
- **Product fix:** fall back to `sys.prefix/Scripts` (Windows) or `sys.prefix/bin` (POSIX) for console scripts.
- **Tests:** unit tests for the fallback; isolate remaining LoRA `train_model` call sites that only mocked the executor (same pattern as finetune/dreambooth).

## Test plan
- [x] `pytest tests/test_get_executable_path.py tests/test_anima_lora_gui.py tests/test_hunyuan_image_lora_gui.py tests/test_lora_gui.py` (47 passed)
- [x] Full suite `pytest tests/ test/test_allowed_paths.py` (151 passed)
- [x] Smoke: bare `.venv\Scripts\python.exe` → `get_executable_path(\"accelerate\")` resolves to `.venv\Scripts\accelerate.exe` while `shutil.which` is `None`