### PR TITLE
fix: use native PyTorch XPU for --use-ipex after IPEX EOL

### DIFF
--- a/docs/Installation/pip_linux.md
+++ b/docs/Installation/pip_linux.md
@@ -118,7 +118,7 @@ You can pass the following arguments to `gui.sh` or `kohya_gui.py`:
   --share               Share the gradio UI
   --headless            Is the server headless
   --language LANGUAGE   Set custom language
-  --use-ipex            Use IPEX environment
+  --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name)
   --use-rocm            Use ROCm environment
   --do_not_use_shell    Enforce not to use shell=True when running external commands
   --do_not_share        Do not share the gradio UI

--- a/docs/Installation/pip_windows.md
+++ b/docs/Installation/pip_windows.md
@@ -146,7 +146,7 @@ This method uses a Python virtual environment managed via pip.
   --share               Share the gradio UI
   --headless            Is the server headless
   --language LANGUAGE   Set custom language
-  --use-ipex            Use IPEX environment
+  --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name; Linux-oriented)
   --use-rocm            Use ROCm environment
   --do_not_use_shell    Enforce not to use shell=True when running external commands
   --do_not_share        Do not share the gradio UI

--- a/docs/Installation/uv_linux.md
+++ b/docs/Installation/uv_linux.md
@@ -80,7 +80,7 @@ To launch the GUI service, run `./gui-uv.sh` or run the `kohya_gui.py` script di
   --share               Share the gradio UI
   --headless            Is the server headless
   --language LANGUAGE   Set custom language
-  --use-ipex            Use IPEX environment
+  --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name)
   --use-rocm            Use ROCm environment
   --do_not_use_shell    Enforce not to use shell=True when running external commands
   --do_not_share        Do not share the gradio UI

--- a/docs/Installation/uv_windows.md
+++ b/docs/Installation/uv_windows.md
@@ -77,7 +77,7 @@ This script utilizes the `uv` managed environment and handles dependencies and u
   --share               Share the gradio UI
   --headless            Is the server headless
   --language LANGUAGE   Set custom language
-  --use-ipex            Use IPEX environment
+  --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name; Linux-oriented)
   --use-rocm            Use ROCm environment
   --do_not_use_shell    Enforce not to use shell=True when running external commands
   --do_not_share        Do not share the gradio UI

--- a/gui.sh
+++ b/gui.sh
@@ -80,7 +80,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     if [ "$RUNPOD" = false ]; then
         if [[ "$@" == *"--use-ipex"* ]]; then
-            REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux_ipex.txt"
+            # Native PyTorch XPU; IPEX wheels EOL — issue #3499
+            REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_ipex_xpu.txt"
         elif [ -x "$(command -v nvidia-smi)" ]; then
             REQUIREMENTS_FILE="$SCRIPT_DIR/requirements_linux.txt"
         elif [[ "$@" == *"--use-rocm"* ]] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -207,7 +207,11 @@ def initialize_arg_parser():
     parser.add_argument(
         "--language", type=str, default=None, help="Set custom language"
     )
-    parser.add_argument("--use-ipex", action="store_true", help="Use IPEX environment")
+    parser.add_argument(
+        "--use-ipex",
+        action="store_true",
+        help="Use native PyTorch XPU environment for Intel Arc GPUs (legacy flag name)",
+    )
     parser.add_argument("--use-rocm", action="store_true", help="Use ROCm environment")
     parser.add_argument(
         "--do_not_use_shell",

--- a/requirements_linux_ipex.txt
+++ b/requirements_linux_ipex.txt
@@ -1,22 +1,4 @@
-# Custom index URL for specific packages
---extra-index-url https://download.pytorch.org/whl/xpu
---extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-
-torch==2.7.0+xpu
-torchvision==0.22.0+xpu
-intel-extension-for-pytorch==2.7.10+xpu
-oneccl_bind_pt==2.7.0+xpu
-
-tensorboard==2.15.2
-tensorflow==2.15.0
-intel-extension-for-tensorflow[xpu]==2.15.0.2
-onnxruntime==1.22.1
-onnxruntime-openvino==1.22.0
-
-mkl==2025.0.1
-mkl-dpcpp==2025.0.1
-oneccl-devel==2021.14.1
-impi-devel==2021.14.1
-
--r requirements.txt
-
+# Legacy filename kept for older docs/scripts that pass this path explicitly.
+# Canonical native PyTorch XPU pins live in requirements_ipex_xpu.txt.
+# IPEX / Intel extension-index wheels are EOL (see GitHub issue #3499).
+-r requirements_ipex_xpu.txt

--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ Options:
   -s, --skip-space-check        Skip the 10Gb minimum storage space check.
   -u, --no-gui                  Skips launching the GUI.
   -v, --verbose                 Increase verbosity levels up to 3.
-      --use-ipex                Use IPEX with Intel ARC GPUs.
+      --use-ipex                Use native PyTorch XPU for Intel Arc GPUs (legacy flag name).
       --use-rocm                Use ROCm with AMD GPUs.
 EOF
 }
