### PR TITLE
feat: Lumina Image 2.0 LoRA training support in the GUI

### DIFF
--- a/kohya_gui/class_lumina.py
+++ b/kohya_gui/class_lumina.py
@@ -1,0 +1,159 @@
+import gradio as gr
+from .common_gui import (
+    get_any_file_path,
+    document_symbol,
+)
+
+
+class luminaTraining:
+    def __init__(
+        self,
+        headless: bool = False,
+        finetuning: bool = False,
+        training_type: str = "",
+        config: dict = {},
+        lumina_checkbox: gr.Checkbox = False,
+    ) -> None:
+        self.headless = headless
+        self.finetuning = finetuning
+        self.training_type = training_type
+        self.config = config
+        self.lumina_checkbox = lumina_checkbox
+
+        with gr.Accordion(
+            "Lumina Image 2.0",
+            open=True,
+            visible=False,
+            elem_classes=["lumina_background"],
+        ) as lumina_accordion:
+            with gr.Group():
+                with gr.Row():
+                    self.gemma2 = gr.Textbox(
+                        label="Gemma2 Path",
+                        placeholder="Path to Gemma2 text encoder model",
+                        value=self.config.get("lumina.gemma2", ""),
+                        interactive=True,
+                    )
+                    self.gemma2_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.gemma2_button.click(
+                        get_any_file_path,
+                        outputs=self.gemma2,
+                        show_progress=False,
+                    )
+
+                    self.ae = gr.Textbox(
+                        label="AE Path",
+                        placeholder="Path to Lumina AutoEncoder (same family as FLUX AE)",
+                        value=self.config.get("lumina.ae", ""),
+                        interactive=True,
+                    )
+                    self.ae_button = gr.Button(
+                        document_symbol,
+                        elem_id="open_folder_small",
+                        visible=(not headless),
+                        interactive=True,
+                    )
+                    self.ae_button.click(
+                        get_any_file_path,
+                        outputs=self.ae,
+                        show_progress=False,
+                    )
+
+                with gr.Row():
+                    self.discrete_flow_shift = gr.Number(
+                        label="Discrete Flow Shift",
+                        value=self.config.get("lumina.discrete_flow_shift", 6.0),
+                        info="Discrete flow shift for the Euler Discrete Scheduler, default is 6.0",
+                        minimum=-1024,
+                        maximum=1024,
+                        step=0.01,
+                        interactive=True,
+                    )
+                    self.model_prediction_type = gr.Dropdown(
+                        label="Model Prediction Type",
+                        choices=["raw", "additive", "sigma_scaled"],
+                        value=self.config.get("lumina.model_prediction_type", "raw"),
+                        interactive=True,
+                    )
+                    self.timestep_sampling = gr.Dropdown(
+                        label="Timestep Sampling",
+                        choices=[
+                            "sigma",
+                            "uniform",
+                            "sigmoid",
+                            "shift",
+                            "nextdit_shift",
+                            "flux_shift",
+                        ],
+                        value=self.config.get("lumina.timestep_sampling", "shift"),
+                        interactive=True,
+                    )
+                    self.sigmoid_scale = gr.Number(
+                        label="Sigmoid Scale",
+                        value=self.config.get("lumina.sigmoid_scale", 1.0),
+                        info='Scale factor for sigmoid timestep sampling (only used when timestep sampling is "sigmoid")',
+                        minimum=0.0,
+                        maximum=1024,
+                        step=0.01,
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.gemma2_max_token_length = gr.Number(
+                        label="Gemma2 Max Token Length",
+                        value=self.config.get("lumina.gemma2_max_token_length", 256),
+                        info="Maximum token length for Gemma2. Backend default is 256 when omitted.",
+                        minimum=1,
+                        maximum=4096,
+                        step=1,
+                        interactive=True,
+                    )
+                    self.system_prompt = gr.Textbox(
+                        label="System Prompt",
+                        placeholder=(
+                            "You are an assistant designed to generate "
+                            "high-quality images based on user prompts."
+                        ),
+                        value=self.config.get("lumina.system_prompt", ""),
+                        interactive=True,
+                    )
+
+                with gr.Row():
+                    self.use_flash_attn = gr.Checkbox(
+                        label="Use Flash Attention",
+                        value=self.config.get("lumina.use_flash_attn", False),
+                        info="Requires flash-attn package",
+                        interactive=True,
+                    )
+                    self.use_sage_attn = gr.Checkbox(
+                        label="Use Sage Attention",
+                        value=self.config.get("lumina.use_sage_attn", False),
+                        interactive=True,
+                    )
+                    self.cache_text_encoder_outputs = gr.Checkbox(
+                        label="Cache Text Encoder Outputs",
+                        value=self.config.get(
+                            "lumina.cache_text_encoder_outputs", False
+                        ),
+                        info="Cache Gemma2 text encoder outputs to reduce memory usage",
+                        interactive=True,
+                    )
+                    self.cache_text_encoder_outputs_to_disk = gr.Checkbox(
+                        label="Cache Text Encoder Outputs to Disk",
+                        value=self.config.get(
+                            "lumina.cache_text_encoder_outputs_to_disk", False
+                        ),
+                        info="Cache text encoder outputs to disk",
+                        interactive=True,
+                    )
+
+                self.lumina_checkbox.change(
+                    lambda lumina_checkbox: gr.Accordion(visible=lumina_checkbox),
+                    inputs=[self.lumina_checkbox],
+                    outputs=[lumina_accordion],
+                )

--- a/kohya_gui/class_lumina.py
+++ b/kohya_gui/class_lumina.py
@@ -12,12 +12,14 @@ class luminaTraining:
         finetuning: bool = False,
         training_type: str = "",
         config: dict = {},
-        lumina_checkbox: gr.Checkbox = False,
+        lumina_checkbox: gr.Checkbox = None,
     ) -> None:
         self.headless = headless
         self.finetuning = finetuning
         self.training_type = training_type
         self.config = config
