### PR TITLE
feat: Lumina Image 2.0 full fine-tune support (#3521)

### DIFF
--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -41,6 +41,7 @@ from .class_metadata import MetaData
 from .class_gui_config import KohyaSSGUIConfig
 from .class_flux1 import flux1Training
 from .class_anima import animaTraining
+from .class_lumina import luminaTraining
 
 from .custom_logging import setup_logging
 
@@ -286,6 +287,20 @@ def save_configuration(
     anima_compile_fullgraph,
     anima_compile_cache_size_limit,
     anima_checkbox,
+    # Lumina Image 2.0
+    lumina_cache_text_encoder_outputs,
+    lumina_cache_text_encoder_outputs_to_disk,
+    lumina_gemma2,
+    lumina_ae,
+    lumina_discrete_flow_shift,
+    lumina_model_prediction_type,
+    lumina_timestep_sampling,
+    lumina_sigmoid_scale,
+    lumina_gemma2_max_token_length,
+    lumina_system_prompt,
+    lumina_use_flash_attn,
+    lumina_use_sage_attn,
+    lumina_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -531,6 +546,20 @@ def open_configuration(
     anima_compile_fullgraph,
     anima_compile_cache_size_limit,
     anima_checkbox,
+    # Lumina Image 2.0
+    lumina_cache_text_encoder_outputs,
+    lumina_cache_text_encoder_outputs_to_disk,
+    lumina_gemma2,
+    lumina_ae,
+    lumina_discrete_flow_shift,
+    lumina_model_prediction_type,
+    lumina_timestep_sampling,
+    lumina_sigmoid_scale,
+    lumina_gemma2_max_token_length,
+    lumina_system_prompt,
+    lumina_use_flash_attn,
+    lumina_use_sage_attn,
+    lumina_checkbox,
     training_preset,
 ):
     # Get list of function parameters and values
@@ -782,6 +811,20 @@ def train_model(
     anima_compile_fullgraph,
     anima_compile_cache_size_limit,
     anima_checkbox,
+    # Lumina Image 2.0
+    lumina_cache_text_encoder_outputs,
+    lumina_cache_text_encoder_outputs_to_disk,
+    lumina_gemma2,
+    lumina_ae,
+    lumina_discrete_flow_shift,
+    lumina_model_prediction_type,
+    lumina_timestep_sampling,
+    lumina_sigmoid_scale,
+    lumina_gemma2_max_token_length,
+    lumina_system_prompt,
+    lumina_use_flash_attn,
+    lumina_use_sage_attn,
+    lumina_checkbox,
 ):
     # Get list of function parameters and values
     parameters = list(locals().items())
@@ -1029,6 +1072,8 @@ def train_model(
         run_cmd.append(rf"{scriptdir}/sd-scripts/flux_train.py")
     elif anima_checkbox:
         run_cmd.append(rf"{scriptdir}/sd-scripts/anima_train.py")
+    elif lumina_checkbox:
+        run_cmd.append(rf"{scriptdir}/sd-scripts/lumina_train.py")
     else:
         run_cmd.append(rf"{scriptdir}/sd-scripts/fine_tune.py")
 
@@ -1042,17 +1087,19 @@ def train_model(
         or (sd3_checkbox and sd3_cache_text_encoder_outputs)
         or (flux1_checkbox and flux1_cache_text_encoder_outputs)
         or (anima_checkbox and anima_cache_text_encoder_outputs)
+        or (lumina_checkbox and lumina_cache_text_encoder_outputs)
     )
     cache_text_encoder_outputs_to_disk = (
         (sd3_checkbox and sd3_cache_text_encoder_outputs_to_disk)
         or (flux1_checkbox and flux1_cache_text_encoder_outputs_to_disk)
         or (anima_checkbox and anima_cache_text_encoder_outputs_to_disk)
+        or (lumina_checkbox and lumina_cache_text_encoder_outputs_to_disk)
     )
     no_half_vae = sdxl_checkbox and sdxl_no_half_vae
 
     # --train_inpainting is only supported by fine_tune.py/sdxl_train.py
     train_inpainting = train_inpainting and not (
-        sd3_checkbox or flux1_checkbox or anima_checkbox
+        sd3_checkbox or flux1_checkbox or anima_checkbox or lumina_checkbox
     )
     if train_inpainting:
         # Masks are generated randomly per training step from the source
@@ -1098,7 +1145,11 @@ def train_model(
         "caption_dropout_rate": caption_dropout_rate,
         "caption_extension": caption_extension,
         "clip_l": flux1_clip_l if flux1_checkbox else clip_l if sd3_checkbox else None,
-        "clip_skip": (clip_skip if clip_skip != 0 and not anima_checkbox else None),
+        "clip_skip": (
+            clip_skip
+            if clip_skip != 0 and not anima_checkbox and not lumina_checkbox
+            else None
+        ),
         "color_aug": color_aug,
         "dataset_config": dataset_config,
         "dataset_repeats": int(dataset_repeats),
@@ -1154,7 +1205,11 @@ def train_model(
         "masked_loss": masked_loss,
         "max_bucket_reso": int(max_bucket_reso),
         "max_timestep": max_timestep if max_timestep != 0 else None,
-        "max_token_length": (int(max_token_length) if not anima_checkbox else None),
+        "max_token_length": (
+            int(max_token_length)
+            if not anima_checkbox and not lumina_checkbox
+            else None
+        ),
         "max_train_epochs": (
             int(max_train_epochs) if int(max_train_epochs) != 0 else None
         ),
@@ -1252,19 +1307,31 @@ def train_model(
         # Flux.1 specific parameters
         # "cache_text_encoder_outputs": see previous assignment above for code
         # "cache_text_encoder_outputs_to_disk": see previous assignment above for code
-        "ae": ae if flux1_checkbox else None,
+        "ae": (lumina_ae if lumina_checkbox else ae if flux1_checkbox else None),
         # "clip_l": see previous assignment above for code
         # "t5xxl": see previous assignment above for code
         "discrete_flow_shift": (
-            float(anima_discrete_flow_shift)
-            if anima_checkbox
-            else discrete_flow_shift if flux1_checkbox else None
+            float(lumina_discrete_flow_shift)
+            if lumina_checkbox
+            else (
+                float(anima_discrete_flow_shift)
+                if anima_checkbox
+                else discrete_flow_shift if flux1_checkbox else None
+            )
         ),
-        "model_prediction_type": model_prediction_type if flux1_checkbox else None,
+        "model_prediction_type": (
+            lumina_model_prediction_type
+            if lumina_checkbox
+            else model_prediction_type if flux1_checkbox else None
+        ),
         "timestep_sampling": (
-            anima_timestep_sampling
-            if anima_checkbox
-            else timestep_sampling if flux1_checkbox else None
+            lumina_timestep_sampling
+            if lumina_checkbox
+            else (
+                anima_timestep_sampling
+                if anima_checkbox
+                else timestep_sampling if flux1_checkbox else None
+            )
         ),
         # split_mode/train_blocks are LoRA-only (flux_train_network.py); this
         # tab only ever targets flux_train.py, which does not accept them.
@@ -1279,24 +1346,32 @@ def train_model(
             cpu_offload_checkpointing if flux1_checkbox else None
         ),
         "blocks_to_swap": (
-            blocks_to_swap if flux1_checkbox or anima_checkbox else None
+            blocks_to_swap
+            if flux1_checkbox or anima_checkbox or lumina_checkbox
+            else None
         ),
         "single_blocks_to_swap": single_blocks_to_swap if flux1_checkbox else None,
         "double_blocks_to_swap": double_blocks_to_swap if flux1_checkbox else None,
         "show_timesteps": (
             show_timesteps
-            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox or lumina_checkbox)
+            and show_timesteps
             else None
         ),
         "show_timesteps_resolution": (
             show_timesteps_resolution
-            if (flux1_checkbox or sd3_checkbox or anima_checkbox) and show_timesteps
+            if (flux1_checkbox or sd3_checkbox or anima_checkbox or lumina_checkbox)
+            and show_timesteps
             else None
         ),
         "mem_eff_save": mem_eff_save if flux1_checkbox else None,
         "apply_t5_attn_mask": apply_t5_attn_mask if flux1_checkbox else None,
-        # Anima specific parameters
-        "sigmoid_scale": (float(anima_sigmoid_scale) if anima_checkbox else None),
+        # Anima / Lumina shared DiT-family parameter
+        "sigmoid_scale": (
+            float(lumina_sigmoid_scale)
+            if lumina_checkbox
+            else float(anima_sigmoid_scale) if anima_checkbox else None
+        ),
         "attn_mode": (
             anima_attn_mode if anima_checkbox and anima_attn_mode != "torch" else None
         ),
@@ -1352,6 +1427,18 @@ def train_model(
             if anima_checkbox and anima_compile and anima_compile_cache_size_limit
             else None
         ),
+        # Lumina Image 2.0 specific parameters
+        "gemma2": lumina_gemma2 if lumina_checkbox else None,
+        "gemma2_max_token_length": (
+            int(lumina_gemma2_max_token_length)
+            if lumina_checkbox and lumina_gemma2_max_token_length
+            else None
+        ),
+        "system_prompt": (
+            lumina_system_prompt if lumina_checkbox and lumina_system_prompt else None
+        ),
+        "use_flash_attn": lumina_use_flash_attn if lumina_checkbox else None,
+        "use_sage_attn": lumina_use_sage_attn if lumina_checkbox else None,
     }
 
     # Given dictionary `config_toml_data`
@@ -1577,6 +1664,14 @@ def finetune_tab(
                 headless=headless,
                 config=config,
                 anima_checkbox=source_model.anima_checkbox,
+                finetuning=True,
+            )
+
+            # Add Lumina Image 2.0 Parameters
+            lumina_training = luminaTraining(
+                headless=headless,
+                config=config,
+                lumina_checkbox=source_model.lumina_checkbox,
                 finetuning=True,
             )
 
@@ -1883,6 +1978,31 @@ def finetune_tab(
                 anima_training.compile_cache_size_limit,
             ),
             ("anima_checkbox", source_model.anima_checkbox),
+            (
+                "lumina_cache_text_encoder_outputs",
+                lumina_training.cache_text_encoder_outputs,
+            ),
+            (
+                "lumina_cache_text_encoder_outputs_to_disk",
+                lumina_training.cache_text_encoder_outputs_to_disk,
+            ),
+            ("lumina_gemma2", lumina_training.gemma2),
+            ("lumina_ae", lumina_training.ae),
+            ("lumina_discrete_flow_shift", lumina_training.discrete_flow_shift),
+            (
+                "lumina_model_prediction_type",
+                lumina_training.model_prediction_type,
+            ),
+            ("lumina_timestep_sampling", lumina_training.timestep_sampling),
+            ("lumina_sigmoid_scale", lumina_training.sigmoid_scale),
+            (
+                "lumina_gemma2_max_token_length",
+                lumina_training.gemma2_max_token_length,
+            ),
+            ("lumina_system_prompt", lumina_training.system_prompt),
+            ("lumina_use_flash_attn", lumina_training.use_flash_attn),
+            ("lumina_use_sage_attn", lumina_training.use_sage_attn),
+            ("lumina_checkbox", source_model.lumina_checkbox),
         ]
         settings_list = [comp for _, comp in FIELD_REGISTRY]
 

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -1441,12 +1441,12 @@ def train_model(
         "use_sage_attn": lumina_use_sage_attn if lumina_checkbox else None,
     }
 
-    # Given dictionary `config_toml_data`
-    # Remove all values = ""
+    # Drop empty/absent values only. Use identity for False so numeric 0 / 0.0
+    # (e.g. sigmoid_scale=0.0) are kept — `0 == False` would otherwise omit them.
     config_toml_data = {
         key: value
         for key, value in config_toml_data.items()
-        if value not in ["", False, None]
+        if value not in ("", None) and value is not False
     }
 
     config_toml_data["max_data_loader_n_workers"] = int(max_data_loader_n_workers)

--- a/tests/test_lumina_finetune_gui.py
+++ b/tests/test_lumina_finetune_gui.py
@@ -170,6 +170,12 @@ class TestLuminaFinetuneConfigOutput(unittest.TestCase):
         config = self._run_and_load_toml({"blocks_to_swap": 8})
         self.assertEqual(config.get("blocks_to_swap"), 8)
 
+    def test_zero_sigmoid_scale_is_preserved(self):
+        """TOML cleanup must not drop 0.0 via `0.0 == False` identity trap."""
+        config = self._run_and_load_toml({"lumina_sigmoid_scale": 0.0})
+        self.assertIn("sigmoid_scale", config)
+        self.assertEqual(config.get("sigmoid_scale"), 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lumina_finetune_gui.py
+++ b/tests/test_lumina_finetune_gui.py
@@ -1,0 +1,175 @@
+"""Regression tests for GH issue #3521: Lumina Image 2.0 full fine-tune
+support in the GUI (finetune tab → lumina_train.py).
+"""
+
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import finetune_gui
+from conftest import (
+    build_train_model_kwargs,
+    run_train_model_and_load_toml,
+    mock_executor,
+)
+
+FIXTURE = "test/config/finetune-AdamW-toml.json"
+
+NUMERIC_FIXUPS = (
+    "lr_warmup_steps",
+    "huber_scale",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "logit_mean",
+    "logit_std",
+    "mode_scale",
+    "sd3_text_encoder_batch_size",
+    "t5xxl_max_token_length",
+    "guidance_scale",
+    "blocks_to_swap",
+    "single_blocks_to_swap",
+    "double_blocks_to_swap",
+    "discrete_flow_shift",
+    "lumina_discrete_flow_shift",
+    "lumina_sigmoid_scale",
+    "lumina_gemma2_max_token_length",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "clip_g",
+    "t5xxl",
+    "flux1_clip_l",
+    "flux1_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "log_config",
+    "lr_scheduler_type",
+    "model_prediction_type",
+    "timestep_sampling",
+    "weighting_scheme",
+    "lumina_gemma2",
+    "lumina_ae",
+    "lumina_model_prediction_type",
+    "lumina_timestep_sampling",
+    "lumina_system_prompt",
+)
+
+LUMINA_OVERRIDES = {
+    "lumina_checkbox": True,
+    "lumina_gemma2": "/models/gemma-2-2b.safetensors",
+    "lumina_ae": "/models/ae.safetensors",
+    "lumina_discrete_flow_shift": 6.0,
+    "lumina_model_prediction_type": "raw",
+    "lumina_timestep_sampling": "nextdit_shift",
+    "lumina_sigmoid_scale": 1.0,
+    "lumina_gemma2_max_token_length": 256,
+    "lumina_system_prompt": (
+        "You are an assistant designed to generate high-quality images "
+        "based on user prompts."
+    ),
+    "lumina_use_flash_attn": False,
+    "lumina_use_sage_attn": False,
+    "lumina_cache_text_encoder_outputs": True,
+    "lumina_cache_text_encoder_outputs_to_disk": False,
+}
+
+
+class TestLuminaFinetuneConfigOutput(unittest.TestCase):
+    """End-to-end: train_model(print_only=True) writes a real TOML file we
+    can inspect for the Lumina Image 2.0 fine-tune keys #3521 requires.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={**LUMINA_OVERRIDES, **overrides},
+        )
+        return run_train_model_and_load_toml(finetune_gui, kwargs)
+
+    def test_script_selection_invokes_lumina_train(self):
+        with patch.object(finetune_gui, "print_command_and_toml") as mocked:
+            kwargs = build_train_model_kwargs(
+                finetune_gui.train_model,
+                FIXTURE,
+                numeric_fixups=NUMERIC_FIXUPS,
+                string_overrides=STRING_OVERRIDES,
+                overrides=LUMINA_OVERRIDES,
+            )
+            mock_executor(finetune_gui)
+            with patch.object(
+                finetune_gui, "get_executable_path", return_value="accelerate"
+            ):
+                finetune_gui.train_model(**kwargs)
+            self.assertTrue(mocked.called)
+            run_cmd = mocked.call_args[0][0]
+            self.assertTrue(
+                any("lumina_train.py" in part for part in run_cmd),
+                f"expected lumina_train.py in {run_cmd}",
+            )
+            joined = " ".join(str(p) for p in run_cmd)
+            self.assertNotIn("lumina_train_network.py", joined)
+            self.assertNotIn("flux_train.py", joined)
+            self.assertNotIn("fine_tune.py", joined)
+
+    def test_model_paths_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("gemma2"), "/models/gemma-2-2b.safetensors")
+        self.assertEqual(config.get("ae"), "/models/ae.safetensors")
+
+    def test_flow_matching_params_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("discrete_flow_shift"), 6.0)
+        self.assertEqual(config.get("model_prediction_type"), "raw")
+        self.assertEqual(config.get("timestep_sampling"), "nextdit_shift")
+        self.assertEqual(config.get("sigmoid_scale"), 1.0)
+
+    def test_system_prompt_and_token_length_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertEqual(config.get("gemma2_max_token_length"), 256)
+        self.assertIn("high-quality images", config.get("system_prompt", ""))
+
+    def test_text_encoder_cache_flags_are_forwarded(self):
+        config = self._run_and_load_toml({})
+        self.assertTrue(config.get("cache_text_encoder_outputs"))
+        self.assertNotIn("cache_text_encoder_outputs_to_disk", config)
+
+    def test_attention_flags_forwarded_when_set(self):
+        config = self._run_and_load_toml(
+            {"lumina_use_flash_attn": True, "lumina_use_sage_attn": True}
+        )
+        self.assertTrue(config.get("use_flash_attn"))
+        self.assertTrue(config.get("use_sage_attn"))
+
+    def test_incompatible_sd_args_are_excluded(self):
+        config = self._run_and_load_toml({})
+        self.assertNotIn("max_token_length", config)
+        self.assertNotIn("clip_skip", config)
+
+    def test_lora_only_args_are_excluded(self):
+        """Full fine-tune must never emit LoRA network keys."""
+        config = self._run_and_load_toml({})
+        self.assertNotIn("network_module", config)
+        self.assertNotIn("network_dim", config)
+        self.assertNotIn("network_alpha", config)
+
+    def test_train_inpainting_dropped_for_lumina_backend(self):
+        config = self._run_and_load_toml({"train_inpainting": True})
+        self.assertNotIn("train_inpainting", config)
+
+    def test_show_timesteps_forwarded_for_lumina(self):
+        config = self._run_and_load_toml(
+            {"show_timesteps": "console", "show_timesteps_resolution": "1024"}
+        )
+        self.assertEqual(config.get("show_timesteps"), "console")
+        self.assertEqual(config.get("show_timesteps_resolution"), "1024")
+
+    def test_blocks_to_swap_forwarded_for_lumina(self):
+        config = self._run_and_load_toml({"blocks_to_swap": 8})
+        self.assertEqual(config.get("blocks_to_swap"), 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Lumina Image 2.0 full fine-tune wiring on the Finetune tab, reusing `class_lumina` for Gemma2/AE pickers and Lumina-specific training args.
- Generated command targets `sd-scripts/lumina_train.py` (not `lumina_train_network.py`) with flow-matching, system prompt, attention, cache, and `blocks_to_swap` flags.
- Regression coverage in `tests/test_lumina_finetune_gui.py` for script selection, TOML forwarding, LoRA-key exclusion, and inpainting drop.

Closes #3521

## Test plan
- [x] `pytest tests/test_lumina_finetune_gui.py`
- [x] `pytest tests/ test/test_allowed_paths.py` (189 passed)
- [x] Manual GUI smoke: open Finetune tab, check Lumina, confirm accordion fields match LoRA tab, Print training command shows `lumina_train.py`