@@ -227,27 +227,36 @@ install_python_dependencies() {
     fi
   fi
 
+  local install_status=0
   case "$OSTYPE" in
     "lin"*)
       if [ "$RUNPOD" = true ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_runpod.txt $QUIET
+        install_status=$?
       elif [ "$USE_IPEX" = true ]; then
-        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_ipex.txt $QUIET
+        # Native PyTorch XPU (requirements_ipex_xpu.txt); IPEX wheels EOL — issue #3499
+        python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_ipex_xpu.txt $QUIET
+        install_status=$?
       elif [ -x "$(command -v nvidia-smi)" ]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
+        install_status=$?
       elif [ "$USE_ROCM" = true ] || [ -x "$(command -v rocminfo)" ] || [ -f "/opt/rocm/bin/rocminfo" ]; then
         echo "Upgrading pip for ROCm."
         pip install --upgrade pip # PyTorch ROCm is too large to install with older pip
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux_rocm.txt $QUIET
+        install_status=$?
       else
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_linux.txt $QUIET
+        install_status=$?
       fi
       ;;
     "darwin"*)
       if [[ "$(uname -m)" == "arm64" ]]; then
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_macos_arm64.txt $QUIET
+        install_status=$?
       else
         python "$SCRIPT_DIR/setup/setup_linux.py" --platform-requirements-file=requirements_macos_amd64.txt $QUIET
+        install_status=$?
       fi
       ;;
   esac
@@ -265,6 +274,12 @@ install_python_dependencies() {
       echo "Keeping conda environment active as it was already activated before running this script."
     fi
   fi
+
+  if [ "$install_status" -ne 0 ]; then
+    echo "Python dependency installation failed (exit code $install_status). Setup cannot continue."
+    return 1
+  fi
+  return 0
 }
 
 # Function to configure accelerate
@@ -556,7 +571,10 @@ if [[ "$OSTYPE" == "lin"* ]]; then
     fi
   fi
 
-  install_python_dependencies
+  if ! install_python_dependencies; then
+    echo "Setup aborted because Python dependencies could not be installed."
+    exit 1
+  fi
 
   # We need just a little bit more setup for non-interactive environments
   if [ "$RUNPOD" = true ]; then
@@ -667,6 +685,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
   if ! install_python_dependencies; then
      echo "You may need to install Python. The command for this is brew install $PYTHON_BREW_VERSION."
+     echo "Setup aborted because Python dependencies could not be installed."
+     exit 1
   fi
 
   configure_accelerate

--- a/setup/setup_common.py
+++ b/setup/setup_common.py
@@ -13,7 +13,20 @@ log = logging.getLogger("sd")
 MIN_PYTHON_VERSION = (3, 10, 9)
 MAX_PYTHON_VERSION = (3, 13, 0)
 LOG_DIR = "../logs/setup/"
-LOG_LEVEL = "INFO" # Set to "INFO" or "WARNING" for less verbose logging
+LOG_LEVEL = "INFO"  # Set to "INFO" or "WARNING" for less verbose logging
+
+# Native PyTorch XPU wheels (pytorch.org). Used by --use-ipex after IPEX EOL (#3499).
+LINUX_INTEL_GPU_REQUIREMENTS_FILE = "requirements_ipex_xpu.txt"
+
+
+def get_linux_intel_gpu_requirements_file() -> str:
+    """Return the requirements file for Intel Arc / XPU Linux installs.
+
+    Historically selected via ``--use-ipex``. Intel archived IPEX and stopped
+    publishing official extension wheels; installs must use native PyTorch XPU
+    from download.pytorch.org instead of intel-extension-for-pytorch.
+    """
+    return LINUX_INTEL_GPU_REQUIREMENTS_FILE
 
 
 def check_python_version():
@@ -36,7 +49,9 @@ def check_python_version():
         return True
     except Exception as e:
         log.error(f"An unexpected error occurred while verifying Python version: {e}")
-        log.error("This might indicate a problem with your Python installation or environment configuration.")
+        log.error(
+            "This might indicate a problem with your Python installation or environment configuration."
+        )
         return False
 
 
@@ -53,14 +68,20 @@ def update_submodule(quiet=True):
         subprocess.run(git_command, check=True, capture_output=True, text=True)
         log.info("Submodule initialized and updated.")
     except subprocess.CalledProcessError as e:
-        log.error(f"Error updating submodule. Git command: '{' '.join(git_command)}' failed with exit code {e.returncode}.")
+        log.error(
+            f"Error updating submodule. Git command: '{' '.join(git_command)}' failed with exit code {e.returncode}."
+        )
         if e.stdout:
             log.error(f"Git stdout: {e.stdout.strip()}")
         if e.stderr:
             log.error(f"Git stderr: {e.stderr.strip()}")
-        log.error("Please ensure Git is installed and accessible in your PATH. Also, check your internet connection and repository permissions.")
+        log.error(
+            "Please ensure Git is installed and accessible in your PATH. Also, check your internet connection and repository permissions."
+        )
     except FileNotFoundError:
-        log.error(f"Error updating submodule: Git command not found. Please ensure Git is installed and accessible in your PATH.")
+        log.error(
+            f"Error updating submodule: Git command not found. Please ensure Git is installed and accessible in your PATH."
+        )
 
 
 def clone_or_checkout(repo_url, branch_or_tag, directory_name):
@@ -112,14 +133,20 @@ def clone_or_checkout(repo_url, branch_or_tag, directory_name):
             else:
                 log.info(f"Already at required branch/tag: {branch_or_tag}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Error during Git operation. Command: '{' '.join(e.cmd)}' failed with exit code {e.returncode}.")
+        log.error(
+            f"Error during Git operation. Command: '{' '.join(e.cmd)}' failed with exit code {e.returncode}."
+        )
         if e.stdout:
             log.error(f"Git stdout: {e.stdout.strip()}")
         if e.stderr:
             log.error(f"Git stderr: {e.stderr.strip()}")
-        log.error(f"Failed to clone or checkout {repo_url} ({branch_or_tag}). Please check the repository URL, branch/tag name, your internet connection, and Git installation.")
+        log.error(
+            f"Failed to clone or checkout {repo_url} ({branch_or_tag}). Please check the repository URL, branch/tag name, your internet connection, and Git installation."
+        )
     except FileNotFoundError:
