### PR TITLE
fix: coerce lr_warmup types before comparison (#3455)

### DIFF
--- a/kohya_gui/class_basic_training.py
+++ b/kohya_gui/class_basic_training.py
@@ -5,6 +5,7 @@ from .custom_logging import setup_logging
 # Set up logging
 log = setup_logging()
 
+
 class BasicTraining:
     """
     This class configures and initializes the basic training settings for a machine learning model,
@@ -14,7 +15,7 @@ class BasicTraining:
         sdxl_checkbox (gr.Checkbox): Checkbox to enable SDXL training.
         learning_rate_value (str): Initial learning rate value.
         lr_scheduler_value (str): Initial learning rate scheduler value.
-        lr_warmup_value (str): Initial learning rate warmup value.
+        lr_warmup_value (float): Initial learning rate warmup percent value.
         finetuning (bool): If True, enables fine-tuning of the model.
         dreambooth (bool): If True, enables Dreambooth training.
     """
@@ -24,7 +25,7 @@ class BasicTraining:
         sdxl_checkbox: gr.Checkbox,
         learning_rate_value: float = "1e-6",
         lr_scheduler_value: str = "constant",
-        lr_warmup_value: float = "0",
+        lr_warmup_value: float = 0,
         lr_warmup_steps_value: int = 0,
         finetuning: bool = False,
         dreambooth: bool = False,
@@ -37,7 +38,7 @@ class BasicTraining:
             sdxl_checkbox (gr.Checkbox): Checkbox to enable SDXL training.
             learning_rate_value (str): Initial learning rate value.
             lr_scheduler_value (str): Initial learning rate scheduler value.
-            lr_warmup_value (str): Initial learning rate warmup value.
+            lr_warmup_value (float): Initial learning rate warmup percent value.
             finetuning (bool): If True, enables fine-tuning of the model.
             dreambooth (bool): If True, enables Dreambooth training.
         """
@@ -45,11 +46,11 @@ class BasicTraining:
         self.learning_rate_value = learning_rate_value
         self.lr_scheduler_value = lr_scheduler_value
         self.lr_warmup_value = lr_warmup_value
-        self.lr_warmup_steps_value= lr_warmup_steps_value
+        self.lr_warmup_steps_value = lr_warmup_steps_value
         self.finetuning = finetuning
         self.dreambooth = dreambooth
         self.config = config
-        
+
         # Initialize old_lr_warmup and old_lr_warmup_steps with default values
         self.old_lr_warmup = 0
         self.old_lr_warmup_steps = 0
@@ -175,7 +176,7 @@ class BasicTraining:
                 ],
                 value=self.config.get("basic.lr_scheduler", self.lr_scheduler_value),
             )
-            
+
             # Initialize the learning rate scheduler type dropdown
             self.lr_scheduler_type = gr.Dropdown(
                 label="LR Scheduler type",
@@ -187,7 +188,7 @@ class BasicTraining:
                 value=self.config.get("basic.lr_scheduler_type", ""),
                 allow_custom_value=True,
             )
-            
+
             # Initialize the optimizer dropdown
             self.optimizer = gr.Dropdown(
                 label="Optimizer",
@@ -230,7 +231,9 @@ class BasicTraining:
         """
         with gr.Row():
             # Initialize the maximum gradient norm slider
-            self.max_grad_norm = gr.Number(label='Max grad norm', value=1.0, interactive=True)
+            self.max_grad_norm = gr.Number(
+                label="Max grad norm", value=1.0, interactive=True
+            )
             # Initialize the learning rate scheduler extra arguments textbox
             self.lr_scheduler_args = gr.Textbox(
                 label="LR scheduler extra arguments",
@@ -309,19 +312,21 @@ class BasicTraining:
             # Initialize the learning rate warmup steps override
             self.lr_warmup_steps = gr.Number(
                 label="LR warmup steps (override)",
-                value=self.config.get("basic.lr_warmup_steps", self.lr_warmup_steps_value),
+                value=self.config.get(
+                    "basic.lr_warmup_steps", self.lr_warmup_steps_value
+                ),
                 minimum=0,
                 step=1,
             )
-            
+
             def lr_scheduler_changed(scheduler, value, value_lr_warmup_steps):
                 if scheduler == "constant":
                     self.old_lr_warmup = value
                     self.old_lr_warmup_steps = value_lr_warmup_steps
                     value = 0
                     value_lr_warmup_steps = 0
-                    interactive=False
-                    info="Can't use LR warmup with LR Scheduler constant... setting to 0 and disabling field..."
+                    interactive = False
+                    info = "Can't use LR warmup with LR Scheduler constant... setting to 0 and disabling field..."
                 else:
                     if self.old_lr_warmup != 0:
                         value = self.old_lr_warmup
@@ -329,10 +334,14 @@ class BasicTraining:
                     if self.old_lr_warmup_steps != 0:
                         value_lr_warmup_steps = self.old_lr_warmup_steps
                         self.old_lr_warmup_steps = 0
-                    interactive=True
-                    info=""
-                return gr.Slider(value=value, interactive=interactive, info=info), gr.Number(value=value_lr_warmup_steps, interactive=interactive, info=info)
-            
+                    interactive = True
+                    info = ""
+                return gr.Slider(
+                    value=value, interactive=interactive, info=info
+                ), gr.Number(
+                    value=value_lr_warmup_steps, interactive=interactive, info=info
+                )
+
             self.lr_scheduler.change(
                 lr_scheduler_changed,
                 inputs=[self.lr_scheduler, self.lr_warmup, self.lr_warmup_steps],
@@ -349,7 +358,7 @@ class BasicTraining:
                 label="LR # cycles",
                 minimum=1,
                 # precision=0, # round to nearest integer
-                step=1, # Increment value by 1
+                step=1,  # Increment value by 1
                 info="Number of restarts for cosine scheduler with restarts",
                 value=self.config.get("basic.lr_scheduler_num_cycles", 1),
             )

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1182,6 +1182,50 @@ def set_pretrained_model_name_or_path_input(
 ###
 
 
+def resolve_lr_warmup_steps(lr_warmup, lr_warmup_steps):
+    """Resolve effective lr_warmup_steps from percent and absolute override.
+
+    Gradio / loaded configs may pass str, None, or empty values. Coerce both
+    inputs to numbers before comparison or arithmetic so train_model paths do
+    not raise TypeError (GH #3455).
+
+    Precedence matches historical train_model behavior:
+    1. If absolute override > 0, use int(override); warn if percent also set.
+    2. Else if percent != 0, return percent / 100 (fraction of total steps).
+    3. Else return 0.
+
+    Args:
+        lr_warmup: LR warmup as percent of total steps (0–100), any coercible type.
+        lr_warmup_steps: Absolute warmup steps override, any coercible type.
+
+    Returns:
+        int or float: Absolute override as int, or percent/100 as float, or 0.
+    """
+
+    def _as_float(value, default=0.0):
+        if value is None or value == "":
+            return default
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    warmup = _as_float(lr_warmup)
+    steps = _as_float(lr_warmup_steps)
+
+    if steps > 0:
+        resolved = int(steps)
+        if warmup > 0:
+            log.warning(
+                "Both lr_warmup and lr_warmup_steps are set. "
+                "lr_warmup_steps will be used."
+            )
+        return resolved
+    if warmup != 0:
+        return warmup / 100
+    return 0
+
+
 def get_int_or_default(kwargs, key, default_value=0):
     """
     Retrieves an integer value from the provided kwargs dictionary based on the given key. If the key is not found,

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -13,6 +13,7 @@ from .common_gui import (
     get_file_path,
     get_saveasfile_path,
     print_command_and_toml,
+    resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
@@ -831,17 +832,8 @@ def train_model(
 
         log.info(f"Total steps: {total_steps}")
 
-    # Calculate lr_warmup_steps
-    if lr_warmup_steps > 0:
-        lr_warmup_steps = int(lr_warmup_steps)
-        if lr_warmup > 0:
-            log.warning(
-                "Both lr_warmup and lr_warmup_steps are set. lr_warmup_steps will be used."
-            )
-    elif lr_warmup != 0:
-        lr_warmup_steps = lr_warmup / 100
-    else:
-        lr_warmup_steps = 0
+    # Calculate lr_warmup_steps (coerce str/None from Gradio/config — GH #3455)
+    lr_warmup_steps = resolve_lr_warmup_steps(lr_warmup, lr_warmup_steps)
 
     log.info(f"Train batch size: {train_batch_size}")
     log.info(f"Gradient accumulation steps: {gradient_accumulation_steps}")

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -14,6 +14,7 @@ from .common_gui import (
     get_file_path,
     get_saveasfile_path,
     print_command_and_toml,
+    resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
@@ -1027,17 +1028,8 @@ def train_model(
 
     log.info(max_train_steps_info)
 
-    # Calculate lr_warmup_steps
-    if lr_warmup_steps > 0:
-        lr_warmup_steps = int(lr_warmup_steps)
-        if lr_warmup > 0:
-            log.warning(
-                "Both lr_warmup and lr_warmup_steps are set. lr_warmup_steps will be used."
-            )
-    elif lr_warmup != 0:
-        lr_warmup_steps = lr_warmup / 100
-    else:
-        lr_warmup_steps = 0
+    # Calculate lr_warmup_steps (coerce str/None from Gradio/config — GH #3455)
+    lr_warmup_steps = resolve_lr_warmup_steps(lr_warmup, lr_warmup_steps)
 
     log.info(f"lr_warmup_steps = {lr_warmup_steps}")
 

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -15,6 +15,7 @@ from .common_gui import (
     get_saveasfile_path,
     output_message,
     print_command_and_toml,
+    resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
@@ -1441,12 +1442,27 @@ def train_model(
                     float(max_train_steps) / 100 * int(stop_text_encoder_training)
                 )
 
-            if lr_warmup != 0:
-                lr_warmup_steps = round(
-                    float(int(lr_warmup) * int(max_train_steps) / 100)
+            # Convert percent warmup to absolute steps when max_train_steps is
+            # known (historical LoRA dataset_config behavior). Coerce types so
+            # str/None do not TypeError (GH #3455). Absolute override is left
+            # for resolve_lr_warmup_steps so precedence stays consistent.
+            try:
+                _warmup_pct = float(lr_warmup) if lr_warmup not in ("", None) else 0.0
+            except (TypeError, ValueError):
+                _warmup_pct = 0.0
+            try:
+                _steps_override = (
+                    float(lr_warmup_steps) if lr_warmup_steps not in ("", None) else 0.0
                 )
-            else:
-                lr_warmup_steps = 0
+            except (TypeError, ValueError):
+                _steps_override = 0.0
+
+            if _steps_override > 0:
+                pass  # resolve_lr_warmup_steps applies override + dual-set warn
+            elif _warmup_pct != 0:
+                lr_warmup_steps = round(_warmup_pct * int(max_train_steps) / 100)
+                # Percent already consumed as absolute steps; avoid false warn
+                lr_warmup = 0
         else:
             stop_text_encoder_training = 0
             lr_warmup_steps = 0
@@ -1541,17 +1557,8 @@ def train_model(
                 float(max_train_steps) / 100 * int(stop_text_encoder_training)
             )
 
-    # Calculate lr_warmup_steps
-    if lr_warmup_steps > 0:
-        lr_warmup_steps = int(lr_warmup_steps)
-        if lr_warmup > 0:
-            log.warning(
-                "Both lr_warmup and lr_warmup_steps are set. lr_warmup_steps will be used."
-            )
-    elif lr_warmup != 0:
-        lr_warmup_steps = lr_warmup / 100
-    else:
-        lr_warmup_steps = 0
+    # Calculate lr_warmup_steps (coerce str/None from Gradio/config — GH #3455)
+    lr_warmup_steps = resolve_lr_warmup_steps(lr_warmup, lr_warmup_steps)
 
     log.info(f"Train batch size: {train_batch_size}")
     log.info(f"Gradient accumulation steps: {gradient_accumulation_steps}")

--- a/kohya_gui/textual_inversion_gui.py
+++ b/kohya_gui/textual_inversion_gui.py
@@ -15,6 +15,7 @@ from .common_gui import (
     list_files,
     output_message,
     print_command_and_toml,
+    resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
@@ -695,17 +696,8 @@ def train_model(
 
         log.info(f"Total steps: {total_steps}")
 
-    # Calculate lr_warmup_steps
-    if lr_warmup_steps > 0:
-        lr_warmup_steps = int(lr_warmup_steps)
-        if lr_warmup > 0:
-            log.warning(
-                "Both lr_warmup and lr_warmup_steps are set. lr_warmup_steps will be used."
-            )
-    elif lr_warmup != 0:
-        lr_warmup_steps = lr_warmup / 100
-    else:
-        lr_warmup_steps = 0
+    # Calculate lr_warmup_steps (coerce str/None from Gradio/config — GH #3455)
+    lr_warmup_steps = resolve_lr_warmup_steps(lr_warmup, lr_warmup_steps)
 
     log.info(f"Train batch size: {train_batch_size}")
     log.info(f"Gradient accumulation steps: {gradient_accumulation_steps}")

--- a/tests/test_lr_warmup_resolve.py
+++ b/tests/test_lr_warmup_resolve.py
@@ -1,0 +1,132 @@
+"""Regression tests for GH issue #3455: string/None lr_warmup values must not
+raise TypeError when computing lr_warmup_steps in train_model paths.
+
+Covers the shared resolve_lr_warmup_steps helper and fine-tune train_model
+integration with string-typed warmup controls.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from kohya_gui.common_gui import resolve_lr_warmup_steps
+from kohya_gui import finetune_gui
+from kohya_gui.class_basic_training import BasicTraining
+from conftest import build_train_model_kwargs, run_train_model_and_load_toml
+
+FIXTURE = "test/config/finetune-AdamW-toml.json"
+
+NUMERIC_FIXUPS = (
+    "lr_warmup_steps",
+    "huber_scale",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "logit_mean",
+    "logit_std",
+    "mode_scale",
+    "sd3_text_encoder_batch_size",
+    "t5xxl_max_token_length",
+    "guidance_scale",
+    "blocks_to_swap",
+    "single_blocks_to_swap",
+    "double_blocks_to_swap",
+    "discrete_flow_shift",
+)
+STRING_OVERRIDES = (
+    "ae",
+    "clip_l",
+    "clip_g",
+    "t5xxl",
+    "flux1_clip_l",
+    "flux1_t5xxl",
+    "t5xxl_device",
+    "t5xxl_dtype",
+    "log_config",
+    "lr_scheduler_type",
+    "model_prediction_type",
+    "timestep_sampling",
+    "weighting_scheme",
+)
+
+
+class TestResolveLrWarmupSteps(unittest.TestCase):
+    """Unit tests for resolve_lr_warmup_steps — pure precedence + coercion."""
+
+    def test_numeric_percent_yields_fraction(self):
+        self.assertEqual(resolve_lr_warmup_steps(10, 0), 0.1)
+        self.assertEqual(resolve_lr_warmup_steps(10.0, 0), 0.1)
+
+    def test_numeric_override_takes_precedence(self):
+        with patch("kohya_gui.common_gui.log") as mock_log:
+            result = resolve_lr_warmup_steps(10, 50)
+        self.assertEqual(result, 50)
+        mock_log.warning.assert_called_once()
+
+    def test_override_without_percent_no_warning(self):
+        with patch("kohya_gui.common_gui.log") as mock_log:
+            result = resolve_lr_warmup_steps(0, 50)
+        self.assertEqual(result, 50)
+        mock_log.warning.assert_not_called()
+
+    def test_both_zero(self):
+        self.assertEqual(resolve_lr_warmup_steps(0, 0), 0)
+
+    def test_string_percent_coerced(self):
+        self.assertEqual(resolve_lr_warmup_steps("10", 0), 0.1)
+        self.assertEqual(resolve_lr_warmup_steps("10", "0"), 0.1)
+
+    def test_string_override_coerced(self):
+        with patch("kohya_gui.common_gui.log"):
+            self.assertEqual(resolve_lr_warmup_steps("10", "100"), 100)
+
+    def test_empty_and_none_treated_as_zero(self):
+        self.assertEqual(resolve_lr_warmup_steps("", None), 0)
+        self.assertEqual(resolve_lr_warmup_steps(None, ""), 0)
+        self.assertEqual(resolve_lr_warmup_steps(None, None), 0)
+
+    def test_invalid_string_falls_back_to_zero(self):
+        self.assertEqual(resolve_lr_warmup_steps("not-a-number", 0), 0)
+        self.assertEqual(resolve_lr_warmup_steps(10, "bad"), 0.1)
+
+
+class TestFinetuneStringLrWarmup(unittest.TestCase):
+    """Integration: finetune train_model must accept string lr_warmup."""
+
+    def _kwargs(self, **overrides):
+        return build_train_model_kwargs(
+            finetune_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides=overrides,
+        )
+
+    def test_string_percent_writes_fraction(self):
+        kwargs = self._kwargs(lr_warmup="10", lr_warmup_steps=0)
+        config = run_train_model_and_load_toml(finetune_gui, kwargs)
+        self.assertAlmostEqual(config.get("lr_warmup_steps"), 0.1)
+
+    def test_string_percent_with_numeric_override(self):
+        kwargs = self._kwargs(lr_warmup="10", lr_warmup_steps=100)
+        config = run_train_model_and_load_toml(finetune_gui, kwargs)
+        self.assertEqual(config.get("lr_warmup_steps"), 100)
+
+    def test_numeric_inputs_unchanged(self):
+        kwargs = self._kwargs(lr_warmup=10, lr_warmup_steps=0)
+        config = run_train_model_and_load_toml(finetune_gui, kwargs)
+        self.assertAlmostEqual(config.get("lr_warmup_steps"), 0.1)
+
+
+class TestBasicTrainingLrWarmupDefault(unittest.TestCase):
+    def test_default_lr_warmup_value_is_numeric(self):
+        # Default used by finetune (no override) must not be a str.
+        import inspect
+
+        sig = inspect.signature(BasicTraining.__init__)
+        default = sig.parameters["lr_warmup_value"].default
+        self.assertIsInstance(default, (int, float))
+        self.assertNotIsInstance(default, bool)
+        self.assertEqual(default, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes TypeError when full fine-tune (and other tabs) compare/divide `lr_warmup` that arrived as a string or None from Gradio/config (GH #3455).
- Adds shared `resolve_lr_warmup_steps` in `common_gui` and uses it from finetune, LoRA, DreamBooth, and textual inversion train paths.
- Fixes `BasicTraining` default `lr_warmup_value` from string `""0""` to numeric `0` (finetune inherits this default).
- LoRA dataset_config pre-pass coerces types and no longer zeros an absolute steps override when percent is zero.

## Test plan
- [x] `pytest tests/test_lr_warmup_resolve.py` (helper + finetune string integration)
- [x] `pytest tests/test_finetune_gui.py tests/test_dreambooth_gui.py tests/test_lora_gui.py tests/test_textual_inversion_gui.py`
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (274 passed, 1 skipped)

## Notes
Supersedes the incomplete approach in #3456 (finetune-only, changes percent math to absolute steps). This PR preserves historical `percent / 100` fraction semantics on the shared path.

Closes #3455