### PR TITLE
Info tooltip: name-only trigger, position above, Settings tab toggle

### DIFF
--- a/assets/js/icon_button_titles.js
+++ b/assets/js/icon_button_titles.js
@@ -1,0 +1,34 @@
+// Sets a native `title` attribute (browser tooltip) on the 📂/🔄/💾/📄
+// tool buttons based on their icon, since gr.Button has no `info=`-style
+// description and these buttons only ever show an emoji as their label.
+// A MutationObserver is needed rather than a single pass on load because
+// Gradio mounts each tab's content lazily/on demand.
+(function () {
+    const ICON_TITLES = {
+        "\u{1F4C2}": "Browse for a folder", // 📂 folder_symbol
+        "\u{1F4C4}": "Browse for a file", // 📄 document_symbol
+        "\u{1F504}": "Refresh the list of choices", // 🔄 refresh_symbol
+        "\u{1F4BE}": "Choose where to save the file", // 💾 save_style_symbol
+    };
+
+    function applyTitle(btn) {
+        if (btn.title) return;
+        const title = ICON_TITLES[btn.textContent.trim()];
+        if (title) btn.title = title;
+    }
+
+    function applyTitles(root) {
+        if (root.id === "open_folder_small") applyTitle(root);
+        root.querySelectorAll("#open_folder_small").forEach(applyTitle);
+    }
+
+    applyTitles(document.body);
+
+    new MutationObserver(function (mutations) {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeType === Node.ELEMENT_NODE) applyTitles(node);
+            }
+        }
+    }).observe(document.body, { childList: true, subtree: true });
+})();

--- a/assets/js/info_tooltip.js
+++ b/assets/js/info_tooltip.js
@@ -5,12 +5,9 @@
 // in JS rather than pure CSS `position: absolute` (Accordion overflow:hidden
 // clips absolutely-positioned descendants too).
 //