-        log.error(f"Error during Git operation: Git command not found. Please ensure Git is installed and accessible in your PATH.")
+        log.error(
+            f"Error during Git operation: Git command not found. Please ensure Git is installed and accessible in your PATH."
+        )
     finally:
         os.chdir(original_dir)
 
@@ -165,11 +192,16 @@ def setup_logging():
 
 def install_requirements_inbulk(
     requirements_file, show_stdout=True, optional_parm="", upgrade=False
-):
+) -> bool:
+    """Install packages from a requirements file.
+
+    Returns:
+        True on success, False if the requirements file is missing or pip fails.
+    """
     log.debug(f"Installing requirements in bulk from: {requirements_file}")
     if not os.path.exists(requirements_file):
         log.error(f"Could not find the requirements file in {requirements_file}.")
-        return
+        return False
 
     log.info(f"Installing/Validating requirements from {requirements_file}...")
 
@@ -188,10 +220,7 @@ def install_requirements_inbulk(
     try:
         # Run the command and filter output in real-time
         process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
         )
 
         for line in process.stdout:
@@ -204,25 +233,45 @@ def install_requirements_inbulk(
         # Capture and log any errors
         stdout, stderr = process.communicate()
         if process.returncode != 0:
-            log.error(f"Failed to install requirements from {requirements_file}. Pip command: '{' '.join(cmd)}'. Exit code: {process.returncode}")
+            log.error(
+                f"Failed to install requirements from {requirements_file}. Pip command: '{' '.join(cmd)}'. Exit code: {process.returncode}"
+            )
             if stdout:
                 log.error(f"Pip stdout: {stdout.strip()}")
             if stderr:
                 log.error(f"Pip stderr: {stderr.strip()}")
-            log.error("Please check the requirements file path, your internet connection, and ensure pip is functioning correctly.")
-        else:
-            if stdout and show_stdout and not installed("uv"): # uv already prints its output
-                for line in stdout.splitlines():
-                    if "Requirement already satisfied" not in line:
-                        log.info(line.strip())
-            if stderr: # Always log stderr if present, even on success
-                log.warning(f"Pip stderr (even on success): {stderr.strip()}")
+                if "403" in stderr or "Forbidden" in stderr:
+                    log.error(
+                        "HTTP 403/Forbidden from a package index usually means the "
+                        "wheel was removed or the index no longer serves that pin "
+                        "(e.g. EOL IPEX). Prefer native PyTorch XPU requirements "
+                        f"({get_linux_intel_gpu_requirements_file()}) for Intel GPUs."
+                    )
+            log.error(
+                "Please check the requirements file path, your internet connection, and ensure pip is functioning correctly."
+            )
+            return False
 
+        if (
+            stdout and show_stdout and not installed("uv")
+        ):  # uv already prints its output
+            for line in stdout.splitlines():
+                if "Requirement already satisfied" not in line:
+                    log.info(line.strip())
+        if stderr:  # Always log stderr if present, even on success
+            log.warning(f"Pip stderr (even on success): {stderr.strip()}")
+        return True
 
     except FileNotFoundError:
-        log.error(f"Error installing requirements: '{cmd[0]}' command not found. Please ensure it is installed and in your PATH.")
+        log.error(
+            f"Error installing requirements: '{cmd[0]}' command not found. Please ensure it is installed and in your PATH."
+        )
+        return False
     except Exception as e:
-        log.error(f"An unexpected error occurred while installing requirements from {requirements_file}: {e}")
+        log.error(
+            f"An unexpected error occurred while installing requirements from {requirements_file}: {e}"
+        )
+        return False
 
 
 def configure_accelerate(run_accelerate=False):
@@ -335,20 +384,24 @@ def check_torch():
 
         log.debug("Torch module imported successfully.")
         try:
-            # Import IPEX / XPU support
-            import intel_extension_for_pytorch as ipex
+            # IPEX is optional/legacy after PyTorch 2.5; native XPU does not need it (#3499)
+            import intel_extension_for_pytorch as ipex  # noqa: F401
 
             log.debug("Intel extension for PyTorch imported successfully.")
         except Exception as e:
-            log.warning(f"Failed to import intel_extension_for_pytorch: {e}")
+            log.debug(f"intel_extension_for_pytorch not available (optional): {e}")
         log.info(f"Torch {torch.__version__}")
 
         _log_gpu_info(torch)
 
         return int(torch.__version__[0])
     except ImportError as e:
-        log.error(f"Failed to import Torch: {e}. Please ensure PyTorch is installed correctly for your system.")
-        log.error("You might need to install or reinstall PyTorch. Check https://pytorch.org/get-started/locally/ for instructions.")
+        log.error(
+            f"Failed to import Torch: {e}. Please ensure PyTorch is installed correctly for your system."
+        )
+        log.error(
+            "You might need to install or reinstall PyTorch. Check https://pytorch.org/get-started/locally/ for instructions."
+        )
         return 0
     except Exception as e:
         log.error(f"An unexpected error occurred while checking Torch: {e}")
@@ -371,9 +424,7 @@ def _check_nvidia_toolkit():
 
 def _check_amd_toolkit():
     """Checks for AMD toolkit."""
-    if shutil.which("rocminfo") is not None or os.path.exists(
-        "/opt/rocm/bin/rocminfo"
-    ):
+    if shutil.which("rocminfo") is not None or os.path.exists("/opt/rocm/bin/rocminfo"):
         log.info("AMD toolkit detected")
         return True
     return False
@@ -424,13 +475,15 @@ def _log_gpu_info(torch_module):
             )
     # Check if XPU is available
     elif hasattr(torch_module, "xpu") and torch_module.xpu.is_available():
