### PR TITLE
fix: safe Dataset Preparation copy that cannot wipe source images

### DIFF
--- a/kohya_gui/dreambooth_folder_creation_gui.py
+++ b/kohya_gui/dreambooth_folder_creation_gui.py
@@ -1,7 +1,8 @@
 import gradio as gr
 from .common_gui import get_folder_path, scriptdir, list_dirs, create_refresh_button
-import shutil
 import os
+import shutil
+import tempfile
 from .class_gui_config import KohyaSSGUIConfig
 
 from .custom_logging import setup_logging
@@ -22,6 +23,118 @@ def copy_info_to_Folders_tab(training_folder):
     return img_folder, reg_folder, model_folder, log_folder
 
 
+def _resolve_path(path: str) -> str:
+    """Absolute, normalized path (resolves .. and symlinks when possible)."""
+    return os.path.realpath(os.path.abspath(os.path.expanduser(path)))
+
+
+def _paths_equal(a: str, b: str) -> bool:
+    return _resolve_path(a) == _resolve_path(b)
+
+
+def _is_under(path: str, parent: str) -> bool:
+    """True if path is strictly inside parent (not equal)."""
+    path_r = _resolve_path(path)
+    parent_r = _resolve_path(parent)
+    if path_r == parent_r:
+        return False
+    try:
+        common = os.path.commonpath([path_r, parent_r])
+    except ValueError:
+        # Different drives on Windows
+        return False
+    return common == parent_r
+
+
+def _validate_copy_pair(src: str, dst: str, label: str) -> str | None:
+    """Return an error message if src→dst is unsafe, else None."""
+    if not src or not str(src).strip():
+        return f"Error: {label} source directory is missing."
+    src = str(src).strip()
+    if not os.path.isdir(src):
+        return f"Error: {label} source does not exist or is not a directory: {src}"
+
+    if _paths_equal(src, dst):
+        return (
+            f"Error: refused — {label} source and destination are the same path "
+            f"({_resolve_path(src)}). This would delete your only copy. "
+            f"Point the {label} source at your original folder, not the prepared "
+            "target folder under the destination."
+        )
+
+    # Destination under source → recursive copy bomb (#1761)
+    if _is_under(dst, src):
+        return (
+            f"Error: refused — {label} destination is inside the source folder "
+            f"(source={_resolve_path(src)}, dest={_resolve_path(dst)}). "
+            f"Choose a destination outside the {label.lower()} source directory."
+        )
+
+    # Source under destination → replacing dest would wipe source
+    if _is_under(src, dst):
+        return (
+            f"Error: refused — {label} source is inside the destination folder "
+            f"(source={_resolve_path(src)}, dest={_resolve_path(dst)}). "
+            "That would delete the source when replacing the destination."
+        )
+
+    return None
+
+
+def _safe_copytree_replace(src: str, dst: str) -> None:
+    """Copy src directory to dst. If dst exists, replace via backup rename after a full staged copy.
+
+    Never deletes src. Existing dst is renamed aside only after the staged copy
+    succeeds; on failure to install the new tree, the backup is restored.
+    """
+    src_r = _resolve_path(src)
+    dst_abs = os.path.abspath(dst)
+    parent = os.path.dirname(dst_abs)
+    os.makedirs(parent, exist_ok=True)
+
+    if _paths_equal(src_r, dst_abs):
+        raise RuntimeError(
+            f"Refusing to replace destination that equals source: {dst_abs}"
+        )
+
+    staging_root = tempfile.mkdtemp(prefix=".kohya_prep_", dir=parent)
+    staged = os.path.join(staging_root, "data")
+    backup_old = None
+    try:
+        shutil.copytree(src_r, staged)
+
+        if os.path.isdir(dst_abs):
+            # Same-filesystem rename keeps previous dest until new tree is installed
+            backup_old = dst_abs + ".kohya_prep_bak"
+            if os.path.exists(backup_old):
+                shutil.rmtree(backup_old)
+            os.rename(dst_abs, backup_old)
+
+        try:
+            try:
+                os.rename(staged, dst_abs)
+            except OSError:
+                shutil.move(staged, dst_abs)
+        except Exception:
+            if backup_old is not None and os.path.isdir(backup_old):
+                if not os.path.exists(dst_abs):
+                    os.rename(backup_old, dst_abs)
+                backup_old = None
+            raise
+
+        if backup_old is not None and os.path.isdir(backup_old):
+            shutil.rmtree(backup_old)
+            backup_old = None
+    finally:
+        if os.path.isdir(staging_root):
+            shutil.rmtree(staging_root, ignore_errors=True)
+        if backup_old is not None and os.path.isdir(backup_old):
+            log.error(
+                "Folder preparation left a backup at %s; restore manually if needed.",
+                backup_old,
+            )
+
+
 def dreambooth_folder_preparation(
     util_training_images_dir_input,
     util_training_images_repeat_input,
@@ -31,85 +144,121 @@ def dreambooth_folder_preparation(
     util_class_prompt_input,
     util_training_dir_output,
 ):
+    """Create kohya training folder layout by copying images.
 
-    # Check if the input variables are empty
-    if not len(util_training_dir_output):
-        log.info(
-            "Destination training directory is missing... can't perform the required task..."
-        )
-        return
-    else:
-        # Create the util_training_dir_output directory if it doesn't exist
-        os.makedirs(util_training_dir_output, exist_ok=True)
+    Returns a status string for the Gradio UI on every path (success or refusal).
+    """
+    # Destination required
+    if not util_training_dir_output or not str(util_training_dir_output).strip():
+        msg = "Error: Destination training directory is missing... can't perform the required task..."
+        log.info(msg)
+        return msg
 
-    # Check for instance prompt
-    if util_instance_prompt_input == "":
-        log.error("Instance prompt missing...")
-        return
+    util_training_dir_output = str(util_training_dir_output).strip()
 
-    # Check for class prompt
-    if util_class_prompt_input == "":
-        log.error("Class prompt missing...")
-        return
+    # Normalize prompts (trailing newlines/spaces break Windows paths — #1541)
+    instance_prompt = (util_instance_prompt_input or "").strip()
+    class_prompt = (util_class_prompt_input or "").strip()
 
-    # Create the training_dir path
-    if util_training_images_dir_input == "":
-        log.info(
-            "Training images directory is missing... can't perform the required task..."
-        )
-        return
-    else:
-        training_dir = os.path.join(
-            util_training_dir_output,
-            f"img/{int(util_training_images_repeat_input)}_{util_instance_prompt_input} {util_class_prompt_input}",
-        )
+    if instance_prompt == "":
+        msg = "Error: Instance prompt missing..."
+        log.error(msg)
+        return msg
 
-        # Remove folders if they exist
-        if os.path.exists(training_dir):
-            log.info(f"Removing existing directory {training_dir}...")
-            shutil.rmtree(training_dir)
+    if class_prompt == "":
+        msg = "Error: Class prompt missing..."
+        log.error(msg)
+        return msg
 
-        # Copy the training images to their respective directories
-        log.info(f"Copy {util_training_images_dir_input} to {training_dir}...")
-        shutil.copytree(util_training_images_dir_input, training_dir)
+    if (
+        not util_training_images_dir_input
+        or not str(util_training_images_dir_input).strip()
+    ):
+        msg = "Error: Training images directory is missing... can't perform the required task..."
+        log.info(msg)
+        return msg
 
-    if not util_regularization_images_dir_input == "":
-        # Create the regularization_dir path
-        if not util_regularization_images_repeat_input > 0:
+    util_training_images_dir_input = str(util_training_images_dir_input).strip()
+
+    try:
+        train_repeats = int(util_training_images_repeat_input)
+    except (TypeError, ValueError):
+        msg = f"Error: Invalid training images repeats value: {util_training_images_repeat_input!r}"
+        log.error(msg)
+        return msg
+
+    training_dir = os.path.join(
+        util_training_dir_output,
+        f"img/{train_repeats}_{instance_prompt} {class_prompt}",
+    )
+
+    # Optional regularization — resolve target early for preflight validation
+    do_reg = bool(
+        util_regularization_images_dir_input
+        and str(util_regularization_images_dir_input).strip()
+    )
+    regularization_dir = None
+    reg_src = None
+    reg_repeats = 0
+    if do_reg:
+        reg_src = str(util_regularization_images_dir_input).strip()
+        try:
+            reg_repeats = int(util_regularization_images_repeat_input)
+        except (TypeError, ValueError):
+            reg_repeats = 0
+        if reg_repeats <= 0:
             log.info("Repeats is missing... not copying regularisation images...")
+            do_reg = False
         else:
             regularization_dir = os.path.join(
                 util_training_dir_output,
-                f"reg/{int(util_regularization_images_repeat_input)}_{util_class_prompt_input}",
+                f"reg/{reg_repeats}_{class_prompt}",
             )
 
-            # Remove folders if they exist
-            if os.path.exists(regularization_dir):
-                log.info(f"Removing existing directory {regularization_dir}...")
-                shutil.rmtree(regularization_dir)
-
-            # Copy the regularisation images to their respective directories
-            log.info(
-                f"Copy {util_regularization_images_dir_input} to {regularization_dir}..."
-            )
-            shutil.copytree(util_regularization_images_dir_input, regularization_dir)
-    else:
-        log.info(
-            "Regularization images directory is missing... not copying regularisation images..."
-        )
-
-    # create log and model folder
-    # Check if the log folder exists and create it if it doesn't
-    if not os.path.exists(os.path.join(util_training_dir_output, "log")):
-        os.makedirs(os.path.join(util_training_dir_output, "log"))
-
-    # Check if the model folder exists and create it if it doesn't
-    if not os.path.exists(os.path.join(util_training_dir_output, "model")):
-        os.makedirs(os.path.join(util_training_dir_output, "model"))
-
-    log.info(
-        f"Done creating kohya_ss training folder structure at {util_training_dir_output}..."
+    # --- Preflight: validate before any mutation ---
+    err = _validate_copy_pair(
+        util_training_images_dir_input, training_dir, "Training images"
     )
+    if err:
+        log.error(err)
+        return err
+
+    if do_reg and regularization_dir is not None:
+        err = _validate_copy_pair(reg_src, regularization_dir, "Regularisation images")
+        if err:
+            log.error(err)
+            return err
+
+    # Create destination root only after validation
+    os.makedirs(util_training_dir_output, exist_ok=True)
+
+    try:
+        log.info(f"Copy {util_training_images_dir_input} to {training_dir}...")
+        _safe_copytree_replace(util_training_images_dir_input, training_dir)
+
+        if do_reg and regularization_dir is not None:
+            log.info(f"Copy {reg_src} to {regularization_dir}...")
+            _safe_copytree_replace(reg_src, regularization_dir)
+        elif not (
+            util_regularization_images_dir_input
+            and str(util_regularization_images_dir_input).strip()
+        ):
+            log.info(
+                "Regularization images directory is missing... not copying regularisation images..."
+            )
+
+        # log and model folders
+        os.makedirs(os.path.join(util_training_dir_output, "log"), exist_ok=True)
+        os.makedirs(os.path.join(util_training_dir_output, "model"), exist_ok=True)
+
+    except Exception as exc:
+        msg = f"Error: folder preparation failed: {exc}"
+        log.error(msg)
+        return msg
+
+    msg = f"Done creating kohya_ss training folder structure at {util_training_dir_output}..."
+    log.info(msg)
+    return msg
 
 
 def gradio_dreambooth_folder_creation_tab(
@@ -178,12 +327,20 @@ def gradio_dreambooth_folder_creation_tab(
             )
             util_training_images_repeat_input = gr.Number(
                 label="Repeats",
-                value=config.get(key="dataset_preparation.util_training_images_repeat_input", default=40),
+                value=config.get(
+                    key="dataset_preparation.util_training_images_repeat_input",
+                    default=40,
+                ),
                 interactive=True,
                 elem_id="number_input",
             )
             util_training_images_dir_input.change(
-                fn=lambda path: gr.Dropdown(choices=[config.get(key="dataset_preparation.images_folder", default="")] + list_train_data_dirs(path)),
+                fn=lambda path: gr.Dropdown(
+                    choices=[
+                        config.get(key="dataset_preparation.images_folder", default="")
+                    ]
+                    + list_train_data_dirs(path)
+                ),
                 inputs=util_training_images_dir_input,
                 outputs=util_training_images_dir_input,
                 show_progress=False,
@@ -229,7 +386,7 @@ def gradio_dreambooth_folder_creation_tab(
                 label="Repeats",
                 value=config.get(
                     key="dataset_preparation.util_regularization_images_repeat_input",
-                    default=1
+                    default=1,
                 ),
                 interactive=True,
                 elem_id="number_input",
@@ -272,13 +429,20 @@ def gradio_dreambooth_folder_creation_tab(
             )
             util_training_dir_output.change(
                 fn=lambda path: gr.Dropdown(
-                    choices=[config.get(key="train_data_dir", default="")] + list_train_output_dirs(path)
+                    choices=[config.get(key="train_data_dir", default="")]
+                    + list_train_output_dirs(path)
                 ),
                 inputs=util_training_dir_output,
                 outputs=util_training_dir_output,
                 show_progress=False,
             )
         button_prepare_training_data = gr.Button("Prepare training data")
+        prepare_status = gr.Textbox(
+            label="Preparation status",
+            interactive=False,
+            lines=3,
+            placeholder="Status messages appear here after you run Prepare training data.",
+        )
         button_prepare_training_data.click(
             dreambooth_folder_preparation,
             inputs=[
@@ -290,11 +454,11 @@ def gradio_dreambooth_folder_creation_tab(
                 util_class_prompt_input,
                 util_training_dir_output,
             ],
-            show_progress=False,
+            outputs=prepare_status,
+            show_progress=True,
         )
-        
-        
-        button_copy_info_to_Folders_tab = gr.Button('Copy info to respective fields')
+
+        button_copy_info_to_Folders_tab = gr.Button("Copy info to respective fields")
         button_copy_info_to_Folders_tab.click(
             copy_info_to_Folders_tab,
             inputs=[util_training_dir_output],

--- a/tests/test_dreambooth_folder_creation_gui.py
+++ b/tests/test_dreambooth_folder_creation_gui.py
@@ -1,0 +1,268 @@
+"""Regression tests for GH issue #3436: Dataset Preparation must not destroy
+source images (same-path rmtree, nested copytree, missing source).
+
+Covers dreambooth_folder_preparation path validation and safe copy/replace.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from kohya_gui.dreambooth_folder_creation_gui import dreambooth_folder_preparation
+
+
+def _write_image(folder: Path, name: str = "photo.png") -> Path:
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / name
+    path.write_bytes(b"fake-image")
+    return path
+
+
+class TestDreamboothFolderPreparation(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="kohya_prep_test_"))
+        self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
+
+    def test_happy_path_copies_without_removing_source(self):
+        src = self.root / "raw_images"
+        dest = self.root / "training"
+        _write_image(src)
+        _write_image(src, "photo.txt")  # caption sibling
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            str(dest),
+        )
+
+        target = dest / "img" / "40_asd person"
+        self.assertTrue(os.path.isdir(target), msg=status)
+        self.assertTrue((target / "photo.png").is_file())
+        self.assertTrue((src / "photo.png").is_file(), "source must remain")
+        self.assertTrue((dest / "log").is_dir())
+        self.assertTrue((dest / "model").is_dir())
+        self.assertIn("Done", status)
+
+    def test_same_path_refuses_and_deletes_nothing(self):
+        dest = self.root / "training"
+        # Already-prepared layout matching computed target
+        src = dest / "img" / "40_asd person"
+        img = _write_image(src)
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertTrue(img.is_file(), "source must not be deleted")
+        self.assertTrue(
+            any(k in status.lower() for k in ("same", "refus", "error", "identical")),
+            msg=status,
+        )
+
+    def test_nested_dest_under_source_refuses(self):
+        # #1761 layout: source=.../img, dest=parent → target under source
+        dest = self.root / "kohya_input"
+        src = dest / "img"
+        img = _write_image(src)
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertTrue(img.is_file())
+        # Must not create nested bomb under src
+        nested = list(src.rglob("40_asd person"))
+        self.assertEqual(nested, [], msg=f"unexpected nested dirs: {nested}; {status}")
+        self.assertTrue(
+            any(
+                k in status.lower()
+                for k in ("nested", "inside", "under", "refus", "error")
+            ),
+            msg=status,
+        )
+
+    def test_source_under_dest_refuses(self):
+        # Source lives inside the computed target folder
+        dest = self.root / "training"
+        target = dest / "img" / "40_asd person"
+        src = target / "nested_source"
+        img = _write_image(src)
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertTrue(img.is_file(), "source under dest must not be deleted")
+        self.assertTrue(
+            any(k in status.lower() for k in ("inside", "under", "refus", "error")),
+            msg=status,
+        )
+
+    def test_regularization_happy_path_copies(self):
+        src = self.root / "raw_images"
+        reg_src = self.root / "raw_reg"
+        dest = self.root / "training"
+        _write_image(src)
+        _write_image(reg_src, "reg.png")
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            str(reg_src),
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertTrue(
+            (dest / "img" / "40_asd person" / "photo.png").is_file(), msg=status
+        )
+        self.assertTrue((dest / "reg" / "1_person" / "reg.png").is_file(), msg=status)
+        self.assertTrue((reg_src / "reg.png").is_file(), "reg source must remain")
+        self.assertIn("Done", status)
+
+    def test_missing_source_refuses_before_mutation(self):
+        dest = self.root / "training"
+        dest.mkdir()
+        missing = self.root / "does_not_exist"
+
+        status = dreambooth_folder_preparation(
+            str(missing),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertFalse(
+            (dest / "img").exists()
+            or any((dest / "img").glob("*") if (dest / "img").exists() else [])
+        )
+        # log/model may still be created on partial runs — only require no img copy
+        target = dest / "img" / "40_asd person"
+        self.assertFalse(target.exists())
+        self.assertTrue(
+            any(
+                k in status.lower()
+                for k in ("missing", "not found", "does not exist", "error")
+            ),
+            msg=status,
+        )
+
+    def test_destination_already_exists_safe_replace(self):
+        src = self.root / "raw_images"
+        dest = self.root / "training"
+        _write_image(src, "new.png")
+        old_target = dest / "img" / "40_asd person"
+        _write_image(old_target, "old.png")
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertTrue((old_target / "new.png").is_file(), msg=status)
+        self.assertFalse((old_target / "old.png").exists())
+        self.assertTrue((src / "new.png").is_file())
+        self.assertIn("Done", status)
+
+    def test_regularization_same_path_refuses(self):
+        src = self.root / "raw_images"
+        dest = self.root / "training"
+        _write_image(src)
+        reg_src = dest / "reg" / "1_person"
+        reg_img = _write_image(reg_src)
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            str(reg_src),
+            1,
+            "person",
+            str(dest),
+        )
+
+        self.assertTrue(reg_img.is_file(), "reg source must not be deleted")
+        self.assertTrue(
+            any(
+                k in status.lower()
+                for k in ("same", "refus", "error", "identical", "regular")
+            ),
+            msg=status,
+        )
+
+    def test_missing_destination_returns_status(self):
+        src = self.root / "raw_images"
+        _write_image(src)
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd",
+            "",
+            1,
+            "person",
+            "",
+        )
+
+        self.assertTrue(status)
+        self.assertTrue(
+            any(k in status.lower() for k in ("destination", "missing", "error")),
+            msg=status,
+        )
+
+    def test_strips_prompt_whitespace(self):
+        src = self.root / "raw_images"
+        dest = self.root / "training"
+        _write_image(src)
+
+        status = dreambooth_folder_preparation(
+            str(src),
+            40,
+            "asd\n",
+            "",
+            1,
+            " person ",
+            str(dest),
+        )
+
+        target = dest / "img" / "40_asd person"
+        self.assertTrue(target.is_dir(), msg=status)
+        self.assertTrue((target / "photo.png").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Dataset Preparation (`dreambooth_folder_preparation`) no longer does delete-then-copy. It validates paths first, refuses same-path and nested layouts, and stages a full copy before swapping the destination into place.
- Every run returns a status string wired to a Gradio **Preparation status** textbox so silent \"completed\" failures are visible.
- Covers historical data-loss reports (#872 same-path wipe, #1761 nested recursive copy).

## Root cause
`shutil.rmtree(training_dir)` ran before `shutil.copytree`. When source already was the prepared `img/<repeats>_…` folder (or dest nested under source), users lost their only copy or filled the disk.

## Test plan
- [x] `pytest tests/test_dreambooth_folder_creation_gui.py` (10 tests: happy, same-path, nested dest-under-src, source-under-dest, missing source, dest exists replace, reg happy, reg same-path, missing dest, prompt strip)
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (282 passed prior to final commit; re-run of focused suite green after review fixes)
- [ ] Manual: Dataset Preparation with source outside dest → status \"Done…\"; re-point source at prepared folder → refuse, images intact

Closes #3436