### PR TITLE
style: black-format four leftover unformatted Python files

### DIFF
--- a/kohya_gui/class_tensorboard.py
+++ b/kohya_gui/class_tensorboard.py
@@ -5,13 +5,16 @@ import time
 import webbrowser
 import shutil
 
+
 def check_avx_support():
     try:
         import cpuinfo
+
         info = cpuinfo.get_cpu_info()
-        return 'avx' in info.get('flags', [])
+        return "avx" in info.get("flags", [])
     except Exception:
         return False
+
 
 visibility = bool(shutil.which("tensorboard") and check_avx_support())
 
@@ -88,7 +91,7 @@ class TensorboardManager:
 
         if not self.headless:
             self.stop_event.clear()
-            
+
             time.sleep(self.wait_time)
             if not self.stop_event.is_set():
                 self.thread = Thread(target=self.open_tensorboard_url)

--- a/kohya_gui/kontext_manual_caption_gui.py
+++ b/kohya_gui/kontext_manual_caption_gui.py
@@ -33,7 +33,9 @@ def _get_quick_tags(quick_tags_text):
     Gets a list of tags from the quick tags text box
     """
     quick_tags = [t.strip() for t in quick_tags_text.split(",") if t.strip()]
-    quick_tags_set = set(tag.lower() for tag in quick_tags) # REFACTOR: Use lowercase for matching
+    quick_tags_set = set(
+        tag.lower() for tag in quick_tags
+    )  # REFACTOR: Use lowercase for matching
     return quick_tags, quick_tags_set
 
 
@@ -44,14 +46,16 @@ def _get_tag_checkbox_updates(caption, quick_tags, quick_tags_set):
     """
     caption_tags_have = [c.strip() for c in caption.split(",") if c.strip()]
     # REFACTOR: Match case-insensitively against quick_tags_set
-    caption_tags_unique = [t for t in caption_tags_have if t.lower() not in quick_tags_set]
+    caption_tags_unique = [
+        t for t in caption_tags_have if t.lower() not in quick_tags_set
+    ]
     caption_tags_all = quick_tags + caption_tags_unique
     return gr.CheckboxGroup(choices=caption_tags_all, value=caption_tags_have)
 
 
 def paginate_go(page, max_page):
     try:
-        page_num = int(page) # REFACTOR: Use int, pages are not fractional
+        page_num = int(page)  # REFACTOR: Use int, pages are not fractional
         return paginate(page_num, max_page, 0)
     except (ValueError, TypeError):
         gr.Warning(f"Invalid page number: {page}")