-        # Log Intel IPEX version
-        # Ensure ipex is imported before accessing __version__
+        # Prefer native PyTorch XPU; IPEX is optional/legacy after PyTorch 2.5 (#3499)
         try:
             import intel_extension_for_pytorch as ipex
+
             log.info(f"Torch backend: Intel IPEX {ipex.__version__}")
         except ImportError:
-            log.warning("Intel IPEX version not available.")
+            log.info(
+                "Torch backend: native PyTorch XPU (intel_extension_for_pytorch not installed)"
+            )
 
         for i in range(torch_module.xpu.device_count()):
             device = torch_module.xpu.device(i)
@@ -500,11 +553,19 @@ def git(arg: str, folder: str = None, ignore: bool = False):
     if result.returncode != 0 and not ignore:
         # global errors # This variable is not defined in this file. Assuming it's a remnant from an older version or a different context.
         # errors += 1
-        log.error(f"Error running git command 'git {arg}' in folder '{folder or '.'}'. Exit code: {result.returncode}")
+        log.error(
+            f"Error running git command 'git {arg}' in folder '{folder or '.'}'. Exit code: {result.returncode}"
+        )
         if "or stash them" in txt:
-            log.error(f"Local changes detected. Please commit or stash them before running this command again. Full git output below.")
-        log.error(f"Git output: {txt}") # Changed from log.debug to log.error for better visibility of error details
-        log.error("Please ensure Git is installed, the repository exists, you have the necessary permissions, and there are no conflicts or uncommitted changes.")
+            log.error(
+                f"Local changes detected. Please commit or stash them before running this command again. Full git output below."
+            )
+        log.error(
+            f"Git output: {txt}"
+        )  # Changed from log.debug to log.error for better visibility of error details
+        log.error(
+            "Please ensure Git is installed, the repository exists, you have the necessary permissions, and there are no conflicts or uncommitted changes."
+        )
 
 
 def pip(arg: str, ignore: bool = False, quiet: bool = False, show_stdout: bool = False):
@@ -558,9 +619,13 @@ def pip(arg: str, ignore: bool = False, quiet: bool = False, show_stdout: bool =
             )
         txt = txt.strip()
         if result.returncode != 0 and not ignore:
-            log.error(f"Error running pip command: '{' '.join(pip_cmd)}'. Exit code: {result.returncode}")
+            log.error(
+                f"Error running pip command: '{' '.join(pip_cmd)}'. Exit code: {result.returncode}"
+            )
             log.error(f"Pip output: {txt}")
-            log.error("Please check the package name, version, your internet connection, and ensure pip is functioning correctly.")
+            log.error(
+                "Please check the package name, version, your internet connection, and ensure pip is functioning correctly."
+            )
         return txt
 
 
