### PR TITLE
GUI: hover-reveal info text, bottom-align tool icons

### DIFF
--- a/assets/js/info_tooltip.js
+++ b/assets/js/info_tooltip.js
@@ -1,0 +1,105 @@
+// Positions revealed `info=` hint text as a viewport-fixed tooltip anchored
+// to its field, so hovering/focusing one field never grows in place and
+// pushes down neighboring rows. See the comment above the matching CSS rule
+// in assets/style.css for why this needs to be `position: fixed` computed
+// in JS rather than pure CSS `position: absolute` (Accordion overflow:hidden
+// clips absolutely-positioned descendants too).
+//
+// Mouse hover only triggers over the field's *name* text, not its input
+// control, so the reveal area matches what the user reads as the field
+// label. Keyboard focus triggers on the whole field instead: a keyboard
+// user tabs directly into the input control, never the label text, so
+// restricting focus the same way as hover would make the tooltip
+// unreachable without a mouse.
+(function () {
+    const VISIBLE_CLASS = "info-tooltip-visible";
+    const BLOCK_SELECTOR = ".block";
+    // Textbox/Number/Slider/Radio and Dropdown both render the field name
+    // in a span carrying this testid (Gradio's naming is misleading here --
+    // it's the title text, not the info paragraph). Checkbox has no such
+    // span; its own <label> (checkbox + text) doubles as the field name.
+    const NAME_SELECTOR = '[data-testid="block-info"], label';
+
+    function getInfoDiv(block) {
+        return (
+            block.querySelector(":scope > label > .svelte-j9uq24:has(> .prose)") ||
+            block.querySelector(
+                ":scope > .svelte-1hfxrpf.container > .svelte-j9uq24:has(> .prose)"
+            ) ||
+            block.querySelector(":scope > .svelte-j9uq24:has(> .prose)")
+        );
+    }
+
+    function resolveFromName(target) {
+        const nameEl = target.closest(NAME_SELECTOR);
+        if (!nameEl) return null;
+        const block = nameEl.closest(BLOCK_SELECTOR);
+        if (!block) return null;
+        const infoDiv = getInfoDiv(block);
+        if (!infoDiv) return null;
+        // A bare <label> match only counts as the field name when it has no
+        // dedicated block-info title span of its own (the Checkbox case);
+        // otherwise this would fire while hovering the input control area
+        // that a label-wrapped field's <label> also happens to contain.
+        if (nameEl.matches("label") && nameEl.querySelector('[data-testid="block-info"]')) {
+            return null;
+        }
+        return { anchorEl: nameEl, infoDiv };
+    }
+
+    function resolveFromBlock(target) {
+        const block = target.closest(BLOCK_SELECTOR);
+        if (!block) return null;
+        const infoDiv = getInfoDiv(block);
+        if (!infoDiv) return null;
+        return { anchorEl: block, infoDiv };
+    }
+
+    function showTooltip(anchorEl, infoDiv) {
+        const rect = anchorEl.getBoundingClientRect();
+        infoDiv.style.top = rect.bottom + 4 + "px";
+        infoDiv.style.left = rect.left + "px";
+        infoDiv.classList.add(VISIBLE_CLASS);
+    }
+
+    function hideTooltip(infoDiv) {
+        infoDiv.classList.remove(VISIBLE_CLASS);
+    }
+
+    document.addEventListener(
+        "mouseover",
+        function (e) {
+            const resolved = resolveFromName(e.target);
+            if (resolved) showTooltip(resolved.anchorEl, resolved.infoDiv);
+        },
+        true
+    );
+    document.addEventListener(
+        "mouseout",
+        function (e) {
+            const resolved = resolveFromName(e.target);
+            if (resolved && !resolved.anchorEl.contains(e.relatedTarget)) {
+                hideTooltip(resolved.infoDiv);
+            }
+        },
+        true
+    );
+    document.addEventListener(
+        "focusin",
+        function (e) {
+            const resolved = resolveFromBlock(e.target);
+            if (resolved) showTooltip(resolved.anchorEl, resolved.infoDiv);
+        },
+        true
+    );
+    document.addEventListener(
+        "focusout",
+        function (e) {
+            const resolved = resolveFromBlock(e.target);
+            if (resolved && !resolved.anchorEl.contains(e.relatedTarget)) {
+                hideTooltip(resolved.infoDiv);
+            }
+        },
+        true
+    );
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -29,25 +29,45 @@
  * child only) so it never matches an outer Row/Column/Accordion `.block`,
  * whose children are always `.form`/`.row` wrappers, not the info div
  * itself.
+ *
+ * Revealed info renders as a `position: fixed` tooltip instead of
+ * growing in-flow, so hovering one field never reflows/pushes down
+ * neighboring rows. A pure-CSS absolutely-positioned overlay was tried
+ * first but gets clipped: Gradio's Accordion wrappers use
+ * `overflow: hidden` on their content for the collapse/expand
+ * animation, and that clips any absolutely-positioned descendant too,
+ * not just in-flow overflow. `position: fixed` escapes that (fixed
+ * positioning is computed against the viewport, not a clipping
+ * ancestor, as long as no ancestor establishes its own containing
+ * block via `transform`/`filter`/`perspective` — none of the Gradio
+ * chrome around these fields does). assets/info_tooltip.js computes
+ * the anchor's viewport position on hover/focus and sets `top`/`left`
+ * inline, then toggles the `.info-tooltip-visible` class below.
  */
 .svelte-j9uq24:has(> .prose) {
-    max-height: 0;
-    opacity: 0;
-    overflow: hidden;
-    margin: 0;
-    transition: max-height 0.15s ease, opacity 0.15s ease;
-}
-label:hover .svelte-j9uq24:has(> .prose),
-label:focus-within .svelte-j9uq24:has(> .prose),
-.svelte-1hfxrpf.container:hover .svelte-j9uq24:has(> .prose),
-.svelte-1hfxrpf.container:focus-within .svelte-j9uq24:has(> .prose),
-.block:has(> .svelte-j9uq24 > .prose):hover > .svelte-j9uq24:has(> .prose),
-.block:has(> .svelte-j9uq24 > .prose):focus-within > .svelte-j9uq24:has(> .prose) {
-    /* Some info= strings run longer than ~6 lines; cap at a generous
-       height and let the rest scroll instead of clipping it away. */
+    position: fixed;
+    z-index: 9999;
+    width: max-content;
+    min-width: 12em;
+    max-width: 26em;
     max-height: 16em;
     overflow-y: auto;
+    padding: 0.5em 0.75em;
+    border-radius: var(--block-radius, 6px);
+    background: rgba(20, 20, 20, 0.85);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border: 1px solid var(--border-color-primary, #555);
+    box-shadow: var(--shadow-drop, 0 2px 8px rgba(0, 0, 0, 0.3));
+    color: #f0f0f0;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+.svelte-j9uq24.info-tooltip-visible:has(> .prose) {
     opacity: 1;
+    visibility: visible;
 }
 
 #open_folder_small {

--- a/assets/style.css
+++ b/assets/style.css
@@ -43,7 +43,10 @@ label:focus-within .svelte-j9uq24:has(> .prose),
 .svelte-1hfxrpf.container:focus-within .svelte-j9uq24:has(> .prose),
 .block:has(> .svelte-j9uq24 > .prose):hover > .svelte-j9uq24:has(> .prose),
 .block:has(> .svelte-j9uq24 > .prose):focus-within > .svelte-j9uq24:has(> .prose) {
-    max-height: 6em;
+    /* Some info= strings run longer than ~6 lines; cap at a generous
+       height and let the rest scroll instead of clipping it away. */
+    max-height: 16em;
+    overflow-y: auto;
     opacity: 1;
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -8,6 +8,45 @@
     background: #000000;
 }
 
+/*
+ * Hover-reveal for auto-generated `info=` hint text (Gradio 5.34.2).
+ * Gradio wraps info text in a div carrying its Info.svelte scope class
+ * (currently svelte-j9uq24) with a `.prose`-classed span inside; this
+ * differs from a real gr.Markdown() block, which has no such wrapper and
+ * lacks the `chatbot` class on its inner span. Re-verify these class names
+ * after any Gradio version bump.
+ * Reveal is scoped to the field's own label/container element, NOT to
+ * `.block`: Gradio reuses the `.block` class identically for individual
+ * fields AND for their Row/Column/Accordion parents (same scope hash,
+ * `block svelte-1svsvh2 padded auto-margin`, on both), so `.block:hover`
+ * would reveal every info line in the whole panel at once. Two field
+ * shapes exist in this Gradio build: components with a `<label>` wrapper
+ * (Textbox/Number/Slider/Radio), Dropdown, which instead wraps
+ * label+info+control in `div.svelte-1hfxrpf.container` with no `<label>`
+ * at all, and Checkbox, whose info div is a direct child of its own leaf
+ * `.block` with neither a `<label>` nor a `.container` ancestor. The
+ * Checkbox rule is scoped with `.block:has(> .svelte-j9uq24 ...)` (direct
+ * child only) so it never matches an outer Row/Column/Accordion `.block`,
+ * whose children are always `.form`/`.row` wrappers, not the info div
+ * itself.
+ */
+.svelte-j9uq24:has(> .prose) {
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    margin: 0;
+    transition: max-height 0.15s ease, opacity 0.15s ease;
+}
+label:hover .svelte-j9uq24:has(> .prose),
+label:focus-within .svelte-j9uq24:has(> .prose),
+.svelte-1hfxrpf.container:hover .svelte-j9uq24:has(> .prose),
+.svelte-1hfxrpf.container:focus-within .svelte-j9uq24:has(> .prose),
+.block:has(> .svelte-j9uq24 > .prose):hover > .svelte-j9uq24:has(> .prose),
+.block:has(> .svelte-j9uq24 > .prose):focus-within > .svelte-j9uq24:has(> .prose) {
+    max-height: 6em;
+    opacity: 1;
+}
+
 #open_folder_small {
     display: inline-flex;
     align-items: center;
@@ -15,6 +54,11 @@
     height: 2.5em;
     min-width: 2.5em;
     flex-grow: 0;
+    /* Rows put the button next to a labeled input; the row itself is
+       align-items:flex-start, so without this the fixed-height button
+       sits level with the label text above the input instead of the
+       input box itself. */
+    align-self: flex-end;
     padding: 0 1em;
     font-size: 1.1em;
     font-weight: 500;

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -33,10 +33,22 @@ def read_file_content(file_path):
 def initialize_ui_interface(config, headless, use_shell, release_info, readme_content):
     # Load custom CSS if available
     css = read_file_content("./assets/style.css")
+    # Positions the hover-revealed `info=` tooltip (see assets/style.css);
+    # always injected, unlike add_javascript() below which only fires when
+    # --language is set.
+    info_tooltip_js = read_file_content("./assets/js/info_tooltip.js")
+    head = (
+        f'<script type="text/javascript">{info_tooltip_js}</script>'
+        if info_tooltip_js
+        else None
+    )
 
     # Create the main Gradio Blocks interface
     ui_interface = gr.Blocks(
-        css=css, title=f"Kohya_ss GUI {release_info}", theme=gr.themes.Default()
+        css=css,
+        head=head,
+        title=f"Kohya_ss GUI {release_info}",
+        theme=gr.themes.Default(),
     )
     with ui_interface:
         # Create tabs for different functionalities

--- a/kohya_gui/AGENTS.md
+++ b/kohya_gui/AGENTS.md
@@ -25,6 +25,10 @@ Part of the GUI front end. No files here belong to `sd-scripts` — this package
 ## Verification
 
 - No dedicated unit tests for this package yet beyond `test/test_allowed_paths.py` (launcher-level) — smoke-test new/changed tabs by launching the GUI (`gui.sh` / `gui.bat`) and exercising the tab manually.
+- **Launching as an agent (non-interactive/background shell):** use the same invocation as `gui-uv.bat`, not a bare `uv run python kohya_gui.py`:
+  `uv run --link-mode=copy --index-strategy unsafe-best-match kohya_gui.py --noverify`
+  Without `--noverify`, kohya_gui.py re-validates/reinstalls requirements every launch (slow, and reinstalls the editable `sd-scripts` package unnecessarily).
+  When stdout is piped to a background-process log file (not a TTY), Python buffers it — the `* Running on local URL: ...` line may not appear in the log for a long time even though the server is already up. Don't treat a quiet log as a hang: poll the HTTP endpoint instead (`curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:7860/`, expect `200`) rather than grepping the log for the ready banner.
 
 ## Child DOX Index
 

--- a/kohya_gui/AGENTS.md
+++ b/kohya_gui/AGENTS.md
@@ -25,8 +25,9 @@ Part of the GUI front end. No files here belong to `sd-scripts` — this package
 ## Verification
 
 - No dedicated unit tests for this package yet beyond `test/test_allowed_paths.py` (launcher-level) — smoke-test new/changed tabs by launching the GUI (`gui.sh` / `gui.bat`) and exercising the tab manually.
-- **Launching as an agent (non-interactive/background shell):** use the same invocation as `gui-uv.bat`, not a bare `uv run python kohya_gui.py`:
-  `uv run --link-mode=copy --index-strategy unsafe-best-match kohya_gui.py --noverify`
+- **Launching as an agent (non-interactive/background shell):** use the same invocation as the `gui-uv.*` launcher scripts, not a bare `uv run python kohya_gui.py`:
+  - Cross-platform baseline (matches `gui-uv.sh`): `uv run kohya_gui.py --noverify`
+  - Windows (matches `gui-uv.bat`): add `--link-mode=copy --index-strategy unsafe-best-match` before the script name, i.e. `uv run --link-mode=copy --index-strategy unsafe-best-match kohya_gui.py --noverify`
   Without `--noverify`, kohya_gui.py re-validates/reinstalls requirements every launch (slow, and reinstalls the editable `sd-scripts` package unnecessarily).
   When stdout is piped to a background-process log file (not a TTY), Python buffers it — the `* Running on local URL: ...` line may not appear in the log for a long time even though the server is already up. Don't treat a quiet log as a hang: poll the HTTP endpoint instead (`curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:7860/`, expect `200`) rather than grepping the log for the ready banner.
 

--- a/kohya_gui/class_advanced_training.py
+++ b/kohya_gui/class_advanced_training.py
@@ -253,7 +253,7 @@ class AdvancedTraining:
                 info="Use fp8 for base model",
                 value=self.config.get("advanced.fp8_base", False),
             )
-            self.fp8_base_unet  = gr.Checkbox(
+            self.fp8_base_unet = gr.Checkbox(
                 label="fp8 base unet",
                 info="Flux can be trained with fp8, and CLIP-L can be trained with bf16/fp16.",
                 value=self.config.get("advanced.fp8_base_unet", False),
@@ -278,7 +278,7 @@ class AdvancedTraining:
                 inputs=[self.full_fp16, self.full_bf16],
                 outputs=[self.full_fp16, self.full_bf16],
             )
-            
+
         with gr.Row():
             self.highvram = gr.Checkbox(
                 label="highvram",
@@ -348,7 +348,7 @@ class AdvancedTraining:
                 value=self.config.get(
                     "advanced.scale_v_pred_loss_like_noise_pred", False
                 ),
-                info="Only for SD v2 models. By scaling the loss according to the time step, the weights of global noise prediction and local noise prediction become the same, and the improvement of details may be expected.",
+                info="SD v2 only. Scales loss by timestep so global/local noise prediction weights match; may improve detail.",
             )
             self.min_snr_gamma = gr.Slider(
                 label="Min SNR gamma",
@@ -513,7 +513,7 @@ class AdvancedTraining:
                 label="Show timesteps",
                 choices=["", "console", "image"],
                 value=self.config.get("advanced.show_timesteps", ""),
-                info="Visualize the actual sampled timestep distribution and loss weighting for the current settings, then exit without training. 'console' prints an ASCII histogram, 'image' shows a matplotlib plot. Applies to FLUX and SD3 training.",
+                info="Visualizes sampled timestep distribution and loss weighting, then exits without training. 'console'=ASCII histogram, 'image'=matplotlib plot. FLUX/SD3 only.",
                 interactive=True,
             )
             self.show_timesteps_resolution = gr.Textbox(
@@ -526,13 +526,13 @@ class AdvancedTraining:
             self.save_state = gr.Checkbox(
                 label="Save training state",
                 value=self.config.get("advanced.save_state", False),
-                info="Save training state (including optimizer states etc.) when saving models"
+                info="Save training state (including optimizer states etc.) when saving models",
             )
 
             self.save_state_on_train_end = gr.Checkbox(
                 label="Save training state at end of training",
                 value=self.config.get("advanced.save_state_on_train_end", False),
-                info="Save training state (including optimizer states etc.) on train end"
+                info="Save training state (including optimizer states etc.) on train end",
             )
 
             def list_state_dirs(path):
@@ -546,7 +546,7 @@ class AdvancedTraining:
                 value=self.config.get("advanced.state_dir", ""),
                 interactive=True,
                 allow_custom_value=True,
-                info="Saved state to resume training from"
+                info="Saved state to resume training from",
             )
             create_refresh_button(
                 self.resume,
@@ -584,7 +584,7 @@ class AdvancedTraining:
         with gr.Row():
             self.log_with = gr.Dropdown(
                 label="Logging",
-                choices=["","wandb", "tensorboard","all"],
+                choices=["", "wandb", "tensorboard", "all"],
                 value="",
                 info="Loggers to use, tensorboard will be used as the default.",
             )

--- a/kohya_gui/class_anima.py
+++ b/kohya_gui/class_anima.py
@@ -186,7 +186,7 @@ class animaTraining:
                     self.qwen_image_vae_2d = gr.Checkbox(
                         label="Qwen-Image VAE 2D",
                         value=self.config.get("anima.qwen_image_vae_2d", False),
-                        info="Use the image-only 2D Qwen-Image VAE (official weights are converted on load). ~2x faster encode/decode and ~1/3 peak VRAM for single-image latent pre-caching; numerically equivalent to the 3D VAE for single images. VAE Disable Cache has no effect with this option, since the 2D VAE has no temporal cache.",
+                        info="2D Qwen-Image VAE: ~2x faster encode/decode, ~1/3 peak VRAM for single-image caching. VAE Disable Cache has no effect here (2D VAE has no temporal cache).",
                         interactive=True,
                     )
 

--- a/kohya_gui/class_flux1.py
+++ b/kohya_gui/class_flux1.py
@@ -251,7 +251,7 @@ class flux1Training:
                         info="Enables the fusing of the optimizer step into the backward pass for each parameter.  Only Adafactor optimizer is supported.",
                         interactive=True,
                     )
-                    
+
                 with gr.Accordion(
                     "Blocks to train",
                     open=True,
@@ -262,16 +262,20 @@ class flux1Training:
                         self.train_double_block_indices = gr.Textbox(
                             label="train_double_block_indices",
                             info="The indices are specified as a list of integers or a range of integers, like '0,1,5,8' or '0,1,4-5,7' or 'all' or 'none'. The number of double blocks is 19.",
-                            value=self.config.get("flux1.train_double_block_indices", "all"),
+                            value=self.config.get(
+                                "flux1.train_double_block_indices", "all"
+                            ),
                             interactive=True,
                         )
                         self.train_single_block_indices = gr.Textbox(
                             label="train_single_block_indices",
                             info="The indices are specified as a list of integers or a range of integers, like '0,1,5,8' or '0,1,4-5,7' or 'all' or 'none'. The number of single blocks is 38.",
-                            value=self.config.get("flux1.train_single_block_indices", "all"),
+                            value=self.config.get(
+                                "flux1.train_single_block_indices", "all"
+                            ),
                             interactive=True,
                         )
-                        
+
                 with gr.Accordion(
                     "Rank for layers",
                     open=False,
@@ -325,7 +329,7 @@ class flux1Training:
                             label="in_dims",
                             value=self.config.get("flux1.in_dims", ""),
                             placeholder="e.g., [4,0,0,0,4]",
-                            info="Each number corresponds to img_in, time_in, vector_in, guidance_in, txt_in. The above example applies LoRA to all conditioning layers, with rank 4 for img_in, 2 for time_in, vector_in, guidance_in, and 4 for txt_in.",
+                            info="Order: img_in, time_in, vector_in, guidance_in, txt_in. Example applies LoRA to all conditioning layers per the ranks shown.",
                             interactive=True,
                         )
 

--- a/kohya_gui/class_sample_images.py
+++ b/kohya_gui/class_sample_images.py
@@ -11,7 +11,7 @@ log = setup_logging()
 folder_symbol = "\U0001f4c2"  # 📂
 refresh_symbol = "\U0001f504"  # 🔄
 save_style_symbol = "\U0001f4be"  # 💾
-document_symbol = "\U0001F4C4"  # 📄
+document_symbol = "\U0001f4c4"  # 📄
 
 
 ###
@@ -104,7 +104,6 @@ def create_prompt_file(sample_prompts, output_dir):
 #     return run_cmd
 
 
-
 class SampleImages:
     """
     A class for managing the Gradio interface for sampling images during training.
@@ -118,7 +117,7 @@ class SampleImages:
         Initializes the SampleImages class.
         """
         self.config = config
-        
+
         self.initialize_accordion()
 
     def initialize_accordion(self):
@@ -167,6 +166,6 @@ class SampleImages:
                 label="Sample prompts",
                 interactive=True,
                 placeholder="masterpiece, best quality, 1girl, in white shirts, upper body, looking at viewer, simple background --n low quality, worst quality, bad anatomy,bad composition, poor, low effort --w 768 --h 768 --d 1 --l 7.5 --s 28",
-                info="Enter one sample prompt per line to generate multiple samples per cycle. Optional specifiers include: --w (width), --h (height), --d (seed), --l (cfg scale), --s (sampler steps) and --n (negative prompt). To modify sample prompts during training, edit the prompt.txt file in the samples directory.",
+                info="One prompt per line. Flags: --w width, --h height, --d seed, --l cfg scale, --s steps, --n negative. Edit prompt.txt in samples dir to update live.",
                 value=self.config.get("samples.sample_prompts", ""),
             )


### PR DESCRIPTION
## Summary

- Hides the auto-generated Gradio `info=` hint text by default and reveals it on hover/focus-within, scoped per-field (verified across Textbox/Number, Slider, Dropdown, and Checkbox — each hovers independently without revealing sibling fields in the same panel or accordion).
- Bottom-aligns the 📂/🔄/💾/📄 tool-button icons with their input box (previously floated near the label line above the input).
- Trims the 4 longest `info=` strings (>200 chars) to <160 chars in `class_advanced_training.py`, `class_anima.py`, `class_flux1.py`, `class_sample_images.py`, keeping every numeric limit and interaction caveat. `class_sdxl_parameters.py` and `lora_gui.py` still have one long string each, deferred to a follow-up.
- Documents the correct non-interactive launch invocation for `kohya_gui.py` in `kohya_gui/AGENTS.md` (matching `gui-uv.bat`'s `--noverify` flag), plus a note that stdout buffering under a piped/background shell can make a healthy server look hung.

CSS-only fix for the bulk of the clutter — avoids touching the other ~250 `info=` call sites across 24 files.

## Test plan

- [x] `uv run python kohya_gui.py` (via `gui-uv.bat`-equivalent invocation) launches with zero tracebacks
- [x] Info text hidden by default across Dreambooth/Accelerate-launch panel: Textbox, Number, Slider, Dropdown, Checkbox field types
- [x] Hovering one field reveals only that field's info, not its row/accordion siblings
- [x] Keyboard focus (`:focus-within`) reveals info identically to mouse hover
- [x] Tool-button icons bottom-align with their input box, no overflow
- [x] `git submodule status` clean (sd-scripts untouched) before every push
- [x] `uv run black --check` clean on touched files
- [x] `uv run pytest tests/ -q` — 194 passed (requires `PYTHONPATH=.`, pre-existing environment quirk unrelated to this change)