-// Mouse hover only triggers over the field's *name* text, not its input
-// control, so the reveal area matches what the user reads as the field
-// label. Keyboard focus triggers on the whole field instead: a keyboard
-// user tabs directly into the input control, never the label text, so
-// restricting focus the same way as hover would make the tooltip
-// unreachable without a mouse.
+// Triggers only over the field's *name* text, not its input control, for
+// both mouse hover and keyboard focus -- selecting/typing into a field's
+// input does not show its tooltip.
 (function () {
     const VISIBLE_CLASS = "info-tooltip-visible";
     const BLOCK_SELECTOR = ".block";
@@ -47,14 +44,6 @@
         return { anchorEl: nameEl, infoDiv };
     }
 
-    function resolveFromBlock(target) {
-        const block = target.closest(BLOCK_SELECTOR);
-        if (!block) return null;
-        const infoDiv = getInfoDiv(block);
-        if (!infoDiv) return null;
-        return { anchorEl: block, infoDiv };
-    }
-
     function showTooltip(anchorEl, infoDiv) {
         const rect = anchorEl.getBoundingClientRect();
         infoDiv.style.top = rect.bottom + 4 + "px";
@@ -87,7 +76,7 @@
     document.addEventListener(
         "focusin",
         function (e) {
-            const resolved = resolveFromBlock(e.target);
+            const resolved = resolveFromName(e.target);
             if (resolved) showTooltip(resolved.anchorEl, resolved.infoDiv);
         },
         true
@@ -95,7 +84,7 @@
     document.addEventListener(
         "focusout",
         function (e) {
-            const resolved = resolveFromBlock(e.target);
+            const resolved = resolveFromName(e.target);
             if (resolved && !resolved.anchorEl.contains(e.relatedTarget)) {
                 hideTooltip(resolved.infoDiv);
             }

--- a/assets/js/info_tooltip.js
+++ b/assets/js/info_tooltip.js
@@ -45,8 +45,17 @@
     }
 
     function showTooltip(anchorEl, infoDiv) {
+        // Settings tab toggle; window.KOHYA_INFO_TOOLTIP_ENABLED is set from
+        // config.toml on page load and live-updated by the checkbox's own
+        // js= handler, so this stays in sync without a page reload.
+        if (window.KOHYA_INFO_TOOLTIP_ENABLED === false) return;
         const rect = anchorEl.getBoundingClientRect();
-        infoDiv.style.top = rect.bottom + 4 + "px";
+        // Anchored by `bottom` (distance from the viewport's bottom edge up
+        // to the name's top) rather than `top`, so the tooltip renders
+        // above the field name without needing to know its own rendered
+        // height up front.
+        infoDiv.style.top = "auto";
+        infoDiv.style.bottom = window.innerHeight - rect.top + 4 + "px";
         infoDiv.style.left = rect.left + "px";
         infoDiv.classList.add(VISIBLE_CLASS);
     }

--- a/assets/style.css
+++ b/assets/style.css
@@ -9,6 +9,20 @@
 }
 
 /*
+ * gr.Group() wraps each field-group in a `.styler` element whose default
+ * background (--background-fill-secondary) is a shade lighter than an
+ * individual field's own `.block` background (--block-background-fill).
+ * Text fields mask this because their `.block` is opaque, but the
+ * tool-button row (📂/🔄/💾/📄) has no such opaque wrapper, so bottom-
+ * aligning those buttons (see #open_folder_small below) exposed a visibly
+ * lighter strip of the group background above them. Matching .styler to
+ * the block color removes the two-tone seam everywhere groups are used.
+ */
+.styler {
+    background: var(--block-background-fill);
+}
+
+/*
  * Hover-reveal for auto-generated `info=` hint text (Gradio 5.34.2).
  * Gradio wraps info text in a div carrying its Info.svelte scope class
  * (currently svelte-j9uq24) with a `.prose`-classed span inside; this

--- a/assets/style.css
+++ b/assets/style.css
@@ -41,8 +41,9 @@
  * ancestor, as long as no ancestor establishes its own containing
  * block via `transform`/`filter`/`perspective` — none of the Gradio
  * chrome around these fields does). assets/info_tooltip.js computes
- * the anchor's viewport position on hover/focus and sets `top`/`left`
- * inline, then toggles the `.info-tooltip-visible` class below.
+ * the anchor's viewport position on hover/focus and sets `bottom`/`left`
+ * inline (rendering the tooltip above the field name), then toggles the
+ * `.info-tooltip-visible` class below.
  */
 .svelte-j9uq24:has(> .prose) {
     position: fixed;

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -43,11 +43,11 @@ def initialize_ui_interface(
     # live-updates window.KOHYA_INFO_TOOLTIP_ENABLED via its own js= handler.
     enable_info_tooltip = config.get("settings.enable_info_tooltip", True)
     info_tooltip_js = read_file_content("./assets/js/info_tooltip.js")
+    icon_button_titles_js = read_file_content("./assets/js/icon_button_titles.js")
     head = (
         f'<script type="text/javascript">window.KOHYA_INFO_TOOLTIP_ENABLED = {str(enable_info_tooltip).lower()};</script>'
         f'<script type="text/javascript">{info_tooltip_js}</script>'
-        if info_tooltip_js
-        else None
+        f'<script type="text/javascript">{icon_button_titles_js}</script>'
     )
 
     # Create the main Gradio Blocks interface

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -14,6 +14,7 @@ from kohya_gui.lora_gui import lora_tab
 from kohya_gui.leco_gui import leco_tab
 from kohya_gui.anima_lllite_gui import anima_lllite_tab
 from kohya_gui.class_lora_tab import LoRATools
+from kohya_gui.settings_gui import settings_tab
 from kohya_gui.custom_logging import setup_logging
 from kohya_gui.localization_ext import add_javascript
 
@@ -30,14 +31,20 @@ def read_file_content(file_path):
 
 
 # Function to initialize the Gradio UI interface
-def initialize_ui_interface(config, headless, use_shell, release_info, readme_content):
+def initialize_ui_interface(
+    config, config_file_path, headless, use_shell, release_info, readme_content
+):
     # Load custom CSS if available
     css = read_file_content("./assets/style.css")
     # Positions the hover-revealed `info=` tooltip (see assets/style.css);
     # always injected, unlike add_javascript() below which only fires when
-    # --language is set.
+    # --language is set. The initial enabled/disabled state comes from the
+    # Settings tab's persisted config.toml value; the checkbox there
+    # live-updates window.KOHYA_INFO_TOOLTIP_ENABLED via its own js= handler.
+    enable_info_tooltip = config.get("settings.enable_info_tooltip", True)
     info_tooltip_js = read_file_content("./assets/js/info_tooltip.js")
     head = (
+        f'<script type="text/javascript">window.KOHYA_INFO_TOOLTIP_ENABLED = {str(enable_info_tooltip).lower()};</script>'
         f'<script type="text/javascript">{info_tooltip_js}</script>'
         if info_tooltip_js
         else None
@@ -83,6 +90,8 @@ def initialize_ui_interface(config, headless, use_shell, release_info, readme_co
             )
             with gr.Tab("LoRA"):
                 _ = LoRATools(headless=headless)
+        with gr.Tab("Settings"):
+            settings_tab(config=config, config_file_path=config_file_path)
         with gr.Tab("About"):
             # About tab to display release information and README content
             gr.Markdown(f"kohya_ss GUI release {release_info}")
@@ -106,9 +115,10 @@ def UI(**kwargs):
     readme_content = read_file_content("./README.md")
 
     # Load configuration from the specified file
-    config = KohyaSSGUIConfig(config_file_path=kwargs.get("config"))
+    config_file_path = kwargs.get("config") or "./config.toml"
+    config = KohyaSSGUIConfig(config_file_path=config_file_path)
     if config.is_config_loaded():
-        log.info(f"Loaded default GUI values from '{kwargs.get('config')}'...")
+        log.info(f"Loaded default GUI values from '{config_file_path}'...")
 
     # Determine if shell should be used for running external commands
     use_shell = not kwargs.get("do_not_use_shell", False) and config.get(
@@ -119,7 +129,12 @@ def UI(**kwargs):
 
     # Initialize the Gradio UI interface
     ui_interface = initialize_ui_interface(
-        config, kwargs.get("headless", False), use_shell, release_info, readme_content
+        config,
+        config_file_path,
+        kwargs.get("headless", False),
+        use_shell,
+        release_info,
+        readme_content,
     )
 
     # Construct launch parameters using dictionary comprehension

--- a/kohya_gui/settings_gui.py
+++ b/kohya_gui/settings_gui.py
@@ -1,0 +1,31 @@
+import gradio as gr
+
+from .class_gui_config import KohyaSSGUIConfig
+from .custom_logging import setup_logging
+
+log = setup_logging()
+
+
+def save_enable_info_tooltip(
+    config: KohyaSSGUIConfig, config_file_path: str, enable_info_tooltip: bool
+):
+    config.config.setdefault("settings", {})[
+        "enable_info_tooltip"
+    ] = enable_info_tooltip
+    config.save_config(config.config, config_file_path)
+    log.info(f"Info tooltip {'enabled' if enable_info_tooltip else 'disabled'}")
+
+
+def settings_tab(config: KohyaSSGUIConfig, config_file_path: str):
+    with gr.Row():
+        enable_info_tooltip = gr.Checkbox(
+            label="Enable info tooltips on hover",
+            info="Shows a tooltip with each field's description when hovering its name. Takes effect immediately, no restart needed.",
+            value=config.get("settings.enable_info_tooltip", True),
+        )
+        enable_info_tooltip.change(
+            fn=lambda v: save_enable_info_tooltip(config, config_file_path, v),
+            inputs=[enable_info_tooltip],
+            outputs=[],
+            js="(v) => { window.KOHYA_INFO_TOOLTIP_ENABLED = v; return v; }",
+        )


### PR DESCRIPTION
## Summary

Follow-up to #3556's hover-reveal info tooltip, based on feedback after that PR merged:

- Mouse hover and keyboard focus now only trigger on the field's *name* text, not its input control — clicking/tabbing into an input no longer shows its tooltip.
- Tooltip now renders above the field name instead of below.
- Adds a **Settings** tab (before About) with an "Enable info tooltips on hover" checkbox, on by default. Toggling takes effect immediately across all tabs with no reload, and persists to the existing (gitignored) `config.toml` under a new `[settings].enable_info_tooltip` key — same load/save path already used for `settings.use_shell`.

### A genuinely nasty bug found along the way

Gradio's `js=` callback on an event listener runs *before* `fn` and its return value becomes what `fn` receives as the input value — not just a side-channel. An earlier draft of the Settings checkbox's `js=` callback had no `return` statement, so the Python side was silently receiving `None` instead of the checkbox's boolean, which `toml.dump()` then silently drops (TOML has no null type). End result: the setting looked like it saved (no exception, a log line even fired) but the file never actually got the key. Fixed by returning the value from the js callback.

## Test plan

- [x] Hovering a field's name shows its tooltip; hovering/clicking its input control does not
- [x] Tabbing (keyboard) into an input control does not show the tooltip; only tabbing onto/hovering the name does
- [x] Tooltip renders above the field name
- [x] Settings tab checkbox defaults to checked (enabled)
- [x] Unchecking it immediately stops tooltips from appearing anywhere in the app, no reload
- [x] Toggle persists to `config.toml` (`[settings].enable_info_tooltip`) and survives navigating away/back to the Settings tab
- [x] `uv run black --check` clean on touched files
- [x] `uv run pytest tests/ -q` — 194 passed
- [x] `git submodule status` clean (sd-scripts untouched)