@@ -768,24 +833,39 @@ def run_cmd(run_cmd):
     """
     log.debug(f"Running command: {run_cmd}")
     try:
-        process = subprocess.run(run_cmd, shell=True, check=True, env=os.environ, capture_output=True, text=True)
+        process = subprocess.run(
+            run_cmd,
+            shell=True,
+            check=True,
+            env=os.environ,
+            capture_output=True,
+            text=True,
+        )
         log.debug(f"Command executed successfully: {run_cmd}")
         if process.stdout:
             log.debug(f"Stdout: {process.stdout.strip()}")
         if process.stderr:
             log.debug(f"Stderr: {process.stderr.strip()}")
     except subprocess.CalledProcessError as e:
-        log.error(f"Error occurred while running command: '{run_cmd}'. Exit code: {e.returncode}")
+        log.error(
+            f"Error occurred while running command: '{run_cmd}'. Exit code: {e.returncode}"
+        )
         if e.stdout:
             log.error(f"Stdout: {e.stdout.strip()}")
         if e.stderr:
             log.error(f"Stderr: {e.stderr.strip()}")
-        log.error("Please check the command syntax, permissions, and ensure all required programs are installed and in PATH.")
+        log.error(
+            "Please check the command syntax, permissions, and ensure all required programs are installed and in PATH."
+        )
     except FileNotFoundError:
         # This might occur if the command itself (e.g., the first part of run_cmd) is not found
-        log.error(f"Error running command: '{run_cmd}'. The command or a part of it was not found. Please ensure it is correctly spelled and accessible in your PATH.")
+        log.error(
+            f"Error running command: '{run_cmd}'. The command or a part of it was not found. Please ensure it is correctly spelled and accessible in your PATH."
+        )
     except Exception as e:
-        log.error(f"An unexpected error occurred while running command '{run_cmd}': {e}")
+        log.error(
+            f"An unexpected error occurred while running command '{run_cmd}': {e}"
+        )
 
 
 def clear_screen():

--- a/setup/setup_linux.py
+++ b/setup/setup_linux.py
@@ -3,42 +3,76 @@ import logging
 import setup_common
 
 errors = 0  # Define the 'errors' variable before using it
-log = logging.getLogger('sd')
+log = logging.getLogger("sd")
 
 # ANSI escape code for yellow color
-YELLOW = '\033[93m'
-RESET_COLOR = '\033[0m'
+YELLOW = "\033[93m"
+RESET_COLOR = "\033[0m"
 
 
-def main_menu(platform_requirements_file, show_stdout: bool = False, no_run_accelerate: bool = False):
-    log.info("Installing python dependencies. This could take a few minutes as it downloads files.")
-    log.info("If this operation ever runs too long, you can rerun this script in verbose mode to check.")
-    
+def main_menu(
+    platform_requirements_file,
+    show_stdout: bool = False,
+    no_run_accelerate: bool = False,
+):
+    log.info(
+        "Installing python dependencies. This could take a few minutes as it downloads files."
+    )
+    log.info(
+        "If this operation ever runs too long, you can rerun this script in verbose mode to check."
+    )
+
     setup_common.check_repo_version()
     # setup_common.check_python()
 
     # Upgrade pip if needed
-    setup_common.install('pip')
-    setup_common.install_requirements_inbulk(
-        platform_requirements_file, show_stdout=show_stdout,
+    setup_common.install("pip")
+    install_ok = setup_common.install_requirements_inbulk(
+        platform_requirements_file,
+        show_stdout=show_stdout,
     )
+    if not install_ok:
+        log.error(
+            "Python dependency installation failed. Setup cannot continue. "
+            "Fix the pip error above and re-run setup."
+        )
+        raise SystemExit(1)
     # setup_common.install_requirements(platform_requirements_file, check_no_verify_flag=False, show_stdout=show_stdout)
     if not no_run_accelerate:
         setup_common.configure_accelerate(run_accelerate=False)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup_common.ensure_base_requirements()
     setup_common.setup_logging()
     if not setup_common.check_python_version():
         exit(1)
-    
+
     setup_common.update_submodule()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--platform-requirements-file', dest='platform_requirements_file', default='requirements_linux.txt', help='Path to the platform-specific requirements file')
-    parser.add_argument('--show_stdout', dest='show_stdout', action='store_true', help='Whether to show stdout during installation')
-    parser.add_argument('--no_run_accelerate', dest='no_run_accelerate', action='store_true', help='Whether to not run accelerate config')
+    parser.add_argument(
+        "--platform-requirements-file",
+        dest="platform_requirements_file",
+        default="requirements_linux.txt",
+        help="Path to the platform-specific requirements file",
+    )
+    parser.add_argument(
+        "--show_stdout",
+        dest="show_stdout",
+        action="store_true",
+        help="Whether to show stdout during installation",
+    )
+    parser.add_argument(
+        "--no_run_accelerate",
+        dest="no_run_accelerate",
+        action="store_true",
+        help="Whether to not run accelerate config",
+    )
     args = parser.parse_args()
 
-    main_menu(args.platform_requirements_file, show_stdout=args.show_stdout, no_run_accelerate=args.no_run_accelerate)
+    main_menu(
+        args.platform_requirements_file,
+        show_stdout=args.show_stdout,
+        no_run_accelerate=args.no_run_accelerate,
+    )

--- a/setup/setup_runpod.py
+++ b/setup/setup_runpod.py
@@ -5,20 +5,23 @@ import os
 import shutil
 
 errors = 0  # Define the 'errors' variable before using it
-log = logging.getLogger('sd')
+log = logging.getLogger("sd")
 
 # ANSI escape code for yellow color
-YELLOW = '\033[93m'
-RESET_COLOR = '\033[0m'
+YELLOW = "\033[93m"
+RESET_COLOR = "\033[0m"
+
 
 def configure_accelerate():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     cache_dir = "/root/.cache/huggingface/accelerate"
-    
+
     log.info("Configuring accelerate...")
     os.makedirs(cache_dir, exist_ok=True)
 
-    config_file_src = os.path.join(script_dir, "config_files", "accelerate", "runpod.yaml")
+    config_file_src = os.path.join(
+        script_dir, "config_files", "accelerate", "runpod.yaml"
+    )
     config_file_dest = os.path.join(cache_dir, "default_config.yaml")
     shutil.copyfile(config_file_src, config_file_dest)
 
@@ -29,48 +32,64 @@ def setup_environment():
 
     # Install tk and python3.10-venv
     log.info("Install tk and python3.10-venv...")
-    subprocess.run(['apt', 'update', '-y'])
-    subprocess.run(['apt', 'install', '-y', 'python3-tk', 'python3.10-venv'])
+    subprocess.run(["apt", "update", "-y"])
+    subprocess.run(["apt", "install", "-y", "python3-tk", "python3.10-venv"])
 
     # Check if the venv folder doesn't exist
-    venv_dir = os.path.join(script_dir, 'venv')
+    venv_dir = os.path.join(script_dir, "venv")
     if not os.path.exists(venv_dir):
         log.info("Creating venv...")
-        subprocess.run(['python3', '-m', 'venv', venv_dir])
+        subprocess.run(["python3", "-m", "venv", venv_dir])
 
     # Activate the virtual environment
     log.info("Activate venv...")
-    activate_script = os.path.join(venv_dir, 'bin', 'activate')
+    activate_script = os.path.join(venv_dir, "bin", "activate")
     activate_command = f'source "{activate_script}" || exit 1'
-    subprocess.run(activate_command, shell=True, executable='/bin/bash')
+    subprocess.run(activate_command, shell=True, executable="/bin/bash")
 
 
 def main_menu(platform_requirements_file):
-    log.info("Installing python dependencies. This could take a few minutes as it downloads files.")
-    log.info("If this operation ever runs too long, you can rerun this script in verbose mode to check.")
+    log.info(
+        "Installing python dependencies. This could take a few minutes as it downloads files."
+    )
+    log.info(
+        "If this operation ever runs too long, you can rerun this script in verbose mode to check."
+    )
 
     setup_common.check_repo_version()
     # setup_common.check_python()
 
     # Upgrade pip if needed
-    setup_common.install('pip')
-    
-    setup_common.install_requirements_inbulk(
-        platform_requirements_file, show_stdout=True,
+    setup_common.install("pip")
+
+    install_ok = setup_common.install_requirements_inbulk(
+        platform_requirements_file,
+        show_stdout=True,
     )
+    if not install_ok:
+        log.error(
+            "Python dependency installation failed. Setup cannot continue. "
+            "Fix the pip error above and re-run setup."
+        )
+        raise SystemExit(1)
     configure_accelerate()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     setup_common.ensure_base_requirements()
     setup_common.setup_logging()
     if not setup_common.check_python_version():
         exit(1)
-    
+
     setup_common.update_submodule()
-    
+
     parser = argparse.ArgumentParser()
-    parser.add_argument('--platform-requirements-file', dest='platform_requirements_file', default='requirements_runpod.txt', help='Path to the platform-specific requirements file')
+    parser.add_argument(
+        "--platform-requirements-file",
+        dest="platform_requirements_file",
+        default="requirements_runpod.txt",
+        help="Path to the platform-specific requirements file",
+    )
     args = parser.parse_args()
-    
+
     main_menu(args.platform_requirements_file)

--- a/setup/setup_windows.py
+++ b/setup/setup_windows.py
@@ -121,12 +121,19 @@ def install_kohya_ss_torch2(headless: bool = False):
     # setup_common.install_requirements(
     #     "requirements_windows_torch2.txt", check_no_verify_flag=False
     # )
-    
-    setup_common.install_requirements_inbulk(
-        "requirements_pytorch_windows.txt", show_stdout=True, 
+
+    install_ok = setup_common.install_requirements_inbulk(
+        "requirements_pytorch_windows.txt",
+        show_stdout=True,
         # optional_parm="--index-url https://download.pytorch.org/whl/cu124"
     )
-    
+    if not install_ok:
+        log.error(
+            "Python dependency installation failed. Setup cannot continue. "
+            "Fix the pip error above and re-run setup."
+        )
+        exit(1)
+
     # setup_common.install_requirements_inbulk(
     #     "requirements_windows.txt", show_stdout=True, upgrade=True
     # )
@@ -189,7 +196,9 @@ def main_menu(headless: bool = False):
             print(
                 "2. (Optional) Install CuDNN files (to use the latest supported CuDNN version)"
             )
-            print("3. (DANGER) Install Triton 2.1.0 for Windows... only do it if you know you need it... might break training...")
+            print(
+                "3. (DANGER) Install Triton 2.1.0 for Windows... only do it if you know you need it... might break training..."
+            )
             print("4. (Optional) Install specific version of bitsandbytes")
             print("5. (Optional) Manually configure Accelerate")
             print("6. (Optional) Launch Kohya_ss GUI in browser")

--- a/setup/validate_requirements.py
+++ b/setup/validate_requirements.py
@@ -20,6 +20,7 @@ from kohya_gui.custom_logging import setup_logging
 log = setup_logging()
 log.debug(f"Project directory set to: {project_directory}")
 
+
 def check_path_with_space():
     """Check if the current working directory contains a space."""
     cwd = os.getcwd()
@@ -34,6 +35,7 @@ def check_path_with_space():
         )
         log.error(f"The current working directory is: {cwd}")
         raise RuntimeError("Invalid path: contains spaces.")
+
 
 def detect_toolkit():
     """Detect the available toolkit (NVIDIA, AMD, or Intel) and log the information."""
@@ -63,6 +65,7 @@ def detect_toolkit():
         log.debug("No specific GPU toolkit detected, defaulting to CPU")
         return "CPU"
 
+
 def check_torch():
     """Check if torch is available and log the relevant information."""
     # Detect the available toolkit (e.g., NVIDIA, AMD, Intel, or CPU)
@@ -80,10 +83,15 @@ def check_torch():
             try:
                 log.debug("Attempting to import Intel Extension for PyTorch (IPEX)...")
                 import intel_extension_for_pytorch as ipex
+
                 log.debug("Intel Extension for PyTorch (IPEX) imported successfully")
             except ImportError:
-                log.warning("Intel Extension for PyTorch (IPEX) not found.")
-        
+                # Optional after IPEX EOL; native torch.xpu is enough (#3499)
+                log.debug(
+                    "Intel Extension for PyTorch (IPEX) not found; "
+                    "using native XPU if available."
+                )
+
         # Log the PyTorch version
         log.info(f"Torch {torch.__version__}")
 
@@ -113,6 +121,7 @@ def check_torch():
         log.error(f"Unexpected error while checking torch: {e}")
         sys.exit(1)
 
+
 def log_cuda_info(torch):
     """Log information about CUDA-enabled GPUs."""
     # Log the CUDA and cuDNN versions if available
@@ -133,26 +142,32 @@ def log_cuda_info(torch):
             f"Torch detected GPU: {props.name} VRAM {round(props.total_memory / 1024 / 1024)}MB Arch {props.major}.{props.minor} Cores {props.multi_processor_count}"
         )
 
+
 def log_mps_info(torch):
     """Log information about Apple Silicone (MPS)"""
     max_recommended_mem = round(torch.mps.recommended_max_memory() / 1024**2)
     log.info(
         f"Torch detected Apple MPS: {max_recommended_mem}MB Unified Memory Available"
     )
-    log.warning('MPS support is still experimental, proceed with caution.')
+    log.warning("MPS support is still experimental, proceed with caution.")
 
 
 def log_xpu_info(torch, ipex):
     """Log information about Intel XPU-enabled GPUs."""
-    # Log the Intel Extension for PyTorch (IPEX) version if available
+    # IPEX is optional; native PyTorch XPU is the supported path after IPEX EOL (#3499)
     if ipex:
         log.info(f"Torch backend: Intel IPEX {ipex.__version__}")
+    else:
+        log.info(
+            "Torch backend: native PyTorch XPU (intel_extension_for_pytorch not installed)"
+        )
     # Log information about each detected XPU-enabled GPU
     for device in range(torch.xpu.device_count()):
         props = torch.xpu.get_device_properties(device)
         log.info(
             f"Torch detected GPU: {props.name} VRAM {round(props.total_memory / 1024 / 1024)}MB Compute Units {props.max_compute_units}"
         )
+
 
 def main():
     # Check the repository version to ensure compatibility
@@ -189,17 +204,25 @@ def main():
     # Install required packages from the specified requirements file
     requirements_file = args.requirements or "requirements_pytorch_windows.txt"
     log.debug(f"Installing requirements from: {requirements_file}")
-    setup_common.install_requirements_inbulk(
-        requirements_file, show_stdout=True, 
+    install_ok = setup_common.install_requirements_inbulk(
+        requirements_file,
+        show_stdout=True,
         # optional_parm="--index-url https://download.pytorch.org/whl/cu124"
     )
-    
+    if not install_ok:
+        log.error(
+            "Requirements installation failed. Aborting validation so a broken "
+            "environment is not treated as ready."
+        )
+        sys.exit(1)
+
     # setup_common.install_requirements(requirements_file, check_no_verify_flag=True)
-    
+
     # log.debug("Installing additional requirements from: requirements_windows.txt")
     # setup_common.install_requirements(
     #     "requirements_windows.txt", check_no_verify_flag=True
     # )
+
 
 if __name__ == "__main__":
     log.debug("Starting main function...")

--- a/tests/test_check_torch_native_xpu.py
+++ b/tests/test_check_torch_native_xpu.py
@@ -1,0 +1,84 @@
+"""Regression for issue #3499: native torch.xpu must not require IPEX."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_repo_root = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "setup_common",
+    _repo_root / "setup" / "setup_common.py",
+)
+setup_common = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(setup_common)
+
+
+def _make_native_xpu_torch(version: str = "2.7.1+xpu"):
+    """Minimal torch stand-in: XPU available, no CUDA, no IPEX."""
+    torch_mod = types.ModuleType("torch")
+    torch_mod.__version__ = version
+    torch_mod.cuda = MagicMock()
+    torch_mod.cuda.is_available.return_value = False
+    torch_mod.xpu = MagicMock()
+    torch_mod.xpu.is_available.return_value = True
+    torch_mod.xpu.device_count.return_value = 1
+    torch_mod.xpu.device.return_value = 0
+    torch_mod.xpu.get_device_name.return_value = "Intel Arc B580"
+    props = MagicMock()
+    props.total_memory = 12 * 1024 * 1024 * 1024
+    props.max_compute_units = 160
+    torch_mod.xpu.get_device_properties.return_value = props
+    return torch_mod
+
+
+class TestCheckTorchNativeXpu(unittest.TestCase):
+    def test_check_torch_accepts_native_xpu_without_ipex(self):
+        torch_mod = _make_native_xpu_torch()
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return torch_mod
+            if name == "intel_extension_for_pytorch":
+                raise ImportError("No module named 'intel_extension_for_pytorch'")
+            return original_import(name, *args, **kwargs)
+
+        original_import = __import__
+
+        with patch.object(setup_common, "_check_hardware_toolkit"):
+            with patch("builtins.__import__", side_effect=fake_import):
+                major = setup_common.check_torch()
+
+        self.assertEqual(major, 2)
+
+    def test_log_gpu_info_reports_native_xpu_when_ipex_missing(self):
+        torch_mod = _make_native_xpu_torch()
+        logs = []
+
+        def capture_info(msg, *args, **kwargs):
+            logs.append(str(msg))
+
+        with patch.object(setup_common.log, "info", side_effect=capture_info):
+            with patch.object(setup_common.log, "warning") as mock_warn:
+                with patch.dict(sys.modules, {"intel_extension_for_pytorch": None}):
+                    # Force ImportError path for IPEX
+                    real_import = __import__
+
+                    def fake_import(name, *args, **kwargs):
+                        if name == "intel_extension_for_pytorch":
+                            raise ImportError("no ipex")
+                        return real_import(name, *args, **kwargs)
+
+                    with patch("builtins.__import__", side_effect=fake_import):
+                        setup_common._log_gpu_info(torch_mod)
+
+        joined = " ".join(logs)
+        self.assertIn("native PyTorch XPU", joined)
+        self.assertIn("Intel Arc B580", joined)
+        mock_warn.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_requirements_failure.py
+++ b/tests/test_install_requirements_failure.py
@@ -1,0 +1,110 @@
+"""Regression for issue #3499: setup must not treat pip failures as success."""
+
+import importlib.util
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_repo_root = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "setup_common",
+    _repo_root / "setup" / "setup_common.py",
+)
+setup_common = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(setup_common)
+
+_linux_spec = importlib.util.spec_from_file_location(
+    "setup_linux",
+    _repo_root / "setup" / "setup_linux.py",
+)
+# setup_linux imports setup_common from the same directory; load after patching path
+import sys
+
+sys.path.insert(0, str(_repo_root / "setup"))
+setup_linux = importlib.util.module_from_spec(_linux_spec)
+_linux_spec.loader.exec_module(setup_linux)
+
+
+class TestInstallRequirementsFailure(unittest.TestCase):
+    def test_install_requirements_inbulk_returns_false_on_pip_failure(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("some-package==1.0.0\n")
+            req_path = tmp.name
+
+        try:
+            mock_proc = MagicMock()
+            mock_proc.stdout = iter([])
+            mock_proc.returncode = 1
+            mock_proc.communicate.return_value = (
+                "",
+                "ERROR: HTTP error 403 while getting wheel",
+            )
+
+            with patch.object(setup_common.subprocess, "Popen", return_value=mock_proc):
+                with patch.object(setup_common, "installed", return_value=False):
+                    result = setup_common.install_requirements_inbulk(
+                        req_path, show_stdout=False
+                    )
+
+            self.assertIs(result, False)
+        finally:
+            os.unlink(req_path)
+
+    def test_install_requirements_inbulk_returns_true_on_success(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("some-package==1.0.0\n")
+            req_path = tmp.name
+
+        try:
+            mock_proc = MagicMock()
+            mock_proc.stdout = iter(["Requirement already satisfied: some-package\n"])
+            mock_proc.returncode = 0
+            mock_proc.communicate.return_value = ("", "")
+
+            with patch.object(setup_common.subprocess, "Popen", return_value=mock_proc):
+                with patch.object(setup_common, "installed", return_value=False):
+                    result = setup_common.install_requirements_inbulk(
+                        req_path, show_stdout=False
+                    )
+
+            self.assertIs(result, True)
+        finally:
+            os.unlink(req_path)
+
+    def test_install_requirements_inbulk_returns_false_when_file_missing(self):
+        result = setup_common.install_requirements_inbulk(
+            str(_repo_root / "no-such-requirements-file-xyz.txt"),
+            show_stdout=False,
+        )
+        self.assertIs(result, False)
+
+    def test_setup_linux_main_menu_exits_on_install_failure(self):
+        with patch.object(setup_linux.setup_common, "check_repo_version"):
+            with patch.object(setup_linux.setup_common, "install"):
+                with patch.object(
+                    setup_linux.setup_common,
+                    "install_requirements_inbulk",
+                    return_value=False,
+                ):
+                    with patch.object(
+                        setup_linux.setup_common, "configure_accelerate"
+                    ) as mock_accel:
+                        with self.assertRaises(SystemExit) as ctx:
+                            setup_linux.main_menu(
+                                "requirements_ipex_xpu.txt",
+                                show_stdout=False,
+                                no_run_accelerate=False,
+                            )
+                        self.assertEqual(ctx.exception.code, 1)
+                        mock_accel.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xpu_requirements.py
+++ b/tests/test_xpu_requirements.py
@@ -1,0 +1,44 @@
+"""Regression for issue #3499: Intel/XPU install must use native PyTorch XPU.
+
+IPEX wheels from Intel's extension index return HTTP 403 after EOL.
+--use-ipex must select a requirements file that does not pin IPEX.
+"""
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "setup_common",
+    _repo_root / "setup" / "setup_common.py",
+)
+setup_common = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(setup_common)
+
+
+def _requirements_text(filename: str) -> str:
+    return (_repo_root / filename).read_text(encoding="utf-8")
+
+
+class TestNativeXpuRequirements(unittest.TestCase):
+    def test_linux_intel_gpu_requirements_file_is_native_xpu(self):
+        filename = setup_common.get_linux_intel_gpu_requirements_file()
+        self.assertEqual(filename, "requirements_ipex_xpu.txt")
+        text = _requirements_text(filename)
+        self.assertNotIn("intel-extension-for-pytorch", text)
+        self.assertNotIn("pytorch-extension.intel.com", text)
+        self.assertIn("download.pytorch.org/whl/xpu", text)
+        self.assertIn("torch", text)
+        self.assertIn("+xpu", text)
+
+    def test_legacy_linux_ipex_requirements_file_does_not_pin_ipex(self):
+        """Old name may still be referenced; it must not pull EOL IPEX wheels."""
+        text = _requirements_text("requirements_linux_ipex.txt")
+        self.assertNotIn("intel-extension-for-pytorch", text)
+        self.assertNotIn("pytorch-extension.intel.com", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wire `--use-ipex` install/runtime to **native PyTorch XPU** (`requirements_ipex_xpu.txt` from pytorch.org) after Intel EOL/403 on IPEX extension wheels.
- Make `install_requirements_inbulk` return success/failure and fail setup/validation hard so pip 403s no longer end with a false "Setup finished!".
- Treat `intel_extension_for_pytorch` as optional when `torch.xpu` is available; log native XPU backend instead of warning.

Closes #3499

## Changes

| Area | Change |
|------|--------|
| `requirements_linux_ipex.txt` | Legacy name redirects to `requirements_ipex_xpu.txt` (no IPEX pins) |
| `setup.sh` / `gui.sh` | Select `requirements_ipex_xpu.txt`; abort on install failure |
| `setup_common.install_requirements_inbulk` | Returns `bool`; clearer 403 messaging |
| `setup_linux` / windows / runpod / `validate_requirements` | Exit non-zero on install failure |
| Torch checks | Native XPU path without requiring IPEX |

## Test plan

- [x] `pytest tests/ test/test_allowed_paths.py` (223 passed)
- [x] Unit: native XPU requirements do not pin IPEX
- [x] Unit: pip failure returns `False` and `setup_linux.main_menu` exits 1
- [x] Unit: `check_torch` / `_log_gpu_info` accept native XPU without IPEX
- [ ] Manual (Linux + Arc): `./setup.sh --use-ipex` completes with `torch==*+xpu` and no IPEX download
- [ ] Manual: force a bad requirements pin and confirm setup exits without "Setup finished!"

## Notes

- Flag name `--use-ipex` is kept for compatibility; behavior is native XPU.
- No `sd-scripts/` edits (submodule ownership).