### PR TITLE
fix: write accelerate config under HF_HOME/accelerate

### DIFF
--- a/setup/setup_common.py
+++ b/setup/setup_common.py
@@ -260,7 +260,11 @@ def configure_accelerate(run_accelerate=False):
     target_config_location = None
 
     env_vars = {
-        "HF_HOME": Path(os.environ.get("HF_HOME", "")),
+        "HF_HOME": Path(
+            os.environ.get("HF_HOME", ""),
+            "accelerate",
+            "default_config.yaml",
+        ),
         "LOCALAPPDATA": Path(
             os.environ.get("LOCALAPPDATA", ""),
             "huggingface",
@@ -285,15 +289,20 @@ def configure_accelerate(run_accelerate=False):
 
     if target_config_location:
         if not target_config_location.is_file():
-            log.debug(
-                f"Creating target config directory: {target_config_location.parent}"
-            )
-            target_config_location.parent.mkdir(parents=True, exist_ok=True)
-            log.debug(
-                f"Copying config file to target location: {target_config_location}"
-            )
-            shutil.copyfile(source_accelerate_config_file, target_config_location)
-            log.info(f"Copied accelerate config file to: {target_config_location}")
+            try:
+                log.debug(
+                    f"Creating target config directory: {target_config_location.parent}"
+                )
+                target_config_location.parent.mkdir(parents=True, exist_ok=True)
+                log.debug(
+                    f"Copying config file to target location: {target_config_location}"
+                )
+                shutil.copyfile(source_accelerate_config_file, target_config_location)
+                log.info(f"Copied accelerate config file to: {target_config_location}")
+            except OSError as e:
+                log.error(
+                    f"Failed to copy accelerate config to {target_config_location}: {e}"
+                )
         elif run_accelerate:
             log.debug("Running accelerate configuration command...")
             run_cmd([sys.executable, "-m", "accelerate", "config"])

--- a/setup/setup_common.py
+++ b/setup/setup_common.py
@@ -303,6 +303,9 @@ def configure_accelerate(run_accelerate=False):
                 log.error(
                     f"Failed to copy accelerate config to {target_config_location}: {e}"
                 )
+                log.warning(
+                    "Could not automatically configure accelerate. Please manually configure accelerate with the option in the menu or with: accelerate config."
+                )
         elif run_accelerate:
             log.debug("Running accelerate configuration command...")
             run_cmd([sys.executable, "-m", "accelerate", "config"])

--- a/tests/test_configure_accelerate_hf_home.py
+++ b/tests/test_configure_accelerate_hf_home.py
@@ -72,7 +72,8 @@ def test_configure_accelerate_copy_failure_does_not_abort(
     dest = hf_home / "accelerate" / "default_config.yaml"
     assert not dest.exists()
     assert any(
-        "accelerate" in record.message.lower() or "copy" in record.message.lower()
+        "accelerate" in record.getMessage().lower()
+        or "copy" in record.getMessage().lower()
         for record in caplog.records
         if record.levelno >= logging.WARNING
     )

--- a/tests/test_configure_accelerate_hf_home.py
+++ b/tests/test_configure_accelerate_hf_home.py
@@ -1,0 +1,78 @@
+"""Regression for configure_accelerate() when HF_HOME is set.
+
+Issue #3502: HF_HOME destination was the cache directory itself, so
+shutil.copyfile raised IsADirectoryError instead of writing
+$HF_HOME/accelerate/default_config.yaml.
+"""
+
+import importlib.util
+import logging
+import os
+
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_spec = importlib.util.spec_from_file_location(
+    "setup_common",
+    os.path.join(_repo_root, "setup", "setup_common.py"),
+)
+setup_common = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(setup_common)
+
+
+def _clear_accelerate_env_candidates(monkeypatch):
+    """Prefer HF_HOME by removing Windows-oriented path candidates."""
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.delenv("USERPROFILE", raising=False)
+
+
+def test_configure_accelerate_copies_to_hf_home_accelerate_yaml(tmp_path, monkeypatch):
+    hf_home = tmp_path / "hf"
+    hf_home.mkdir()
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    _clear_accelerate_env_candidates(monkeypatch)
+
+    setup_common.configure_accelerate(run_accelerate=False)
+
+    dest = hf_home / "accelerate" / "default_config.yaml"
+    assert dest.is_file()
+    assert hf_home.is_dir()
+    assert not hf_home.is_file()
+
+
+def test_configure_accelerate_skips_copy_when_hf_home_config_exists(
+    tmp_path, monkeypatch
+):
+    hf_home = tmp_path / "hf"
+    dest = hf_home / "accelerate" / "default_config.yaml"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("existing: true\n", encoding="utf-8")
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    _clear_accelerate_env_candidates(monkeypatch)
+
+    setup_common.configure_accelerate(run_accelerate=False)
+
+    assert dest.read_text(encoding="utf-8") == "existing: true\n"
+
+
+def test_configure_accelerate_copy_failure_does_not_abort(
+    tmp_path, monkeypatch, caplog
+):
+    hf_home = tmp_path / "hf"
+    hf_home.mkdir()
+    monkeypatch.setenv("HF_HOME", str(hf_home))
+    _clear_accelerate_env_candidates(monkeypatch)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("simulated copy failure")
+
+    monkeypatch.setattr(setup_common.shutil, "copyfile", _boom)
+
+    with caplog.at_level(logging.ERROR):
+        setup_common.configure_accelerate(run_accelerate=False)
+
+    dest = hf_home / "accelerate" / "default_config.yaml"
+    assert not dest.exists()
+    assert any(
+        "accelerate" in record.message.lower() or "copy" in record.message.lower()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    )


### PR DESCRIPTION
## Summary
- Restore `$HF_HOME/accelerate/default_config.yaml` as the destination in `configure_accelerate()` (regression from `0d27fea`) so setup no longer raises `IsADirectoryError` when `HF_HOME` is set
- Leave an existing accelerate config under HF_HOME untouched on re-run
- Catch `OSError` on copy/mkdir and log an error instead of aborting the rest of setup

## Test plan
- [x] `pytest tests/test_configure_accelerate_hf_home.py` (3 tests: copy path, skip existing, non-fatal copy failure)
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (208 passed)

Closes #3502