### PR TITLE
docs/fix: remote/SSH --headless guidance for overwrite softlock (#3570)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Support for Linux and macOS is also available. While Linux support is actively m
   - [Offline / air-gapped GUI shell](#offline--air-gapped-gui-shell)
 - [Custom Path Defaults](#custom-path-defaults)
 - [Server Options](#server-options)
+  - [`allowed_paths`](#allowed_paths)
+  - [Remote / SSH: use `--headless`](#remote--ssh-use---headless)
 - [LoRA](#lora)
   - [Sample image generation during training](#sample-image-generation-during-training)
   - [Troubleshooting](#troubleshooting)
@@ -207,6 +209,29 @@ The `allowed_paths` option allows you to specify a list of directories that the 
 [server]
 allowed_paths = ["/mnt/external_drive/models", "/home/user/datasets"]
 ```
+
+### Remote / SSH: use `--headless`
+
+When you run the GUI on a remote machine (SSH, Runpod, Docker, cloud GPU) and open it in a browser, **start with `--headless`**.
+
+Without it, native OS dialogs (easygui overwrite confirmation, local file pickers) run on the **server** process. Over SSH there is usually no interactive display, so those prompts can **block training indefinitely**.
+
+`--headless` does two things that matter for remote use:
+
+* Hides local file/folder picker buttons in the Gradio UI (type paths instead).
+* Skips the easygui “overwrite existing model?” prompt and overwrites if the output name already exists.
+
+Examples:
+
+```bash
+# Linux / macOS
+./gui.sh --listen 0.0.0.0 --server_port 7860 --headless
+
+# Windows
+gui.bat --listen 0.0.0.0 --server_port 7860 --headless
+```
+
+If you start without `--headless` over SSH or without a display, the process logs a warning recommending `--headless`. There is no separate `--skip_overwrite` flag; use `--headless` for that behavior on train start.
 
 ## LoRA
 

--- a/docs/Installation/pip_linux.md
+++ b/docs/Installation/pip_linux.md
@@ -116,7 +116,7 @@ You can pass the following arguments to `gui.sh` or `kohya_gui.py`:
                         Port to run the server listener on
   --inbrowser           Open in browser
   --share               Share the gradio UI
-  --headless            Is the server headless
+  --headless            Remote/SSH: hide local file pickers; skip overwrite dialog
   --language LANGUAGE   Set custom language
   --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name)
   --use-rocm            Use ROCm environment
@@ -127,6 +127,12 @@ You can pass the following arguments to `gui.sh` or `kohya_gui.py`:
   --root_path ROOT_PATH
                         `root_path` for Gradio to enable reverse proxy support. e.g. /kohya_ss
   --noverify            Disable requirements verification
+```
+
+On remote/SSH or headless servers, **always pass `--headless`**. Without it, native overwrite confirmation and file dialogs can block the server process. See [Remote / SSH: use `--headless`](../../README.md#remote--ssh-use---headless).
+
+```bash
+./gui.sh --headless --listen 0.0.0.0 --server_port 7860
 ```
 
 ## Upgrade Instructions

--- a/docs/Installation/pip_windows.md
+++ b/docs/Installation/pip_windows.md
@@ -144,7 +144,7 @@ This method uses a Python virtual environment managed via pip.
                         Port to run the server listener on
   --inbrowser           Open in browser
   --share               Share the gradio UI
-  --headless            Is the server headless
+  --headless            Remote/SSH: hide local file pickers; skip overwrite dialog
   --language LANGUAGE   Set custom language
   --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name; Linux-oriented)
   --use-rocm            Use ROCm environment

--- a/docs/Installation/uv_linux.md
+++ b/docs/Installation/uv_linux.md
@@ -78,7 +78,7 @@ To launch the GUI service, run `./gui-uv.sh` or run the `kohya_gui.py` script di
                         Port to run the server listener on
   --inbrowser           Open in browser
   --share               Share the gradio UI
-  --headless            Is the server headless
+  --headless            Remote/SSH: hide local file pickers; skip overwrite dialog
   --language LANGUAGE   Set custom language
   --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name)
   --use-rocm            Use ROCm environment
@@ -97,7 +97,7 @@ When you run `gui-uv.sh`, it will first check if `uv` is installed on your syste
 ./gui-uv.sh --listen 127.0.0.1 --server_port 7860 --inbrowser --share
 ```
 
-If you are running on a headless server, use:
+If you are running on a remote/SSH or headless server, **always pass `--headless`**. Without it, native overwrite confirmation and file dialogs can block the server process with no way to answer them. See also [Remote / SSH: use `--headless`](../../README.md#remote--ssh-use---headless) in the main README.
 
 ```shell
 ./gui-uv.sh --headless --listen 127.0.0.1 --server_port 7860 --inbrowser --share

--- a/docs/Installation/uv_windows.md
+++ b/docs/Installation/uv_windows.md
@@ -75,7 +75,7 @@ This script utilizes the `uv` managed environment and handles dependencies and u
                         Port to run the server listener on
   --inbrowser           Open in browser
   --share               Share the gradio UI
-  --headless            Is the server headless
+  --headless            Remote/SSH: hide local file pickers; skip overwrite dialog
   --language LANGUAGE   Set custom language
   --use-ipex            Use native PyTorch XPU for Intel Arc GPUs (legacy flag name; Linux-oriented)
   --use-rocm            Use ROCm environment

--- a/docs/installation_docker.md
+++ b/docs/installation_docker.md
@@ -20,6 +20,7 @@ Install the NVIDIA Container Toolkit with this guide.
 
 #### Design of our Dockerfile
 
+- The image starts the GUI with **`--headless`** by default (see `Dockerfile` `CMD`). That skips native overwrite dialogs and local file pickers so training cannot softlock inside the container. Override carefully if you change the command.
 - It is required that all training data is stored in the `dataset` subdirectory, which is mounted into the container at `/dataset`.
 - Please note that the file picker functionality is not available. Instead, you will need to manually input the folder path and configuration file path.
 - TensorBoard has been separated from the project.

--- a/docs/installation_runpod.md
+++ b/docs/installation_runpod.md
@@ -22,7 +22,7 @@ To install the necessary components for Runpod and run kohya_ss, follow these st
    ./setup-runpod.sh
    ```
 
-5. Run the GUI with:
+5. Run the GUI with **`--headless`** (required on Runpod/SSH so native overwrite dialogs do not block training):
 
    ```shell
    ./gui.sh --share --headless

--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -16,6 +16,10 @@ from kohya_gui.anima_lllite_gui import anima_lllite_tab
 from kohya_gui.class_lora_tab import LoRATools
 from kohya_gui.settings_gui import settings_tab
 from kohya_gui.custom_logging import setup_logging
+from kohya_gui.common_gui import (
+    HEADLESS_RECOMMENDATION_MESSAGE,
+    should_recommend_headless,
+)
 from kohya_gui.localization_ext import add_javascript
 from kohya_gui.offline_assets import (
     build_offline_theme,
@@ -117,7 +121,10 @@ def UI(**kwargs):
     install_offline_template_patches()
     # Add custom JavaScript if specified
     add_javascript(kwargs.get("language"))
-    log.info(f"headless: {kwargs.get('headless', False)}")
+    headless = kwargs.get("headless", False)
+    log.info(f"headless: {headless}")
+    if should_recommend_headless(headless):
+        log.warning(HEADLESS_RECOMMENDATION_MESSAGE)
 
     # Load release and README information
     release_info = read_file_content("./.release")
@@ -141,7 +148,7 @@ def UI(**kwargs):
     ui_interface = initialize_ui_interface(
         config,
         config_file_path,
-        kwargs.get("headless", False),
+        headless,
         use_shell,
         release_info,
         readme_content,
@@ -202,7 +209,13 @@ def initialize_arg_parser():
     parser.add_argument("--inbrowser", action="store_true", help="Open in browser")
     parser.add_argument("--share", action="store_true", help="Share the gradio UI")
     parser.add_argument(
-        "--headless", action="store_true", help="Is the server headless"
+        "--headless",
+        action="store_true",
+        help=(
+            "Run without local GUI dialogs: hide file/folder picker buttons and "
+            "skip easygui overwrite confirmation (required for remote/SSH; "
+            "existing models are overwritten without a prompt)"
+        ),
     )
     parser.add_argument(
         "--language", type=str, default=None, help="Set custom language"

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     pass
 from easygui import msgbox, ynbox
-from typing import Optional
+from typing import Mapping, Optional
 from .custom_logging import setup_logging
 from .sd_modeltype import SDModelType
 
@@ -117,6 +117,54 @@ def calculate_max_train_steps(
             * int(reg_factor)
         )
     )
+
+
+def should_recommend_headless(
+    headless: bool = False,
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+    platform: Optional[str] = None,
+) -> bool:
+    """
+    Return True when starting without --headless is likely to hang on native dialogs.
+
+    Remote/SSH sessions and Unix environments without DISPLAY/Wayland cannot
+    interact with easygui/tkinter prompts that run on the server process.
+    Callers should pass --headless so overwrite confirmation is skipped and
+    local file-picker buttons stay hidden.
+
+    Parameters:
+        headless: Whether --headless was already requested.
+        environ: Environment mapping (defaults to os.environ; injectable for tests).
+        platform: sys.platform value (injectable for tests).
+
+    Returns:
+        True if a startup warning recommending --headless should be emitted.
+    """
+    if headless:
+        return False
+
+    env = os.environ if environ is None else environ
+    plat = sys.platform if platform is None else platform
+
+    # OpenSSH (and compatible) session markers — cross-platform when set.
+    if any(env.get(key) for key in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
+        return True
+
+    # Non-Windows without a graphical display: native dialogs will hang.
+    if plat != "win32":
+        if not (env.get("DISPLAY") or env.get("WAYLAND_DISPLAY")):
+            return True
+
+    return False
+
+
+HEADLESS_RECOMMENDATION_MESSAGE = (
+    "No interactive display detected (or SSH session). "
+    "Native dialogs (easygui/tkinter) can block the process. "
+    "Start with --headless for remote/SSH use so overwrite confirmation "
+    "and local file pickers are skipped."
+)
 
 
 def check_if_model_exist(

--- a/tests/test_headless_recommendation.py
+++ b/tests/test_headless_recommendation.py
@@ -1,0 +1,97 @@
+"""Regression for remote/SSH headless guidance (#3570).
+
+--headless already skips easygui overwrite confirms in check_if_model_exist.
+These tests lock that contract and the startup heuristic that warns when a
+native display is unlikely to be available.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from kohya_gui.common_gui import check_if_model_exist, should_recommend_headless
+
+
+class TestShouldRecommendHeadless(unittest.TestCase):
+    def test_headless_true_never_recommends(self):
+        self.assertFalse(
+            should_recommend_headless(
+                True,
+                environ={"SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 10"},
+                platform="linux",
+            )
+        )
+        self.assertFalse(should_recommend_headless(True, environ={}, platform="linux"))
+
+    def test_ssh_session_recommends_even_with_display(self):
+        env = {
+            "SSH_CONNECTION": "10.0.0.1 12345 10.0.0.2 22",
+            "DISPLAY": ":0",
+        }
+        self.assertTrue(should_recommend_headless(False, environ=env, platform="linux"))
+        self.assertTrue(should_recommend_headless(False, environ=env, platform="win32"))
+
+    def test_ssh_client_marker_recommends(self):
+        self.assertTrue(
+            should_recommend_headless(
+                False,
+                environ={"SSH_CLIENT": "10.0.0.1 12345 22"},
+                platform="win32",
+            )
+        )
+
+    def test_unix_without_display_recommends(self):
+        self.assertTrue(should_recommend_headless(False, environ={}, platform="linux"))
+        self.assertTrue(should_recommend_headless(False, environ={}, platform="darwin"))
+
+    def test_unix_with_display_local_does_not_recommend(self):
+        self.assertFalse(
+            should_recommend_headless(
+                False, environ={"DISPLAY": ":1"}, platform="linux"
+            )
+        )
+        self.assertFalse(
+            should_recommend_headless(
+                False,
+                environ={"WAYLAND_DISPLAY": "wayland-0"},
+                platform="linux",
+            )
+        )
+
+    def test_windows_local_without_ssh_does_not_recommend(self):
+        self.assertFalse(should_recommend_headless(False, environ={}, platform="win32"))
+
+
+class TestCheckIfModelExistHeadless(unittest.TestCase):
+    def test_headless_skips_ynbox_and_allows_overwrite(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_path = os.path.join(tmp, "existing.safetensors")
+            with open(model_path, "w", encoding="utf-8") as f:
+                f.write("")
+
+            with patch("kohya_gui.common_gui.ynbox") as mock_ynbox:
+                result = check_if_model_exist(
+                    "existing", tmp, "safetensors", headless=True
+                )
+
+            self.assertFalse(result)
+            mock_ynbox.assert_not_called()
+
+    def test_non_headless_calls_ynbox_when_model_exists(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_path = os.path.join(tmp, "existing.safetensors")
+            with open(model_path, "w", encoding="utf-8") as f:
+                f.write("")
+
+            with patch("kohya_gui.common_gui.ynbox", return_value=False) as mock_ynbox:
+                result = check_if_model_exist(
+                    "existing", tmp, "safetensors", headless=False
+                )
+
+            self.assertTrue(result)
+            mock_ynbox.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Closes #3570 by documenting and reinforcing **`--headless`** for remote/SSH instead of adding `--skip_overwrite`.
- `check_if_model_exist(..., headless=True)` already skips `easygui.ynbox` and overwrites; train tabs already pass `headless` through.
- Startup warning when not headless and SSH/no display is detected.
- Clearer `--headless` CLI help and README / install / Docker / Runpod notes.

## Why not `--skip_overwrite`?

That flag would re-plumb six GUI modules for behavior headless already provides on train start, while leaving other native dialog softlocks unaddressed. Non-headless + remote browser still runs easygui/tkinter on the **server**.

## Test plan

- [x] `pytest tests/test_headless_recommendation.py` (8 passed)
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (241 passed)
- [ ] Manual: start without `--headless` over SSH → expect log warning recommending `--headless`
- [ ] Manual: start with `--headless`, train with existing output name → no overwrite dialog; training proceeds

## Review

- Standards: no hard AGENTS violations; soft test filename note only.
- Spec: AC1 docs + AC2 no new flag + AC3 optional warning met; AC4 easygui cleanup left out of scope.