@@ -107,16 +111,12 @@ def delete_images_and_caption(
         log.info(f"Deleted target image: {target_image_path}")
 
     # Delete caption file
-    caption_path = _get_caption_path(
-        image_file, target_images_dir, caption_ext
-    )
+    caption_path = _get_caption_path(image_file, target_images_dir, caption_ext)
     if caption_path and os.path.exists(caption_path):
         os.remove(caption_path)
         log.info(f"Deleted caption file: {caption_path}")
 
-    return gr.Markdown(
-        f"🗑️ Deleted files for `{image_file}`", visible=True
-    )
+    return gr.Markdown(f"🗑️ Deleted files for `{image_file}`", visible=True)
 
 
 def update_quick_tags(quick_tags_text, *image_caption_texts):
@@ -222,7 +222,15 @@ def load_images(
     def error_message(msg):
         gr.Warning(msg)
         # REFACTOR: Return updates for all outputs to clear state on error
-        return [None, None, None, 1, 1, gr.Markdown(f"⚠️ {msg}", visible=True), gr.update()]
+        return [
+            None,
+            None,
+            None,
+            1,
+            1,
+            gr.Markdown(f"⚠️ {msg}", visible=True),
+            gr.update(),
+        ]
 
     if not target_images_dir or not os.path.exists(target_images_dir):
         return error_message("Target image folder is missing or does not exist.")
@@ -232,9 +240,7 @@ def load_images(
         return error_message("Please provide an extension for the caption files.")
 
     target_image_files = {
-        f
-        for f in os.listdir(target_images_dir)
-        if f.lower().endswith(IMAGE_EXTENSIONS)
+        f for f in os.listdir(target_images_dir) if f.lower().endswith(IMAGE_EXTENSIONS)
     }
     control_image_files = {
         f
@@ -255,18 +261,25 @@ def load_images(
         control_image_path = os.path.join(control_images_dir, image_file)
 
         try:
-            with Image.open(target_image_path) as target_img, Image.open(control_image_path) as control_img:
+            with (
+                Image.open(target_image_path) as target_img,
+                Image.open(control_image_path) as control_img,
+            ):
                 target_aspect_ratio = target_img.width / target_img.height
                 control_aspect_ratio = control_img.width / control_img.height
 
                 if abs(target_aspect_ratio - control_aspect_ratio) > 1e-2:
                     mismatched_files.append(image_file)
-                    log.warning(f"Aspect ratio mismatch for {image_file}: Target AR is {target_aspect_ratio:.4f}, Control AR is {control_aspect_ratio:.4f}")
+                    log.warning(
+                        f"Aspect ratio mismatch for {image_file}: Target AR is {target_aspect_ratio:.4f}, Control AR is {control_aspect_ratio:.4f}"
+                    )
         except Exception as e:
             log.error(f"Could not load or process image {image_file}. Error: {e}")
-    
+
     if mismatched_files:
-        gr.Warning(f"Found {len(mismatched_files)} images with aspect ratio mismatches. Use the 'Apply Correction' button to fix them.")
+        gr.Warning(
+            f"Found {len(mismatched_files)} images with aspect ratio mismatches. Use the 'Apply Correction' button to fix them."
+        )
 
     total_images = len(shared_files)
     max_pages = ceil(total_images / IMAGES_TO_SHOW)
@@ -313,7 +326,7 @@ def crop_image(image, target_aspect_ratio):
         top = (height - new_height) / 2
         right = width
         bottom = top + new_height
-        
+
     return image.crop((left, top, right, bottom))
 
 
@@ -331,7 +344,7 @@ def pad_image(image, target_aspect_ratio, color="white"):
         new_width = int(height * target_aspect_ratio)
         padded_image = Image.new(image.mode, (new_width, height), color)
         padded_image.paste(image, (int((new_width - width) / 2), 0))
-        
+
     return padded_image
 
 
@@ -343,10 +356,10 @@ def save_image_with_backup(image_path, image_to_save):
     try:
         directory = os.path.dirname(image_path)
         original_dir = os.path.join(directory, "original")
-        
+
         if not os.path.exists(original_dir):
             os.makedirs(original_dir)
-            
+
         base_filename = os.path.basename(image_path)
         backup_path = os.path.join(original_dir, base_filename)
 
@@ -359,10 +372,10 @@ def save_image_with_backup(image_path, image_to_save):
 
         os.rename(image_path, backup_path)
         log.info(f"Backed up original image to {backup_path}")
-        
+
         image_to_save.save(image_path)
         log.info(f"Saved modified image to {image_path}")
-        
+
     except Exception as e:
         log.error(f"Error saving image with backup: {e}")
 
@@ -388,9 +401,10 @@ def apply_correction(
         control_image_path = os.path.join(control_images_dir, image_file)
 
         try:
-            with Image.open(target_image_path) as target_img, Image.open(
-                control_image_path
-            ) as control_img:
+            with (
+                Image.open(target_image_path) as target_img,
+                Image.open(control_image_path) as control_img,
+            ):
                 target_aspect_ratio = target_img.width / target_img.height
                 control_aspect_ratio = control_img.width / control_img.height
 
@@ -407,15 +421,19 @@ def apply_correction(
                         correct_aspect_ratio = target_aspect_ratio
 
                     if correction_method == "Crop":
-                        modified_image = crop_image(image_to_correct, correct_aspect_ratio)
+                        modified_image = crop_image(
+                            image_to_correct, correct_aspect_ratio
+                        )
                     elif correction_method == "Pad":
-                        modified_image = pad_image(image_to_correct, correct_aspect_ratio)
+                        modified_image = pad_image(
+                            image_to_correct, correct_aspect_ratio
+                        )
                     else:
                         continue  # Should not happen
 
                     if save_padded:
                         save_image_with_backup(path_to_save, modified_image)
-                    
+
                     corrected_files += 1
 
         except Exception as e:
@@ -432,7 +450,7 @@ def apply_correction(
 
 
 def update_images(
-    image_files, # REFACTOR: Receive the list of files from gr.State
+    image_files,  # REFACTOR: Receive the list of files from gr.State
     target_images_dir,
     control_images_dir,
     caption_ext,
@@ -455,7 +473,14 @@ def update_images(
     start_index = (int(page) - 1) * IMAGES_TO_SHOW
 
     # Build component updates in lists
-    rows_update, files_update, target_paths, control_paths, captions, tags_checks = [], [], [], [], [], []
+    rows_update, files_update, target_paths, control_paths, captions, tags_checks = (
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+    )
 
     for i in range(IMAGES_TO_SHOW):
         image_index = start_index + i
@@ -468,7 +493,9 @@ def update_images(
             image_file = image_files[image_index]
             target_path = os.path.join(target_images_dir, image_file)
             control_path = os.path.join(control_images_dir, image_file)
-            caption_file_path = _get_caption_path(image_file, target_images_dir, caption_ext)
+            caption_file_path = _get_caption_path(
+                image_file, target_images_dir, caption_ext
+            )
             if caption_file_path and os.path.exists(caption_file_path):
                 with open(caption_file_path, "r", encoding="utf-8") as f:
                     caption = f.read()
@@ -477,7 +504,9 @@ def update_images(
         target_paths.append(target_path)
         control_paths.append(control_path)
         captions.append(caption)
-        tags_checks.append(_get_tag_checkbox_updates(caption, quick_tags, quick_tags_set))
+        tags_checks.append(
+            _get_tag_checkbox_updates(caption, quick_tags, quick_tags_set)
+        )
 
     # Combine all updates into a single list
     outputs.extend(rows_update)
@@ -486,7 +515,7 @@ def update_images(
     outputs.extend(control_paths)
     outputs.extend(captions)
     outputs.extend(tags_checks)
-    outputs.extend([gr.Row(visible=True), gr.Row(visible=True)]) # Pagination rows
+    outputs.extend([gr.Row(visible=True), gr.Row(visible=True)])  # Pagination rows
 
     return outputs
 
@@ -505,15 +534,31 @@ def gradio_kontext_manual_caption_gui_tab(headless=False, default_images_dir=Non
     # REFACTOR: Define pagination UI and logic in one place
     def render_pagination_with_logic(page, max_page):
         with gr.Row(visible=False) as pagination_row:
-            gr.Button("◀ Prev").click(paginate, inputs=[page, max_page, gr.Number(-1, visible=False)], outputs=[page])
-            page_count = gr.Text("Page 1 / 1", show_label=False, interactive=False, text_align="center")
-            page_goto_text = gr.Textbox(show_label=False, placeholder="Go to page...", container=False, scale=1)
-            gr.Button("Next ▶").click(paginate, inputs=[page, max_page, gr.Number(1, visible=False)], outputs=[page])
-            page_goto_text.submit(paginate_go, inputs=[page_goto_text, max_page], outputs=[page])
+            gr.Button("◀ Prev").click(
+                paginate,
+                inputs=[page, max_page, gr.Number(-1, visible=False)],
+                outputs=[page],
+            )
+            page_count = gr.Text(
+                "Page 1 / 1", show_label=False, interactive=False, text_align="center"
+            )
+            page_goto_text = gr.Textbox(
+                show_label=False, placeholder="Go to page...", container=False, scale=1
+            )
+            gr.Button("Next ▶").click(
+                paginate,
+                inputs=[page, max_page, gr.Number(1, visible=False)],
+                outputs=[page],
+            )
+            page_goto_text.submit(
+                paginate_go, inputs=[page_goto_text, max_page], outputs=[page]
+            )
         return pagination_row, page_count
 
     with gr.Tab("Kontext Manual Captioning"):
-        gr.Markdown("This utility allows quick captioning and tagging of images for fine-tuning with before and after images.")
+        gr.Markdown(
+            "This utility allows quick captioning and tagging of images for fine-tuning with before and after images."
+        )
 
         # REFACTOR: Use gr.State for non-UI data
         image_files_state = gr.State([])
@@ -527,25 +572,81 @@ def gradio_kontext_manual_caption_gui_tab(headless=False, default_images_dir=Non
         with gr.Group():
             with gr.Row():
                 # FIX: Convert generator from list_dirs to a list
-                control_images_dir = gr.Dropdown(label="Control image folder", choices=[""] + list(list_dirs(default_images_dir)), value="", interactive=True, allow_custom_value=True, scale=2)
-                create_refresh_button(control_images_dir, lambda: None, lambda: {"choices": list(list_dirs(control_images_dir.value or default_images_dir))}, "open_folder_small")
-                gr.Button("📂", elem_id="open_folder_small", elem_classes=["tool"], visible=not headless).click(get_folder_path, outputs=control_images_dir, show_progress=False)
-                
+                control_images_dir = gr.Dropdown(
+                    label="Control image folder",
+                    choices=[""] + list(list_dirs(default_images_dir)),
+                    value="",
+                    interactive=True,
+                    allow_custom_value=True,
+                    scale=2,
+                )
+                create_refresh_button(
+                    control_images_dir,
+                    lambda: None,
+                    lambda: {
+                        "choices": list(
+                            list_dirs(control_images_dir.value or default_images_dir)
+                        )
+                    },
+                    "open_folder_small",
+                )
+                gr.Button(
+                    "📂",
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=not headless,
+                ).click(
+                    get_folder_path, outputs=control_images_dir, show_progress=False
+                )
+
                 # FIX: Convert generator from list_dirs to a list
-                target_images_dir = gr.Dropdown(label="Target image folder", choices=[""] + list(list_dirs(default_images_dir)), value="", interactive=True, allow_custom_value=True, scale=2)
-                create_refresh_button(target_images_dir, lambda: None, lambda: {"choices": list(list_dirs(target_images_dir.value or default_images_dir))}, "open_folder_small")
-                gr.Button("📂", elem_id="open_folder_small", elem_classes=["tool"], visible=not headless).click(get_folder_path, outputs=target_images_dir, show_progress=False)
+                target_images_dir = gr.Dropdown(
+                    label="Target image folder",
+                    choices=[""] + list(list_dirs(default_images_dir)),
+                    value="",
+                    interactive=True,
+                    allow_custom_value=True,
+                    scale=2,
+                )
+                create_refresh_button(
+                    target_images_dir,
+                    lambda: None,
+                    lambda: {
+                        "choices": list(
+                            list_dirs(target_images_dir.value or default_images_dir)
+                        )
+                    },
+                    "open_folder_small",
+                )
+                gr.Button(
+                    "📂",
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=not headless,
+                ).click(get_folder_path, outputs=target_images_dir, show_progress=False)
 
             with gr.Row():
-                caption_ext = gr.Dropdown(label="Caption file extension", choices=[".cap", ".caption", ".txt"], value=".txt", interactive=True, allow_custom_value=True)
+                caption_ext = gr.Dropdown(
+                    label="Caption file extension",
+                    choices=[".cap", ".caption", ".txt"],
+                    value=".txt",
+                    interactive=True,
+                    allow_custom_value=True,
+                )
                 auto_save = gr.Checkbox(label="Autosave", value=True, interactive=True)
 
             load_images_button = gr.Button("Load Images", variant="primary")
-            
+
             with gr.Row():
-                aspect_ratio_correction = gr.Dropdown(["None", "Crop", "Pad"], label="Aspect Ratio Correction", value="None")
-                save_padded_images = gr.Checkbox(label="Save Corrected Images (Crop/Pad)", value=True)
-                
+                aspect_ratio_correction = gr.Dropdown(
+                    ["None", "Crop", "Pad"],
+                    label="Aspect Ratio Correction",
+                    value="None",
+                )
+                save_padded_images = gr.Checkbox(
+                    label="Save Corrected Images (Crop/Pad)", value=True
+                )
+
             apply_correction_button = gr.Button("Apply Correction")
 
             apply_correction_button.click(
@@ -560,13 +661,20 @@ def gradio_kontext_manual_caption_gui_tab(headless=False, default_images_dir=Non
                 outputs=info_box,
             )
 
-            target_images_dir.change(update_dir_list, inputs=target_images_dir, outputs=target_images_dir, show_progress=False)
+            target_images_dir.change(
+                update_dir_list,
+                inputs=target_images_dir,
+                outputs=target_images_dir,
+                show_progress=False,
+            )
             control_images_dir.change(
                 lambda path, current_target: (
                     update_dir_list(path),
-                    derive_target_folder(path)
-                    if not current_target
-                    else current_target,
+                    (
+                        derive_target_folder(path)
+                        if not current_target
+                        else current_target
+                    ),
                 ),
                 inputs=[control_images_dir, target_images_dir],
                 outputs=[control_images_dir, target_images_dir],
@@ -574,36 +682,102 @@ def gradio_kontext_manual_caption_gui_tab(headless=False, default_images_dir=Non
             )
 
         with gr.Group():
-            quick_tags_text = gr.Textbox(label="Quick Tags", placeholder="Comma separated list of tags", interactive=True)
+            quick_tags_text = gr.Textbox(
+                label="Quick Tags",
+                placeholder="Comma separated list of tags",
+                interactive=True,
+            )
             with gr.Row():
-                ignore_load_tags_word_count = gr.Slider(minimum=1, maximum=100, value=10, step=1, label="Ignore Imported Tags Above Word Count", interactive=True, scale=2)
-            
+                ignore_load_tags_word_count = gr.Slider(
+                    minimum=1,
+                    maximum=100,
+                    value=10,
+                    step=1,
+                    label="Ignore Imported Tags Above Word Count",
+                    interactive=True,
+                    scale=2,
+                )
+
             with gr.Row():
                 import_tags_button = gr.Button("Import tags from captions", scale=1)
 
         pagination_row1, page_count1 = render_pagination_with_logic(page, max_page)
 
-        image_rows, image_files, target_image_images, control_image_images, image_caption_texts, image_tag_checks, save_buttons, delete_buttons = [], [], [], [], [], [], [], []
+        (
+            image_rows,
+            image_files,
+            target_image_images,
+            control_image_images,
+            image_caption_texts,
+            image_tag_checks,
+            save_buttons,
+            delete_buttons,
+        ) = ([], [], [], [], [], [], [], [])
         for i in range(IMAGES_TO_SHOW):
             with gr.Row(visible=False) as row:
                 image_file = gr.Text(visible=False)
                 with gr.Column():
-                    control_image_image = gr.Image(type="filepath", label="Control Image")
+                    control_image_image = gr.Image(
+                        type="filepath", label="Control Image"
+                    )
                 with gr.Column():
                     target_image_image = gr.Image(type="filepath", label="Target Image")
                 with gr.Column(scale=2):
-                    image_caption_text = gr.TextArea(label="Captions", placeholder="Input captions for target image", interactive=True)
-                    tag_checkboxes = gr.CheckboxGroup([], label="Tags", interactive=True)
+                    image_caption_text = gr.TextArea(
+                        label="Captions",
+                        placeholder="Input captions for target image",
+                        interactive=True,
+                    )
+                    tag_checkboxes = gr.CheckboxGroup(
+                        [], label="Tags", interactive=True
+                    )
                 with gr.Column(min_width=40):
                     save_button = gr.Button("💾", elem_id="save_button", visible=False)
                     delete_button = gr.Button("🗑️", elem_id="delete_button")
 
-                image_rows.append(row); image_files.append(image_file); control_image_images.append(control_image_image); target_image_images.append(target_image_image)
-                image_caption_texts.append(image_caption_text); image_tag_checks.append(tag_checkboxes); save_buttons.append(save_button); delete_buttons.append(delete_button)
+                image_rows.append(row)
+                image_files.append(image_file)
+                control_image_images.append(control_image_image)
+                target_image_images.append(target_image_image)
+                image_caption_texts.append(image_caption_text)
+                image_tag_checks.append(tag_checkboxes)
+                save_buttons.append(save_button)
+                delete_buttons.append(delete_button)
 
-                image_caption_text.input(update_image_caption, inputs=[quick_tags_text, image_caption_text, image_file, loaded_images_dir, caption_ext, auto_save], outputs=tag_checkboxes)
-                tag_checkboxes.input(update_image_tags, inputs=[quick_tags_text, tag_checkboxes, image_file, loaded_images_dir, caption_ext, auto_save], outputs=[image_caption_text])
-                save_button.click(save_caption, inputs=[image_caption_text, caption_ext, image_file, loaded_images_dir], outputs=info_box)
+                image_caption_text.input(
+                    update_image_caption,
+                    inputs=[
+                        quick_tags_text,
+                        image_caption_text,
+                        image_file,
+                        loaded_images_dir,
+                        caption_ext,
+                        auto_save,
+                    ],
+                    outputs=tag_checkboxes,
+                )
+                tag_checkboxes.input(
+                    update_image_tags,
+                    inputs=[
+                        quick_tags_text,
+                        tag_checkboxes,
+                        image_file,
+                        loaded_images_dir,
+                        caption_ext,
+                        auto_save,
+                    ],
+                    outputs=[image_caption_text],
+                )
+                save_button.click(
+                    save_caption,
+                    inputs=[
+                        image_caption_text,
+                        caption_ext,
+                        image_file,
+                        loaded_images_dir,
+                    ],
+                    outputs=info_box,
+                )
                 delete_button.click(
                     delete_images_and_caption,
                     inputs=[
@@ -635,7 +809,11 @@ def gradio_kontext_manual_caption_gui_tab(headless=False, default_images_dir=Non
 
         pagination_row2, page_count2 = render_pagination_with_logic(page, max_page)
 
-        quick_tags_text.change(update_quick_tags, inputs=[quick_tags_text] + image_caption_texts, outputs=image_tag_checks)
+        quick_tags_text.change(
+            update_quick_tags,
+            inputs=[quick_tags_text] + image_caption_texts,
+            outputs=image_tag_checks,
+        )
         import_tags_button.click(
             import_tags_from_captions,
             inputs=[
@@ -669,16 +847,52 @@ def gradio_kontext_manual_caption_gui_tab(headless=False, default_images_dir=Non
         )
 
         # REFACTOR: A single trigger to update the images view
-        update_trigger_inputs = [image_files_state, loaded_images_dir, loaded_control_images_dir, caption_ext, quick_tags_text, page]
+        update_trigger_inputs = [
+            image_files_state,
+            loaded_images_dir,
+            loaded_control_images_dir,
+            caption_ext,
+            quick_tags_text,
+            page,
+        ]
         update_outputs = (
-            image_rows + image_files + target_image_images + control_image_images +
-            image_caption_texts + image_tag_checks + [pagination_row1, pagination_row2]
+            image_rows
+            + image_files
+            + target_image_images
+            + control_image_images
+            + image_caption_texts
+            + image_tag_checks
+            + [pagination_row1, pagination_row2]
         )
 
         # Trigger update when page or data changes
-        page.change(update_images, inputs=update_trigger_inputs, outputs=update_outputs, show_progress=False)
-        image_files_state.change(update_images, inputs=update_trigger_inputs, outputs=update_outputs, show_progress=False)
+        page.change(
+            update_images,
+            inputs=update_trigger_inputs,
+            outputs=update_outputs,
+            show_progress=False,
+        )
+        image_files_state.change(
+            update_images,
+            inputs=update_trigger_inputs,
+            outputs=update_outputs,
+            show_progress=False,
+        )
 
-        auto_save.change(lambda is_auto_save: [gr.Button(visible=not is_auto_save)] * IMAGES_TO_SHOW, inputs=auto_save, outputs=save_buttons)
-        page.change(lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"), inputs=[page, max_page], outputs=[page_count1, page_count2], show_progress=False)
-        max_page.change(lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"), inputs=[page, max_page], outputs=[page_count1, page_count2], show_progress=False)
+        auto_save.change(
+            lambda is_auto_save: [gr.Button(visible=not is_auto_save)] * IMAGES_TO_SHOW,
+            inputs=auto_save,
+            outputs=save_buttons,
+        )
+        page.change(
+            lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"),
+            inputs=[page, max_page],
+            outputs=[page_count1, page_count2],
+            show_progress=False,
+        )
+        max_page.change(
+            lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"),
+            inputs=[page, max_page],
+            outputs=[page_count1, page_count2],
+            show_progress=False,
+        )

--- a/kohya_gui/manual_caption_gui.py
+++ b/kohya_gui/manual_caption_gui.py
@@ -42,7 +42,9 @@ def _get_tag_checkbox_updates(caption, quick_tags, quick_tags_set):
     already included in the caption
     """
     caption_tags_have = [c.strip() for c in caption.split(",") if c.strip()]
-    caption_tags_unique = [t for t in caption_tags_have if t.lower() not in quick_tags_set]
+    caption_tags_unique = [
+        t for t in caption_tags_have if t.lower() not in quick_tags_set
+    ]
     caption_tags_all = quick_tags + caption_tags_unique
     return gr.CheckboxGroup(choices=caption_tags_all, value=caption_tags_have)
 
@@ -115,7 +117,9 @@ def import_tags_from_captions(
     images_dir, caption_ext, quick_tags_text, ignore_load_tags_word_count
 ):
     if not images_dir or not os.path.exists(images_dir):
-        gr.Warning("Image folder is not set or does not exist. Please load images first.")
+        gr.Warning(
+            "Image folder is not set or does not exist. Please load images first."
+        )
         return gr.update()
 
     if not caption_ext:
@@ -123,7 +127,10 @@ def import_tags_from_captions(
         return gr.update()
 
     if quick_tags_text:
-        if not boolbox("Are you sure you wish to overwrite the current quick tags?", choices=("Yes", "No")):
+        if not boolbox(
+            "Are you sure you wish to overwrite the current quick tags?",
+            choices=("Yes", "No"),
+        ):
             return gr.update()
 
     tags = []
@@ -158,7 +165,9 @@ def load_images(images_dir, caption_ext):
     if not caption_ext:
         return error_message("Please provide an extension for the caption files.")
 
-    image_files = sorted([f for f in os.listdir(images_dir) if f.lower().endswith(IMAGE_EXTENSIONS)])
+    image_files = sorted(
+        [f for f in os.listdir(images_dir) if f.lower().endswith(IMAGE_EXTENSIONS)]
+    )
 
     if not image_files:
         return error_message("No images found in the folder.")
@@ -212,7 +221,9 @@ def update_images(
         files_update.append(image_file)
         paths_update.append(image_path)
         captions.append(caption)
-        tags_checks.append(_get_tag_checkbox_updates(caption, quick_tags, quick_tags_set))
+        tags_checks.append(
+            _get_tag_checkbox_updates(caption, quick_tags, quick_tags_set)
+        )
 
     outputs.extend(rows_update)
     outputs.extend(files_update)
@@ -235,11 +246,25 @@ def gradio_manual_caption_gui_tab(headless=False, default_images_dir=None):
 
     def render_pagination_with_logic(page, max_page):
         with gr.Row(visible=False) as pagination_row:
-            gr.Button("◀ Prev").click(paginate, inputs=[page, max_page, gr.Number(-1, visible=False)], outputs=[page])
-            page_count = gr.Text("Page 1 / 1", show_label=False, interactive=False, text_align="center")
-            page_goto_text = gr.Textbox(show_label=False, placeholder="Go to page...", container=False, scale=1)
-            gr.Button("Next ▶").click(paginate, inputs=[page, max_page, gr.Number(1, visible=False)], outputs=[page])
-            page_goto_text.submit(paginate_go, inputs=[page_goto_text, max_page], outputs=[page])
+            gr.Button("◀ Prev").click(
+                paginate,
+                inputs=[page, max_page, gr.Number(-1, visible=False)],
+                outputs=[page],
+            )
+            page_count = gr.Text(
+                "Page 1 / 1", show_label=False, interactive=False, text_align="center"
+            )
+            page_goto_text = gr.Textbox(
+                show_label=False, placeholder="Go to page...", container=False, scale=1
+            )
+            gr.Button("Next ▶").click(
+                paginate,
+                inputs=[page, max_page, gr.Number(1, visible=False)],
+                outputs=[page],
+            )
+            page_goto_text.submit(
+                paginate_go, inputs=[page_goto_text, max_page], outputs=[page]
+            )
         return pagination_row, page_count
 
     with gr.Tab("Manual Captioning"):
@@ -254,39 +279,94 @@ def gradio_manual_caption_gui_tab(headless=False, default_images_dir=None):
 
         with gr.Group():
             with gr.Row():
-                images_dir = gr.Dropdown(label="Image folder to caption", choices=[""] + list(list_dirs(default_images_dir)), value="", interactive=True, allow_custom_value=True)
-                create_refresh_button(images_dir, lambda: None, lambda: {"choices": list(list_dirs(images_dir.value or default_images_dir))}, "open_folder_small")
-                gr.Button("📂", elem_id="open_folder_small", elem_classes=["tool"], visible=not headless).click(get_folder_path, outputs=images_dir, show_progress=False)
-
+                images_dir = gr.Dropdown(
+                    label="Image folder to caption",
+                    choices=[""] + list(list_dirs(default_images_dir)),
+                    value="",
+                    interactive=True,
+                    allow_custom_value=True,
+                )
+                create_refresh_button(
+                    images_dir,
+                    lambda: None,
+                    lambda: {
+                        "choices": list(
+                            list_dirs(images_dir.value or default_images_dir)
+                        )
+                    },
+                    "open_folder_small",
+                )
+                gr.Button(
+                    "📂",
+                    elem_id="open_folder_small",
+                    elem_classes=["tool"],
+                    visible=not headless,
+                ).click(get_folder_path, outputs=images_dir, show_progress=False)
 
             with gr.Row():
-                caption_ext = gr.Dropdown(label="Caption file extension", choices=[".cap", ".caption", ".txt"], value=".txt", interactive=True, allow_custom_value=True)
+                caption_ext = gr.Dropdown(
+                    label="Caption file extension",
+                    choices=[".cap", ".caption", ".txt"],
+                    value=".txt",
+                    interactive=True,
+                    allow_custom_value=True,
+                )
                 auto_save = gr.Checkbox(label="Autosave", value=True, interactive=True)
-                
+
             with gr.Row():
                 load_images_button = gr.Button("Load Images", variant="primary")
 
-            images_dir.change(update_dir_list, inputs=images_dir, outputs=images_dir, show_progress=False)
+            images_dir.change(
+                update_dir_list,
+                inputs=images_dir,
+                outputs=images_dir,
+                show_progress=False,
+            )
 
         with gr.Group():
-            quick_tags_text = gr.Textbox(label="Quick Tags", placeholder="Comma separated list of tags", interactive=True)
+            quick_tags_text = gr.Textbox(
+                label="Quick Tags",
+                placeholder="Comma separated list of tags",
+                interactive=True,
+            )
             with gr.Row():
-                ignore_load_tags_word_count = gr.Slider(minimum=1, maximum=100, value=10, step=1, label="Ignore Imported Tags Above Word Count", interactive=True, scale=2)
-            
+                ignore_load_tags_word_count = gr.Slider(
+                    minimum=1,
+                    maximum=100,
+                    value=10,
+                    step=1,
+                    label="Ignore Imported Tags Above Word Count",
+                    interactive=True,
+                    scale=2,
+                )
+
             with gr.Row():
                 import_tags_button = gr.Button("Import tags from captions", scale=1)
 
         pagination_row1, page_count1 = render_pagination_with_logic(page, max_page)
 
-        image_rows, image_files, image_images, image_caption_texts, image_tag_checks, save_buttons = [], [], [], [], [], []
+        (
+            image_rows,
+            image_files,
+            image_images,
+            image_caption_texts,
+            image_tag_checks,
+            save_buttons,
+        ) = ([], [], [], [], [], [])
         for i in range(IMAGES_TO_SHOW):
             with gr.Row(visible=False) as row:
                 image_file = gr.Text(visible=False)
                 with gr.Column():
                     image_image = gr.Image(type="filepath", label=f"Image {i+1}")
                 with gr.Column(scale=2):
-                    image_caption_text = gr.TextArea(label="Captions", placeholder="Input captions for image", interactive=True)
-                    tag_checkboxes = gr.CheckboxGroup([], label="Tags", interactive=True)
+                    image_caption_text = gr.TextArea(
+                        label="Captions",
+                        placeholder="Input captions for image",
+                        interactive=True,
+                    )
+                    tag_checkboxes = gr.CheckboxGroup(
+                        [], label="Tags", interactive=True
+                    )
                 with gr.Column(min_width=40):
                     save_button = gr.Button("💾", elem_id="save_button", visible=False)
 
@@ -297,28 +377,119 @@ def gradio_manual_caption_gui_tab(headless=False, default_images_dir=None):
                 image_tag_checks.append(tag_checkboxes)
                 save_buttons.append(save_button)
 
-                image_caption_text.input(update_image_caption, inputs=[quick_tags_text, image_caption_text, image_file, loaded_images_dir, caption_ext, auto_save], outputs=tag_checkboxes)
-                tag_checkboxes.input(update_image_tags, inputs=[quick_tags_text, tag_checkboxes, image_file, loaded_images_dir, caption_ext, auto_save], outputs=[image_caption_text])
-                save_button.click(save_caption, inputs=[image_caption_text, caption_ext, image_file, loaded_images_dir], outputs=info_box)
+                image_caption_text.input(
+                    update_image_caption,
+                    inputs=[
+                        quick_tags_text,
+                        image_caption_text,
+                        image_file,
+                        loaded_images_dir,
+                        caption_ext,
+                        auto_save,
+                    ],
+                    outputs=tag_checkboxes,
+                )
+                tag_checkboxes.input(
+                    update_image_tags,
+                    inputs=[
+                        quick_tags_text,
+                        tag_checkboxes,
+                        image_file,
+                        loaded_images_dir,
+                        caption_ext,
+                        auto_save,
+                    ],
+                    outputs=[image_caption_text],
+                )
+                save_button.click(
+                    save_caption,
+                    inputs=[
+                        image_caption_text,
+                        caption_ext,
+                        image_file,
+                        loaded_images_dir,
+                    ],
+                    outputs=info_box,
+                )
 
         pagination_row2, page_count2 = render_pagination_with_logic(page, max_page)
 
-        quick_tags_text.change(update_quick_tags, inputs=[quick_tags_text] + image_caption_texts, outputs=image_tag_checks)
-        import_tags_button.click(import_tags_from_captions, inputs=[loaded_images_dir, caption_ext, quick_tags_text, ignore_load_tags_word_count], outputs=quick_tags_text)
-
-        load_images_outputs = [image_files_state, loaded_images_dir, page, max_page, info_box]
-        load_images_button.click(load_images, inputs=[images_dir, caption_ext], outputs=load_images_outputs)
-
-        update_trigger_inputs = [image_files_state, loaded_images_dir, caption_ext, quick_tags_text, page]
-        update_outputs = (
-            image_rows + image_files + image_images +
-            image_caption_texts + image_tag_checks + [pagination_row1, pagination_row2]
+        quick_tags_text.change(
+            update_quick_tags,
+            inputs=[quick_tags_text] + image_caption_texts,
+            outputs=image_tag_checks,
+        )
+        import_tags_button.click(
+            import_tags_from_captions,
+            inputs=[
+                loaded_images_dir,
+                caption_ext,
+                quick_tags_text,
+                ignore_load_tags_word_count,
+            ],
+            outputs=quick_tags_text,
         )
 
-        page.change(update_images, inputs=update_trigger_inputs, outputs=update_outputs, show_progress=False)
-        image_files_state.change(update_images, inputs=update_trigger_inputs, outputs=update_outputs, show_progress=False)
+        load_images_outputs = [
+            image_files_state,
+            loaded_images_dir,
+            page,
+            max_page,
+            info_box,
+        ]
+        load_images_button.click(
+            load_images, inputs=[images_dir, caption_ext], outputs=load_images_outputs
+        )
 
-        auto_save.change(lambda is_auto_save: [gr.Button(visible=not is_auto_save)] * IMAGES_TO_SHOW, inputs=auto_save, outputs=save_buttons)
-        page.change(lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"), inputs=[page, max_page], outputs=[page_count1, page_count2], show_progress=False)
-        image_files_state.change(lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"), inputs=[page, max_page], outputs=[page_count1, page_count2], show_progress=False)
-        max_page.change(lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"), inputs=[page, max_page], outputs=[page_count1, page_count2], show_progress=False)
+        update_trigger_inputs = [
+            image_files_state,
+            loaded_images_dir,
+            caption_ext,
+            quick_tags_text,
+            page,
+        ]
+        update_outputs = (
+            image_rows
+            + image_files
+            + image_images
+            + image_caption_texts
+            + image_tag_checks
+            + [pagination_row1, pagination_row2]
+        )
+
+        page.change(
+            update_images,
+            inputs=update_trigger_inputs,
+            outputs=update_outputs,
+            show_progress=False,
+        )
+        image_files_state.change(
+            update_images,
+            inputs=update_trigger_inputs,
+            outputs=update_outputs,
+            show_progress=False,
+        )
+
+        auto_save.change(
+            lambda is_auto_save: [gr.Button(visible=not is_auto_save)] * IMAGES_TO_SHOW,
+            inputs=auto_save,
+            outputs=save_buttons,
+        )
+        page.change(
+            lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"),
+            inputs=[page, max_page],
+            outputs=[page_count1, page_count2],
+            show_progress=False,
+        )
+        image_files_state.change(
+            lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"),
+            inputs=[page, max_page],
+            outputs=[page_count1, page_count2],
+            show_progress=False,
+        )
+        max_page.change(
+            lambda p, m: (f"Page {int(p)} / {int(m)}", f"Page {int(p)} / {int(m)}"),
+            inputs=[page, max_page],
+            outputs=[page_count1, page_count2],
+            show_progress=False,
+        )

--- a/local_train.py
+++ b/local_train.py
@@ -2,16 +2,20 @@ import os
 import shlex
 import subprocess
 
+
 def run_command(command):
     """Runs a command and prints its output."""
     print(f"Running command: {command}")
     args = shlex.split(command, posix=(os.name != "nt"))
-    process = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    process = subprocess.Popen(
+        args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
     for line in process.stdout:
         print(line, end="")
     process.wait()
     if process.returncode != 0:
         raise subprocess.CalledProcessError(process.returncode, command)
+
 
 def main():
     print("Starting local training setup...")
@@ -48,9 +52,11 @@ def main():
     # It's better if bitsandbytes is installed as a pip package if possible.
     print("Building and installing bitsandbytes...")
     os.chdir("bitsandbytes")
-    run_command("make cuda11x") # This assumes CUDA 11.8 development toolkit is available
+    run_command(
+        "make cuda11x"
+    )  # This assumes CUDA 11.8 development toolkit is available
     run_command("python setup.py install")
-    os.chdir("..") # Back to base_dir
+    os.chdir("..")  # Back to base_dir
 
     # 4. Clone kohya_ss
     if not os.path.exists("kohya_ss"):
@@ -61,7 +67,6 @@ def main():
         # os.chdir("kohya_ss")
         # run_command("git pull")
         # os.chdir("..")
-
 
     # 5. Launch Kohya GUI
     print("Launching Kohya GUI...")
@@ -75,9 +80,12 @@ def main():
         run_command("python kohya_gui.py --headless")
     except Exception as e:
         print(f"Error launching Kohya GUI: {e}")
-        print("Please ensure all dependencies, including CUDA and xformers, are correctly installed.")
+        print(
+            "Please ensure all dependencies, including CUDA and xformers, are correctly installed."
+        )
     finally:
-        os.chdir(original_dir) # Change back to the original directory
+        os.chdir(original_dir)  # Change back to the original directory
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- Run `black` on four files that failed `black --check` on master after the v26 merge work
- Files: `local_train.py`, `kohya_gui/class_tensorboard.py`, `kohya_gui/manual_caption_gui.py`, `kohya_gui/kontext_manual_caption_gui.py`
- Formatting only — no behavior changes

## Test plan

- [x] `uv run black --check local_train.py kohya_gui/class_tensorboard.py kohya_gui/manual_caption_gui.py kohya_gui/kontext_manual_caption_gui.py` passes
- [ ] CI black/typos checks pass on the PR