### PR TITLE
Clean up HunyuanImage-2.1 LoRA arg-forwarding cosmetics

### DIFF
--- a/kohya_gui/class_hunyuan_image.py
+++ b/kohya_gui/class_hunyuan_image.py
@@ -160,7 +160,7 @@ class hunyuanImageTraining:
                         step=1,
                         interactive=True,
                     )
-                    self.hunyuan_image_cache_text_encoder_outputs = gr.Checkbox(
+                    self.cache_text_encoder_outputs = gr.Checkbox(
                         label="Cache Text Encoder Outputs",
                         value=self.config.get(
                             "hunyuan_image.cache_text_encoder_outputs", False
@@ -168,7 +168,7 @@ class hunyuanImageTraining:
                         info="Cache Qwen2.5-VL and byT5 text encoder outputs to reduce memory usage",
                         interactive=True,
                     )
-                    self.hunyuan_image_cache_text_encoder_outputs_to_disk = gr.Checkbox(
+                    self.cache_text_encoder_outputs_to_disk = gr.Checkbox(
                         label="Cache Text Encoder Outputs to Disk",
                         value=self.config.get(
                             "hunyuan_image.cache_text_encoder_outputs_to_disk", False

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -2132,7 +2132,7 @@ def train_model(
         "training_comment": training_comment,
         "unet_lr": unet_lr_float if unet_lr_float != 0.0 else None,
         "log_with": log_with,
-        "v2": v2,
+        "v2": v2 if not hunyuan_image_checkbox else None,
         "v_parameterization": v_parameterization,
         "v_pred_like_loss": v_pred_like_loss if v_pred_like_loss != 0 else None,
         "vae": vae_value,
@@ -2256,11 +2256,7 @@ def train_model(
         "attn_mode": (
             anima_attn_mode
             if anima_checkbox and anima_attn_mode != "torch"
-            else (
-                hunyuan_attn_mode
-                if hunyuan_image_checkbox and hunyuan_attn_mode != "torch"
-                else None
-            )
+            else (hunyuan_attn_mode if hunyuan_image_checkbox else None)
         ),
         "split_attn": (
             anima_split_attn
@@ -3728,11 +3724,11 @@ def lora_tab(
             ("sd3_checkbox", source_model.sd3_checkbox),
             (
                 "hunyuan_image_cache_text_encoder_outputs",
-                hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs,
+                hunyuan_image_training.cache_text_encoder_outputs,
             ),
             (
                 "hunyuan_image_cache_text_encoder_outputs_to_disk",
-                hunyuan_image_training.hunyuan_image_cache_text_encoder_outputs_to_disk,
+                hunyuan_image_training.cache_text_encoder_outputs_to_disk,
             ),
             ("hunyuan_text_encoder", hunyuan_image_training.text_encoder),
             ("hunyuan_byt5", hunyuan_image_training.byt5),

--- a/tests/test_hunyuan_image_lora_gui.py
+++ b/tests/test_hunyuan_image_lora_gui.py
@@ -148,6 +148,25 @@ class TestHunyuanImageLoraConfigOutput(unittest.TestCase):
         self.assertNotIn("max_token_length", config)
         self.assertNotIn("clip_skip", config)
 
+    def test_v2_is_excluded_even_when_true(self):
+        """#3538: --v2 is incompatible with HunyuanImage-2.1; exclude it the
+        same way as clip_skip / max_token_length, even if a caller forces v2=True
+        (the UI toggle group normally prevents this combination).
+        """
+        config = self._run_and_load_toml({"v2": True})
+        self.assertNotIn("v2", config)
+
+    def test_attn_mode_torch_is_forwarded_verbatim(self):
+        """#3538: explicit 'torch' selection is written through, not collapsed
+        to None (backend default). Matches other HunyuanImage dropdowns.
+        """
+        config = self._run_and_load_toml({"hunyuan_attn_mode": "torch"})
+        self.assertEqual(config.get("attn_mode"), "torch")
+
+    def test_attn_mode_non_default_is_forwarded(self):
+        config = self._run_and_load_toml({"hunyuan_attn_mode": "xformers"})
+        self.assertEqual(config.get("attn_mode"), "xformers")
+
     def test_script_selection_invokes_hunyuan_image_train_network(self):
         with patch.object(lora_gui, "print_command_and_toml") as mocked:
             kwargs = build_train_model_kwargs(
@@ -167,6 +186,27 @@ class TestHunyuanImageLoraConfigOutput(unittest.TestCase):
             self.assertTrue(
                 any("hunyuan_image_train_network.py" in part for part in run_cmd)
             )
+
+
+class TestHunyuanImageClassAttributeNames(unittest.TestCase):
+    """#3538: cache-text-encoder attrs should match the unprefixed style of
+    the other fields on hunyuanImageTraining (text_encoder, byt5, vae, …).
+    """
+
+    def test_cache_text_encoder_attrs_are_unprefixed(self):
+        import gradio as gr
+        from kohya_gui.class_hunyuan_image import hunyuanImageTraining
+
+        with gr.Blocks():
+            checkbox = gr.Checkbox(value=False)
+            training = hunyuanImageTraining(hunyuan_image_checkbox=checkbox)
+
+        self.assertTrue(hasattr(training, "cache_text_encoder_outputs"))
+        self.assertTrue(hasattr(training, "cache_text_encoder_outputs_to_disk"))
+        self.assertFalse(hasattr(training, "hunyuan_image_cache_text_encoder_outputs"))
+        self.assertFalse(
+            hasattr(training, "hunyuan_image_cache_text_encoder_outputs_to_disk")
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Follow-up cosmetics from the #3537 code review (HunyuanImage-2.1 LoRA, closes #3522). None of these affect training correctness.

1. **Exclude `--v2` for HunyuanImage-2.1** — same `not hunyuan_image_checkbox` guard already used for `clip_skip` / `max_token_length`, so the incompatible arg is never written even if a caller forces `v2=True`.
2. **Forward `attn_mode` including explicit "torch"`** — drop the `!= "torch"` collapse so an explicit dropdown selection matches other HunyuanImage-2.1 dropdowns.
3. **Unprefix cache-text-encoder class attributes** — `self.cache_text_encoder_outputs` / `self.cache_text_encoder_outputs_to_disk` on `hunyuanImageTraining`, consistent with `text_encoder` / `byt5` / `vae`. Gradio/`train_model` param names stay `hunyuan_image_cache_*` for disambiguation.

## Test plan
- [x] `pytest tests/test_hunyuan_image_lora_gui.py` — covers v2 exclusion, attn_mode torch + xformers, unprefixed attrs
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (195 passed)
- [ ] Manual smoke (optional): select HunyuanImage-2.1, print command/TOML, confirm `attn_mode = "torch"` present and no `v2`

Closes #3538