+        if lumina_checkbox is None:
+            raise ValueError("lumina_checkbox must be provided")
         self.lumina_checkbox = lumina_checkbox
 
         with gr.Accordion(

--- a/kohya_gui/class_source_model.py
+++ b/kohya_gui/class_source_model.py
@@ -15,7 +15,7 @@ from .class_gui_config import KohyaSSGUIConfig
 folder_symbol = "\U0001f4c2"  # 📂
 refresh_symbol = "\U0001f504"  # 🔄
 save_style_symbol = "\U0001f4be"  # 💾
-document_symbol = "\U0001F4C4"  # 📄
+document_symbol = "\U0001f4c4"  # 📄
 
 default_models = [
     "stabilityai/stable-diffusion-xl-base-1.0",
@@ -111,7 +111,9 @@ class SourceModel:
                         self.pretrained_model_name_or_path = gr.Dropdown(
                             label="Pretrained model name or path",
                             choices=default_models + model_checkpoints,
-                            value=self.config.get("model.models_dir", "runwayml/stable-diffusion-v1-5"),
+                            value=self.config.get(
+                                "model.models_dir", "runwayml/stable-diffusion-v1-5"
+                            ),
                             allow_custom_value=True,
                             visible=True,
                             min_width=100,
@@ -131,7 +133,11 @@ class SourceModel:
                         )
                         self.pretrained_model_name_or_path_file.click(
                             get_file_path,
-                            inputs=[self.pretrained_model_name_or_path, model_ext, model_ext_name],
+                            inputs=[
+                                self.pretrained_model_name_or_path,
+                                model_ext,
+                                model_ext_name,
+                            ],
                             outputs=self.pretrained_model_name_or_path,
                             show_progress=False,
                         )
@@ -251,7 +257,10 @@ class SourceModel:
                     with gr.Column():
                         with gr.Row():
                             self.v2 = gr.Checkbox(
-                                label="v2", value=False, visible=False, min_width=60,
+                                label="v2",
+                                value=False,
+                                visible=False,
+                                min_width=60,
                                 interactive=True,
                             )
                             self.v_parameterization = gr.Checkbox(
@@ -296,30 +305,76 @@ class SourceModel:
                                 min_width=60,
                                 interactive=True,
                             )
+                            self.lumina_checkbox = gr.Checkbox(
+                                label="Lumina",
+                                value=False,
+                                visible=False,
+                                min_width=60,
+                                interactive=True,
+                            )
 
-                            def toggle_checkboxes(v2, v_parameterization, sdxl_checkbox, sd3_checkbox, flux1_checkbox, hunyuan_image_checkbox, anima_checkbox):
+                            def toggle_checkboxes(
+                                v2,
+                                v_parameterization,
+                                sdxl_checkbox,
+                                sd3_checkbox,
+                                flux1_checkbox,
+                                hunyuan_image_checkbox,
+                                anima_checkbox,
+                                lumina_checkbox,
+                            ):
                                 # Check if all checkboxes are unchecked
-                                if not v2 and not sdxl_checkbox and not sd3_checkbox and not flux1_checkbox and not hunyuan_image_checkbox and not anima_checkbox:
+                                if (
+                                    not v2
+                                    and not sdxl_checkbox
+                                    and not sd3_checkbox
+                                    and not flux1_checkbox
+                                    and not hunyuan_image_checkbox
+                                    and not anima_checkbox
+                                    and not lumina_checkbox
+                                ):
                                     # If all unchecked, return new interactive checkboxes
                                     return (
                                         gr.Checkbox(interactive=True),  # v2 checkbox
-                                        gr.Checkbox(interactive=False, value=False),  # v_parameterization checkbox
+                                        gr.Checkbox(
+                                            interactive=False, value=False
+                                        ),  # v_parameterization checkbox
                                         gr.Checkbox(interactive=True),  # sdxl_checkbox
                                         gr.Checkbox(interactive=True),  # sd3_checkbox
                                         gr.Checkbox(interactive=True),  # flux1_checkbox
-                                        gr.Checkbox(interactive=True),  # hunyuan_image_checkbox
+                                        gr.Checkbox(
+                                            interactive=True
+                                        ),  # hunyuan_image_checkbox
                                         gr.Checkbox(interactive=True),  # anima_checkbox
+                                        gr.Checkbox(
+                                            interactive=True
+                                        ),  # lumina_checkbox
                                     )
                                 else:
                                     # If any checkbox is checked, return checkboxes with current interactive state
                                     return (
                                         gr.Checkbox(interactive=v2),  # v2 checkbox
-                                        gr.Checkbox(interactive=v2),  # v_parameterization checkbox
-                                        gr.Checkbox(interactive=sdxl_checkbox),  # sdxl_checkbox
-                                        gr.Checkbox(interactive=sd3_checkbox),  # sd3_checkbox
-                                        gr.Checkbox(interactive=flux1_checkbox),  # flux1_checkbox
-                                        gr.Checkbox(interactive=hunyuan_image_checkbox),  # hunyuan_image_checkbox
-                                        gr.Checkbox(interactive=anima_checkbox),  # anima_checkbox
+                                        gr.Checkbox(
+                                            interactive=v2
+                                        ),  # v_parameterization checkbox
+                                        gr.Checkbox(
+                                            interactive=sdxl_checkbox
+                                        ),  # sdxl_checkbox
+                                        gr.Checkbox(
+                                            interactive=sd3_checkbox
+                                        ),  # sd3_checkbox
+                                        gr.Checkbox(
+                                            interactive=flux1_checkbox
+                                        ),  # flux1_checkbox
+                                        gr.Checkbox(
+                                            interactive=hunyuan_image_checkbox
+                                        ),  # hunyuan_image_checkbox
+                                        gr.Checkbox(
+                                            interactive=anima_checkbox
+                                        ),  # anima_checkbox
+                                        gr.Checkbox(
+                                            interactive=lumina_checkbox
+                                        ),  # lumina_checkbox
                                     )
 
                             checkbox_inputs = [
@@ -330,6 +385,7 @@ class SourceModel:
                                 self.flux1_checkbox,
                                 self.hunyuan_image_checkbox,
                                 self.anima_checkbox,
+                                self.lumina_checkbox,
                             ]
 
                             self.v2.change(
@@ -374,6 +430,12 @@ class SourceModel:
                                 outputs=checkbox_inputs,
                                 show_progress=False,
                             )
+                            self.lumina_checkbox.change(
+                                fn=toggle_checkboxes,
+                                inputs=checkbox_inputs,
+                                outputs=checkbox_inputs,
+                                show_progress=False,
+                            )
                     with gr.Column():
                         gr.Group(visible=False)
 
@@ -413,6 +475,7 @@ class SourceModel:
                         self.flux1_checkbox,
                         self.hunyuan_image_checkbox,
                         self.anima_checkbox,
+                        self.lumina_checkbox,
                     ],
                     show_progress=False,
                 )

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -993,8 +993,8 @@ def set_pretrained_model_name_or_path_input(
 
     Returns:
         tuple: A tuple containing the Dropdown widget, v2 checkbox, v_parameterization checkbox,
-               sdxl checkbox, sd3 checkbox, flux1 checkbox, hunyuan_image checkbox, and anima
-               checkbox.
+               sdxl checkbox, sd3 checkbox, flux1 checkbox, hunyuan_image checkbox, anima
+               checkbox, and lumina checkbox.
     """
     # Check if the given pretrained_model_name_or_path is in the list of SDXL models
     if pretrained_model_name_or_path in SDXL_MODELS:
@@ -1006,6 +1006,7 @@ def set_pretrained_model_name_or_path_input(
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
         anima = gr.Checkbox(value=False, visible=False)
+        lumina = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1015,6 +1016,7 @@ def set_pretrained_model_name_or_path_input(
             flux1,
             hunyuan_image,
             anima,
+            lumina,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V2 base models
@@ -1027,6 +1029,7 @@ def set_pretrained_model_name_or_path_input(
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
         anima = gr.Checkbox(value=False, visible=False)
+        lumina = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1036,6 +1039,7 @@ def set_pretrained_model_name_or_path_input(
             flux1,
             hunyuan_image,
             anima,
+            lumina,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V parameterization models
@@ -1050,6 +1054,7 @@ def set_pretrained_model_name_or_path_input(
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
         anima = gr.Checkbox(value=False, visible=False)
+        lumina = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1059,6 +1064,7 @@ def set_pretrained_model_name_or_path_input(
             flux1,
             hunyuan_image,
             anima,
+            lumina,
         )
 
     # Check if the given pretrained_model_name_or_path is in the list of V1 models
@@ -1071,6 +1077,7 @@ def set_pretrained_model_name_or_path_input(
         flux1 = gr.Checkbox(value=False, visible=False)
         hunyuan_image = gr.Checkbox(value=False, visible=False)
         anima = gr.Checkbox(value=False, visible=False)
+        lumina = gr.Checkbox(value=False, visible=False)
         return (
             gr.Dropdown(),
             v2,
@@ -1080,6 +1087,7 @@ def set_pretrained_model_name_or_path_input(
             flux1,
             hunyuan_image,
             anima,
+            lumina,
         )
 
     # Check if the model_list is set to 'custom'
@@ -1090,6 +1098,7 @@ def set_pretrained_model_name_or_path_input(
     flux1 = gr.Checkbox(visible=True)
     hunyuan_image = gr.Checkbox(visible=True)
     anima = gr.Checkbox(visible=True)
+    lumina = gr.Checkbox(visible=True)
 
     # Auto-detect model type if safetensors file path is given
     if pretrained_model_name_or_path.lower().endswith(".safetensors"):
@@ -1116,6 +1125,7 @@ def set_pretrained_model_name_or_path_input(
         flux1,
         hunyuan_image,
         anima,
+        lumina,
     )
 
 

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -45,6 +45,7 @@ from .class_gui_config import KohyaSSGUIConfig
 from .class_flux1 import flux1Training
 from .class_hunyuan_image import hunyuanImageTraining
 from .class_anima import animaTraining
+from .class_lumina import luminaTraining
 
 from .dreambooth_folder_creation_gui import (
     gradio_dreambooth_folder_creation_tab,
@@ -381,6 +382,20 @@ def save_configuration(
     anima_compile_fullgraph,
     anima_compile_cache_size_limit,
     anima_checkbox,
+    # Lumina Image 2.0 parameters
+    lumina_cache_text_encoder_outputs,
+    lumina_cache_text_encoder_outputs_to_disk,
+    lumina_gemma2,
+    lumina_ae,
+    lumina_discrete_flow_shift,
+    lumina_model_prediction_type,
+    lumina_timestep_sampling,
+    lumina_sigmoid_scale,
+    lumina_gemma2_max_token_length,
+    lumina_system_prompt,
+    lumina_use_flash_attn,
+    lumina_use_sage_attn,
+    lumina_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -713,6 +728,20 @@ def open_configuration(
     anima_compile_fullgraph,
     anima_compile_cache_size_limit,
     anima_checkbox,
+    # Lumina Image 2.0 parameters
+    lumina_cache_text_encoder_outputs,
+    lumina_cache_text_encoder_outputs_to_disk,
+    lumina_gemma2,
+    lumina_ae,
+    lumina_discrete_flow_shift,
+    lumina_model_prediction_type,
+    lumina_timestep_sampling,
+    lumina_sigmoid_scale,
+    lumina_gemma2_max_token_length,
+    lumina_system_prompt,
+    lumina_use_flash_attn,
+    lumina_use_sage_attn,
+    lumina_checkbox,
     ##
     training_preset,
 ):
@@ -1209,6 +1238,20 @@ def train_model(
     anima_compile_fullgraph,
     anima_compile_cache_size_limit,
     anima_checkbox,
+    # Lumina Image 2.0 parameters
+    lumina_cache_text_encoder_outputs,
+    lumina_cache_text_encoder_outputs_to_disk,
+    lumina_gemma2,
+    lumina_ae,
+    lumina_discrete_flow_shift,
+    lumina_model_prediction_type,
+    lumina_timestep_sampling,
+    lumina_sigmoid_scale,
+    lumina_gemma2_max_token_length,
+    lumina_system_prompt,
+    lumina_use_flash_attn,
+    lumina_use_sage_attn,
+    lumina_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -1264,6 +1307,18 @@ def train_model(
         )
         return TRAIN_BUTTON_VISIBLE
 
+    if lumina_checkbox and LoRA_type != "Lumina":
+        log.error(
+            "LoRA type must be set to 'Lumina' if the Lumina model checkbox is checked."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
+    if LoRA_type == "Lumina" and not lumina_checkbox:
+        log.error(
+            "The Lumina model checkbox must be checked when LoRA type is set to 'Lumina'."
+        )
+        return TRAIN_BUTTON_VISIBLE
+
     # Native LoHa/LoKr only support SDXL and Anima (see sd-scripts/docs/loha_lokr.md).
     if LoRA_type in KOHYA_LOHA_LOKR_TYPES:
         if not (sdxl or anima_checkbox):
@@ -1273,9 +1328,9 @@ def train_model(
                 "auto-detect those architectures)."
             )
             return TRAIN_BUTTON_VISIBLE
-        if flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox:
+        if flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox or lumina_checkbox:
             log.error(
-                f"{LoRA_type} is not supported with Flux1, SD3, or HunyuanImage-2.1."
+                f"{LoRA_type} is not supported with Flux1, SD3, HunyuanImage-2.1, or Lumina."
             )
             return TRAIN_BUTTON_VISIBLE
 
@@ -1538,12 +1593,18 @@ def train_model(
         run_cmd.append(rf"{scriptdir}/sd-scripts/hunyuan_image_train_network.py")
     elif anima_checkbox:
         run_cmd.append(rf"{scriptdir}/sd-scripts/anima_train_network.py")
+    elif lumina_checkbox:
+        run_cmd.append(rf"{scriptdir}/sd-scripts/lumina_train_network.py")
     else:
         run_cmd.append(rf"{scriptdir}/sd-scripts/train_network.py")
 
     # --train_inpainting is only supported by train_network.py/sdxl_train_network.py
     train_inpainting = train_inpainting and not (
-        flux1_checkbox or sd3_checkbox or hunyuan_image_checkbox or anima_checkbox
+        flux1_checkbox
+        or sd3_checkbox
+        or hunyuan_image_checkbox
+        or anima_checkbox
+        or lumina_checkbox
     )
     if train_inpainting:
         # Masks are generated randomly per training step from the source
@@ -1674,6 +1735,9 @@ def train_model(
 
     if LoRA_type == "Anima":
         network_module = "networks.lora_anima"
+
+    if LoRA_type == "Lumina":
+        network_module = "networks.lora_lumina"
 
     # Native sd-scripts LoHa/LoKr (not lycoris.kohya). Targets/excludes are
     # auto-detected from the loaded model; optional conv/factor args only.
@@ -1884,6 +1948,7 @@ def train_model(
             or (sd3_checkbox and sd3_cache_text_encoder_outputs)
             or (hunyuan_image_checkbox and hunyuan_image_cache_text_encoder_outputs)
             or (anima_checkbox and anima_cache_text_encoder_outputs)
+            or (lumina_checkbox and lumina_cache_text_encoder_outputs)
             else None
         ),
         "cache_text_encoder_outputs_to_disk": (
@@ -1896,6 +1961,8 @@ def train_model(
             and hunyuan_image_cache_text_encoder_outputs_to_disk
             or anima_checkbox
             and anima_cache_text_encoder_outputs_to_disk
+            or lumina_checkbox
+            and lumina_cache_text_encoder_outputs_to_disk
             else None
         ),
         "caption_dropout_every_n_epochs": int(caption_dropout_every_n_epochs),
@@ -1904,7 +1971,10 @@ def train_model(
         "clip_l": clip_l_value,
         "clip_skip": (
             clip_skip
-            if clip_skip != 0 and not hunyuan_image_checkbox and not anima_checkbox
+            if clip_skip != 0
+            and not hunyuan_image_checkbox
+            and not anima_checkbox
+            and not lumina_checkbox
             else None
         ),
         "color_aug": color_aug,
@@ -1959,7 +2029,10 @@ def train_model(
         "max_timestep": max_timestep if max_timestep != 0 else None,
         "max_token_length": (
             int(max_token_length)
-            if not flux1_checkbox and not hunyuan_image_checkbox and not anima_checkbox
+            if not flux1_checkbox
+            and not hunyuan_image_checkbox
+            and not anima_checkbox
+            and not lumina_checkbox
             else None
         ),
         "max_train_epochs": (
@@ -2095,11 +2168,11 @@ def train_model(
         # Flux.1 specific parameters
         # "cache_text_encoder_outputs": see previous assignment above for code
         # "cache_text_encoder_outputs_to_disk": see previous assignment above for code
-        "ae": ae if flux1_checkbox else None,
+        "ae": (lumina_ae if lumina_checkbox else ae if flux1_checkbox else None),
         # "clip_l": see previous assignment above for code
         "t5xxl": t5xxl_value,
         # "discrete_flow_shift", "model_prediction_type", "timestep_sampling":
-        # see consolidated HunyuanImage-2.1/Flux1 assignment below
+        # see consolidated DiT family assignment below
         "split_mode": split_mode if flux1_checkbox else None,
         "t5xxl_max_token_length": (
             int(t5xxl_max_token_length) if flux1_checkbox else None
@@ -2116,50 +2189,69 @@ def train_model(
             or sd3_checkbox
             or hunyuan_image_checkbox
             or anima_checkbox
+            or lumina_checkbox
             else None
         ),
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
         "show_timesteps": (
             show_timesteps
-            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox or lumina_checkbox)
+            and show_timesteps
             else None
         ),
         "show_timesteps_resolution": (
             show_timesteps_resolution
-            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox or lumina_checkbox)
+            and show_timesteps
             else None
         ),
         # HunyuanImage-2.1 specific parameters
         "text_encoder": hunyuan_text_encoder if hunyuan_image_checkbox else None,
         "byt5": hunyuan_byt5 if hunyuan_image_checkbox else None,
         "discrete_flow_shift": (
-            float(anima_discrete_flow_shift)
-            if anima_checkbox
+            float(lumina_discrete_flow_shift)
+            if lumina_checkbox
             else (
-                float(hunyuan_discrete_flow_shift)
-                if hunyuan_image_checkbox
-                else float(discrete_flow_shift) if flux1_checkbox else None
+                float(anima_discrete_flow_shift)
+                if anima_checkbox
+                else (
+                    float(hunyuan_discrete_flow_shift)
+                    if hunyuan_image_checkbox
+                    else float(discrete_flow_shift) if flux1_checkbox else None
+                )
             )
         ),
         "model_prediction_type": (
-            hunyuan_model_prediction_type
-            if hunyuan_image_checkbox
-            else model_prediction_type if flux1_checkbox else None
+            lumina_model_prediction_type
+            if lumina_checkbox
+            else (
+                hunyuan_model_prediction_type
+                if hunyuan_image_checkbox
+                else model_prediction_type if flux1_checkbox else None
+            )
         ),
         "timestep_sampling": (
-            anima_timestep_sampling
-            if anima_checkbox
+            lumina_timestep_sampling
+            if lumina_checkbox
             else (
-                hunyuan_timestep_sampling
-                if hunyuan_image_checkbox
-                else timestep_sampling if flux1_checkbox else None
+                anima_timestep_sampling
+                if anima_checkbox
+                else (
+                    hunyuan_timestep_sampling
+                    if hunyuan_image_checkbox
+                    else timestep_sampling if flux1_checkbox else None
+                )
             )
         ),
         "sigmoid_scale": (
-            float(anima_sigmoid_scale)
-            if anima_checkbox
-            else float(hunyuan_sigmoid_scale) if hunyuan_image_checkbox else None
+            float(lumina_sigmoid_scale)
+            if lumina_checkbox
+            else (
+                float(anima_sigmoid_scale)
+                if anima_checkbox
+                else float(hunyuan_sigmoid_scale) if hunyuan_image_checkbox else None
+            )
         ),
         "attn_mode": (
             anima_attn_mode
@@ -2189,6 +2281,18 @@ def train_model(
                 else None
             )
         ),
+        # Lumina Image 2.0 specific parameters
+        "gemma2": lumina_gemma2 if lumina_checkbox else None,
+        "gemma2_max_token_length": (
+            int(lumina_gemma2_max_token_length)
+            if lumina_checkbox and lumina_gemma2_max_token_length
+            else None
+        ),
+        "system_prompt": (
+            lumina_system_prompt if lumina_checkbox and lumina_system_prompt else None
+        ),
+        "use_flash_attn": lumina_use_flash_attn if lumina_checkbox else None,
+        "use_sage_attn": lumina_use_sage_attn if lumina_checkbox else None,
         # Anima specific parameters
         "qwen3": anima_qwen3 if anima_checkbox else None,
         "llm_adapter_path": (
@@ -2407,6 +2511,7 @@ def lora_tab(
                             "Kohya LoHa",
                             "Kohya LoKr",
                             "LoRA-FA",
+                            "Lumina",
                             "LyCORIS/iA3",
                             "LyCORIS/BOFT",
                             "LyCORIS/Diag-OFT",
@@ -3218,6 +3323,13 @@ def lora_tab(
                 anima_checkbox=source_model.anima_checkbox,
             )
 
+            # Add Lumina Image 2.0 Parameters
+            lumina_training = luminaTraining(
+                headless=headless,
+                config=config,
+                lumina_checkbox=source_model.lumina_checkbox,
+            )
+
             with gr.Accordion(
                 "Advanced", open=False, elem_classes="advanced_background"
             ):
@@ -3673,6 +3785,31 @@ def lora_tab(
             ("anima_compile_fullgraph", anima_training.compile_fullgraph),
             ("anima_compile_cache_size_limit", anima_training.compile_cache_size_limit),
             ("anima_checkbox", source_model.anima_checkbox),
+            (
+                "lumina_cache_text_encoder_outputs",
+                lumina_training.cache_text_encoder_outputs,
+            ),
+            (
+                "lumina_cache_text_encoder_outputs_to_disk",
+                lumina_training.cache_text_encoder_outputs_to_disk,
+            ),
+            ("lumina_gemma2", lumina_training.gemma2),
+            ("lumina_ae", lumina_training.ae),
+            ("lumina_discrete_flow_shift", lumina_training.discrete_flow_shift),
+            (
+                "lumina_model_prediction_type",
+                lumina_training.model_prediction_type,
+            ),
+            ("lumina_timestep_sampling", lumina_training.timestep_sampling),
+            ("lumina_sigmoid_scale", lumina_training.sigmoid_scale),
+            (
+                "lumina_gemma2_max_token_length",
+                lumina_training.gemma2_max_token_length,
+            ),
+            ("lumina_system_prompt", lumina_training.system_prompt),
+            ("lumina_use_flash_attn", lumina_training.use_flash_attn),
+            ("lumina_use_sage_attn", lumina_training.use_sage_attn),
+            ("lumina_checkbox", source_model.lumina_checkbox),
         ]
         settings_list = [comp for _, comp in FIELD_REGISTRY]
 

--- a/tests/test_lumina_lora_gui.py
+++ b/tests/test_lumina_lora_gui.py
@@ -1,0 +1,190 @@
+"""Regression tests for GH issue #3360: Lumina Image 2.0 LoRA training
+support in the GUI.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import lora_gui
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_toml,
+    mock_executor,
+)
+
+FIXTURE = "test/config/locon-AdamW8bit-toml.json"
+
+NUMERIC_FIXUPS = (
+    "max_train_steps",
+    "max_train_epochs",
+    "num_processes",
+    "num_machines",
+    "gradient_accumulation_steps",
+    "seed",
+    "vae_batch_size",
+    "save_every_n_steps",
+    "save_every_n_epochs",
+    "save_last_n_steps",
+    "save_last_n_steps_state",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "lr_scheduler_num_cycles",
+    "min_bucket_reso",
+    "max_bucket_reso",
+    "bucket_reso_steps",
+    "max_data_loader_n_workers",
+    "keep_tokens",
+    "clip_skip",
+    "max_token_length",
+    "caption_dropout_every_n_epochs",
+    "min_snr_gamma",
+    "min_timestep",
+    "max_timestep",
+    "sample_every_n_steps",
+    "sample_every_n_epochs",
+    "gpu_ids",
+    "main_process_port",
+    "num_cpu_threads_per_process",
+    "t5xxl_max_token_length",
+    "block_lr_zero_threshold",
+    "lumina_gemma2_max_token_length",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "t5xxl",
+    "sd3_clip_l",
+    "sd3_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "huggingface_repo_id",
+    "huggingface_token",
+    "huggingface_repo_type",
+    "huggingface_repo_visibility",
+    "huggingface_path_in_repo",
+    "metadata_author",
+    "metadata_description",
+    "metadata_license",
+    "metadata_tags",
+    "metadata_title",
+    "log_with",
+    "log_config",
+    "loss_type",
+    "huber_schedule",
+    "lr_scheduler_type",
+    "dynamo_backend",
+    "dynamo_mode",
+    "extra_accelerate_launch_args",
+    "network_weights",
+    "model_prediction_type",
+    "timestep_sampling",
+    "train_blocks",
+    "weighting_scheme",
+    "in_dims",
+    "lumina_system_prompt",
+)
+
+LUMINA_OVERRIDES = {
+    "LoRA_type": "Lumina",
+    "lumina_checkbox": True,
+    "lumina_gemma2": "/models/gemma-2-2b.safetensors",
+    "lumina_ae": "/models/ae.safetensors",
+    "lumina_discrete_flow_shift": 6.0,
+    "lumina_model_prediction_type": "raw",
+    "lumina_timestep_sampling": "nextdit_shift",
+    "lumina_sigmoid_scale": 1.0,
+    "lumina_gemma2_max_token_length": 256,
+    "lumina_system_prompt": (
+        "You are an assistant designed to generate high-quality images "
+        "based on user prompts."
+    ),
+    "lumina_use_flash_attn": False,
+    "lumina_use_sage_attn": False,
+    "lumina_cache_text_encoder_outputs": True,
+    "lumina_cache_text_encoder_outputs_to_disk": False,
+}
+
+
+class TestLuminaLoraConfigOutput(unittest.TestCase):
+    """End-to-end: train_model(print_only=True) writes a real TOML file we
+    can inspect for the Lumina Image 2.0 specific keys #3360 requires.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**LUMINA_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_network_module_is_lora_lumina(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("network_module"), "networks.lora_lumina")
+
+    def test_model_paths_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("gemma2"), "/models/gemma-2-2b.safetensors")
+        self.assertEqual(config.get("ae"), "/models/ae.safetensors")
+
+    def test_flow_matching_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("discrete_flow_shift"), 6.0)
+        self.assertEqual(config.get("model_prediction_type"), "raw")
+        self.assertEqual(config.get("timestep_sampling"), "nextdit_shift")
+        self.assertEqual(config.get("sigmoid_scale"), 1.0)
+
+    def test_system_prompt_and_token_length_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("gemma2_max_token_length"), 256)
+        self.assertIn("high-quality images", config.get("system_prompt", ""))
+
+    def test_text_encoder_cache_flags_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertTrue(config.get("cache_text_encoder_outputs"))
+        self.assertNotIn("cache_text_encoder_outputs_to_disk", config)
+
+    def test_attention_flags_forwarded_when_set(self):
+        config = self._run_and_load_toml(
+            {"lumina_use_flash_attn": True, "lumina_use_sage_attn": True}
+        )
+        self.assertTrue(config.get("use_flash_attn"))
+        self.assertTrue(config.get("use_sage_attn"))
+
+    def test_incompatible_sd_args_are_excluded(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("max_token_length", config)
+        self.assertNotIn("clip_skip", config)
+
+    def test_text_encoder_lora_is_not_forced_off(self):
+        """Lumina can train Gemma2 LoRA unless the user opts into unet-only,
+        so network_train_unet_only must not be forced True just because the
+        Lumina checkbox is set (unlike HunyuanImage-2.1).
+        """
+        config = self._run_and_load_toml({"text_encoder_lr": 0.0001, "unet_lr": 0.0001})
+        self.assertNotIn("network_train_unet_only", config)
+        self.assertNotIn("network_train_text_encoder_only", config)
+
+    def test_script_selection_invokes_lumina_train_network(self):
+        with patch.object(lora_gui, "print_command_and_toml") as mocked:
+            kwargs = build_train_model_kwargs(
+                lora_gui.train_model,
+                FIXTURE,
+                numeric_fixups=NUMERIC_FIXUPS,
+                string_overrides=STRING_OVERRIDES,
+                overrides=LUMINA_OVERRIDES,
+            )
+            mock_executor(lora_gui)
+            with patch.object(
+                lora_gui, "get_executable_path", return_value="accelerate"
+            ):
+                lora_gui.train_model(**kwargs)
+            self.assertTrue(mocked.called)
+            run_cmd = mocked.call_args[0][0]
+            self.assertTrue(any("lumina_train_network.py" in part for part in run_cmd))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add Lumina Image 2.0 as a LoRA model family in the GUI, wrapping `sd-scripts/lumina_train_network.py` with `networks.lora_lumina`.
- New `class_lumina` widget (Gemma2, AE, flow-matching, system prompt, flash/sage attn, TE cache) + source-model checkbox mutual exclusion with other families.
- Command/TOML builder forwards Lumina-specific flags and strips incompatible SD args (`clip_skip`, `max_token_length`).

Closes #3360

## Test plan

- [x] `pytest tests/test_lumina_lora_gui.py` (9 new cases)
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (179 passed)
- [x] Sibling regressions: Hunyuan, Anima, LoRA FIELD_REGISTRY, LoHa/LoKr
- [x] Manual: enable Lumina checkbox + LoRA type Lumina, print command, confirm `lumina_train_network.py` and expected flags

## Notes

- Fine-tune via `lumina_train.py` remains #3521 (reuses `class_lumina`).
- `sd-scripts` submodule unchanged.