### PR TITLE
feat: surface training setup errors for missing output dir

### DIFF
--- a/kohya_gui/anima_lllite_gui.py
+++ b/kohya_gui/anima_lllite_gui.py
@@ -33,12 +33,12 @@ from .common_gui import (
     join_config_path,
     list_dirs,
     list_files,
-    output_message,
     print_command_and_toml,
     require_writable_directory,
     run_cmd_advanced_training,
     scriptdir,
     setup_environment,
+    try_save_training_config,
     update_my_data,
     validate_args_setting,
     write_toml_config,
@@ -758,16 +758,7 @@ def train_model(
 
         log.info(f"Saving training config to {file_path}...")
 
-        try:
-            SaveConfigFile(
-                parameters=parameters,
-                file_path=file_path,
-                exclusion=["file_path", "save_as", "headless", "print_only"],
-            )
-        except OSError as exc:
-            msg = f"Failed to write training config {file_path}: {exc}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
+        if not try_save_training_config(parameters, file_path, headless=headless):
             return TRAIN_BUTTON_VISIBLE
 
         env = setup_environment()

--- a/kohya_gui/anima_lllite_gui.py
+++ b/kohya_gui/anima_lllite_gui.py
@@ -30,14 +30,18 @@ from .common_gui import (
     get_file_path,
     get_folder_path,
     get_saveasfile_path,
+    join_config_path,
     list_dirs,
     list_files,
+    output_message,
     print_command_and_toml,
+    require_writable_directory,
     run_cmd_advanced_training,
     scriptdir,
     setup_environment,
     update_my_data,
     validate_args_setting,
+    write_toml_config,
     validate_file_path,
     validate_folder_path,
     validate_model_path,
@@ -545,9 +549,7 @@ def train_model(
     if not validate_file_path(network_weights):
         return TRAIN_BUTTON_VISIBLE
 
-    if not validate_folder_path(
-        output_dir, can_be_written_to=True, create_if_not_exists=True
-    ):
+    if not require_writable_directory(output_dir, headless=headless):
         return TRAIN_BUTTON_VISIBLE
 
     if not validate_folder_path(resume):
@@ -556,10 +558,6 @@ def train_model(
     #
     # End of path validation
     #
-
-    if output_dir != "":
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
 
     if not print_only and check_if_model_exist(
         output_name, output_dir, save_model_as, headless=headless
@@ -737,15 +735,12 @@ def train_model(
 
     current_datetime = datetime.now()
     formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-    tmpfilename = os.path.join(
+    tmpfilename = join_config_path(
         output_dir, f"config_anima_lllite-{formatted_datetime}.toml"
     )
 
-    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
-        toml.dump(config_toml_data, toml_file)
-
-        if not os.path.exists(toml_file.name):
-            log.error(f"Failed to write TOML file: {toml_file.name}")
+    if not write_toml_config(tmpfilename, config_toml_data, headless=headless):
+        return TRAIN_BUTTON_VISIBLE
 
     run_cmd.append("--config_file")
     run_cmd.append(rf"{tmpfilename}")
@@ -757,15 +752,23 @@ def train_model(
     else:
         current_datetime = datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+        file_path = join_config_path(
+            output_dir, f"{output_name}_{formatted_datetime}.json"
+        )
 
         log.info(f"Saving training config to {file_path}...")
 
-        SaveConfigFile(
-            parameters=parameters,
-            file_path=file_path,
-            exclusion=["file_path", "save_as", "headless", "print_only"],
-        )
+        try:
+            SaveConfigFile(
+                parameters=parameters,
+                file_path=file_path,
+                exclusion=["file_path", "save_as", "headless", "print_only"],
+            )
+        except OSError as exc:
+            msg = f"Failed to write training config {file_path}: {exc}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return TRAIN_BUTTON_VISIBLE
 
         env = setup_environment()
 

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1589,6 +1589,82 @@ def validate_folder_path(
     return True
 
 
+def require_writable_directory(
+    folder_path: str,
+    *,
+    label: str = "Output directory",
+    headless: bool = False,
+    create_if_not_exists: bool = True,
+) -> bool:
+    """Require a non-empty, writable directory; surface a user-facing message on failure.
+
+    Unlike :func:`validate_folder_path`, an empty path is rejected (required for
+    training output dirs). Creates the directory when missing if requested.
+    """
+    if folder_path is None or not str(folder_path).strip():
+        msg = f"{label} is required"
+        log.error(msg)
+        output_message(msg=msg, headless=headless)
+        return False
+
+    folder_path = str(folder_path).strip()
+    msg = f"Validating {folder_path} existence and writability..."
+    try:
+        if not os.path.isdir(folder_path):
+            if create_if_not_exists:
+                os.makedirs(folder_path)
+                log.info(f"{msg} SUCCESS (created)")
+                return True
+            fail = f"{label} does not exist: {folder_path}"
+            log.error(fail)
+            output_message(msg=fail, headless=headless)
+            return False
+        if not os.access(folder_path, os.W_OK):
+            fail = f"{label} is not writable: {folder_path}"
+            log.error(fail)
+            output_message(msg=fail, headless=headless)
+            return False
+    except OSError as exc:
+        fail = f"{label} is not usable ({folder_path}): {exc}"
+        log.error(fail)
+        output_message(msg=fail, headless=headless)
+        return False
+
+    log.info(f"{msg} SUCCESS")
+    return True
+
+
+def join_config_path(base_dir: str, filename: str) -> str:
+    """Join a config filename under ``base_dir``.
+
+    Raises ``ValueError`` if ``base_dir`` is empty/whitespace so callers never
+    build a root-absolute path like ``/config_….toml`` from an empty output dir.
+    """
+    if base_dir is None or not str(base_dir).strip():
+        raise ValueError("base directory must not be empty")
+    if not filename or not str(filename).strip():
+        raise ValueError("filename must not be empty")
+    return os.path.join(str(base_dir).strip(), str(filename).strip())
+
+
+def write_toml_config(path: str, data: dict, headless: bool = False) -> bool:
+    """Write ``data`` as TOML to ``path``. On OSError, log + user message; return False."""
+    try:
+        with open(path, "w", encoding="utf-8") as toml_file:
+            toml.dump(data, toml_file)
+        if not os.path.exists(path):
+            msg = f"Failed to write TOML file: {path}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return False
+        return True
+    except OSError as exc:
+        msg = f"Failed to write config file {path}: {exc}"
+        log.error(msg)
+        output_message(msg=msg, headless=headless)
+        return False
+
+
 def validate_toml_file(file_path: str) -> bool:
     if file_path == "":
         return True

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1465,6 +1465,29 @@ def SaveConfigFile(
         json.dump(variables, file, indent=2)
 
 
+def try_save_training_config(
+    parameters,
+    file_path: str,
+    *,
+    headless: bool = False,
+    exclusion: list = None,
+) -> bool:
+    """Save training JSON via :func:`SaveConfigFile`; surface OSError to the user.
+
+    Returns True on success, False after logging and messaging on write failure.
+    """
+    if exclusion is None:
+        exclusion = ["file_path", "save_as", "headless", "print_only"]
+    try:
+        SaveConfigFile(parameters=parameters, file_path=file_path, exclusion=exclusion)
+        return True
+    except OSError as exc:
+        msg = f"Failed to write training config {file_path}: {exc}"
+        log.error(msg)
+        output_message(msg=msg, headless=headless)
+        return False
+
+
 def save_to_file(content):
     """
     Appends the given content to a file named 'print_command.txt' within a 'logs' directory.
@@ -1652,11 +1675,6 @@ def write_toml_config(path: str, data: dict, headless: bool = False) -> bool:
     try:
         with open(path, "w", encoding="utf-8") as toml_file:
             toml.dump(data, toml_file)
-        if not os.path.exists(path):
-            msg = f"Failed to write TOML file: {path}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
-            return False
         return True
     except OSError as exc:
         msg = f"Failed to write config file {path}: {exc}"

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -13,7 +13,6 @@ from .common_gui import (
     get_file_path,
     get_saveasfile_path,
     join_config_path,
-    output_message,
     print_command_and_toml,
     require_writable_directory,
     resolve_lr_warmup_steps,
@@ -21,6 +20,7 @@ from .common_gui import (
     SaveConfigFile,
     scriptdir,
     train_inpainting_changed,
+    try_save_training_config,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -1183,16 +1183,7 @@ def train_model(
 
         log.info(f"Saving training config to {file_path}...")
 
-        try:
-            SaveConfigFile(
-                parameters=parameters,
-                file_path=file_path,
-                exclusion=["file_path", "save_as", "headless", "print_only"],
-            )
-        except OSError as exc:
-            msg = f"Failed to write training config {file_path}: {exc}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
+        if not try_save_training_config(parameters, file_path, headless=headless):
             return TRAIN_BUTTON_VISIBLE
 
         # log.info(run_cmd)

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -12,7 +12,10 @@ from .common_gui import (
     get_executable_path,
     get_file_path,
     get_saveasfile_path,
+    join_config_path,
+    output_message,
     print_command_and_toml,
+    require_writable_directory,
     resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
@@ -24,6 +27,7 @@ from .common_gui import (
     validate_model_path,
     validate_args_setting,
     setup_environment,
+    write_toml_config,
 )
 from .class_accelerate_launch import AccelerateLaunch
 from .class_configuration_file import ConfigurationFile
@@ -715,9 +719,7 @@ def train_model(
     ):
         return TRAIN_BUTTON_VISIBLE
 
-    if not validate_folder_path(
-        output_dir, can_be_written_to=True, create_if_not_exists=True
-    ):
+    if not require_writable_directory(output_dir, headless=headless):
         return TRAIN_BUTTON_VISIBLE
 
     if not validate_model_path(pretrained_model_name_or_path):
@@ -1151,14 +1153,12 @@ def train_model(
 
     current_datetime = datetime.now()
     formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-    tmpfilename = rf"{output_dir}/config_dreambooth-{formatted_datetime}.toml"
+    tmpfilename = join_config_path(
+        output_dir, f"config_dreambooth-{formatted_datetime}.toml"
+    )
 
-    # Save the updated TOML data back to the file
-    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
-        toml.dump(config_toml_data, toml_file)
-
-        if not os.path.exists(toml_file.name):
-            log.error(f"Failed to write TOML file: {toml_file.name}")
+    if not write_toml_config(tmpfilename, config_toml_data, headless=headless):
+        return TRAIN_BUTTON_VISIBLE
 
     run_cmd.append(f"--config_file")
     run_cmd.append(rf"{tmpfilename}")
@@ -1177,16 +1177,23 @@ def train_model(
         # Saving config file for model
         current_datetime = datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-        # config_dir = os.path.dirname(os.path.dirname(train_data_dir))
-        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+        file_path = join_config_path(
+            output_dir, f"{output_name}_{formatted_datetime}.json"
+        )
 
         log.info(f"Saving training config to {file_path}...")
 
-        SaveConfigFile(
-            parameters=parameters,
-            file_path=file_path,
-            exclusion=["file_path", "save_as", "headless", "print_only"],
-        )
+        try:
+            SaveConfigFile(
+                parameters=parameters,
+                file_path=file_path,
+                exclusion=["file_path", "save_as", "headless", "print_only"],
+            )
+        except OSError as exc:
+            msg = f"Failed to write training config {file_path}: {exc}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return TRAIN_BUTTON_VISIBLE
 
         # log.info(run_cmd)
 

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -14,7 +14,6 @@ from .common_gui import (
     get_file_path,
     get_saveasfile_path,
     join_config_path,
-    output_message,
     print_command_and_toml,
     require_writable_directory,
     resolve_lr_warmup_steps,
@@ -22,6 +21,7 @@ from .common_gui import (
     SaveConfigFile,
     scriptdir,
     train_inpainting_changed,
+    try_save_training_config,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -1479,16 +1479,7 @@ def train_model(
 
         log.info(f"Saving training config to {file_path}...")
 
-        try:
-            SaveConfigFile(
-                parameters=parameters,
-                file_path=file_path,
-                exclusion=["file_path", "save_as", "headless", "print_only"],
-            )
-        except OSError as exc:
-            msg = f"Failed to write training config {file_path}: {exc}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
+        if not try_save_training_config(parameters, file_path, headless=headless):
             return TRAIN_BUTTON_VISIBLE
 
         # log.info(run_cmd)

--- a/kohya_gui/finetune_gui.py
+++ b/kohya_gui/finetune_gui.py
@@ -13,7 +13,10 @@ from .common_gui import (
     get_executable_path,
     get_file_path,
     get_saveasfile_path,
+    join_config_path,
+    output_message,
     print_command_and_toml,
+    require_writable_directory,
     resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
@@ -25,6 +28,7 @@ from .common_gui import (
     validate_model_path,
     validate_args_setting,
     setup_environment,
+    write_toml_config,
 )
 from .class_accelerate_launch import AccelerateLaunch
 from .class_configuration_file import ConfigurationFile
@@ -883,9 +887,7 @@ def train_model(
     ):
         return TRAIN_BUTTON_VISIBLE
 
-    if not validate_folder_path(
-        output_dir, can_be_written_to=True, create_if_not_exists=True
-    ):
+    if not require_writable_directory(output_dir, headless=headless):
         return TRAIN_BUTTON_VISIBLE
 
     if not validate_model_path(pretrained_model_name_or_path):
@@ -1448,13 +1450,11 @@ def train_model(
 
     current_datetime = datetime.now()
     formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-    tmpfilename = rf"{output_dir}/config_finetune-{formatted_datetime}.toml"
-    # Save the updated TOML data back to the file
-    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
-        toml.dump(config_toml_data, toml_file)
-
-        if not os.path.exists(toml_file.name):
-            log.error(f"Failed to write TOML file: {toml_file.name}")
+    tmpfilename = join_config_path(
+        output_dir, f"config_finetune-{formatted_datetime}.toml"
+    )
+    if not write_toml_config(tmpfilename, config_toml_data, headless=headless):
+        return TRAIN_BUTTON_VISIBLE
 
     run_cmd.append("--config_file")
     run_cmd.append(rf"{tmpfilename}")
@@ -1473,16 +1473,23 @@ def train_model(
         # Saving config file for model
         current_datetime = datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-        # config_dir = os.path.dirname(os.path.dirname(train_data_dir))
-        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+        file_path = join_config_path(
+            output_dir, f"{output_name}_{formatted_datetime}.json"
+        )
 
         log.info(f"Saving training config to {file_path}...")
 
-        SaveConfigFile(
-            parameters=parameters,
-            file_path=file_path,
-            exclusion=["file_path", "save_as", "headless", "print_only"],
-        )
+        try:
+            SaveConfigFile(
+                parameters=parameters,
+                file_path=file_path,
+                exclusion=["file_path", "save_as", "headless", "print_only"],
+            )
+        except OSError as exc:
+            msg = f"Failed to write training config {file_path}: {exc}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return TRAIN_BUTTON_VISIBLE
 
         # log.info(run_cmd)
 

--- a/kohya_gui/leco_gui.py
+++ b/kohya_gui/leco_gui.py
@@ -12,9 +12,12 @@ from .common_gui import (
     get_folder_path,
     get_saveasfile_path,
     check_if_model_exist,
+    join_config_path,
     list_files,
     create_refresh_button,
+    output_message,
     print_command_and_toml,
+    require_writable_directory,
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
@@ -25,6 +28,7 @@ from .common_gui import (
     validate_toml_file,
     validate_args_setting,
     setup_environment,
+    write_toml_config,
 )
 from .class_source_model import default_models
 from .class_accelerate_launch import AccelerateLaunch
@@ -405,9 +409,7 @@ def train_model(
     if not validate_file_path(network_weights):
         return TRAIN_BUTTON_VISIBLE
 
-    if not validate_folder_path(
-        output_dir, can_be_written_to=True, create_if_not_exists=True
-    ):
+    if not require_writable_directory(output_dir, headless=headless):
         return TRAIN_BUTTON_VISIBLE
 
     if not validate_model_path(pretrained_model_name_or_path):
@@ -419,10 +421,6 @@ def train_model(
     #
     # End of path validation
     #
-
-    if output_dir != "":
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
 
     if not print_only and check_if_model_exist(
         output_name, output_dir, save_model_as, headless=headless
@@ -536,13 +534,10 @@ def train_model(
 
     current_datetime = datetime.now()
     formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-    tmpfilename = os.path.join(output_dir, f"config_leco-{formatted_datetime}.toml")
+    tmpfilename = join_config_path(output_dir, f"config_leco-{formatted_datetime}.toml")
 
-    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
-        toml.dump(config_toml_data, toml_file)
-
-        if not os.path.exists(toml_file.name):
-            log.error(f"Failed to write TOML file: {toml_file.name}")
+    if not write_toml_config(tmpfilename, config_toml_data, headless=headless):
+        return TRAIN_BUTTON_VISIBLE
 
     run_cmd.append("--config_file")
     run_cmd.append(rf"{tmpfilename}")
@@ -554,15 +549,23 @@ def train_model(
     else:
         current_datetime = datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+        file_path = join_config_path(
+            output_dir, f"{output_name}_{formatted_datetime}.json"
+        )
 
         log.info(f"Saving training config to {file_path}...")
 
-        SaveConfigFile(
-            parameters=parameters,
-            file_path=file_path,
-            exclusion=["file_path", "save_as", "headless", "print_only"],
-        )
+        try:
+            SaveConfigFile(
+                parameters=parameters,
+                file_path=file_path,
+                exclusion=["file_path", "save_as", "headless", "print_only"],
+            )
+        except OSError as exc:
+            msg = f"Failed to write training config {file_path}: {exc}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return TRAIN_BUTTON_VISIBLE
 
         env = setup_environment()
 

--- a/kohya_gui/leco_gui.py
+++ b/kohya_gui/leco_gui.py
@@ -15,12 +15,12 @@ from .common_gui import (
     join_config_path,
     list_files,
     create_refresh_button,
-    output_message,
     print_command_and_toml,
     require_writable_directory,
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
+    try_save_training_config,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -555,16 +555,7 @@ def train_model(
 
         log.info(f"Saving training config to {file_path}...")
 
-        try:
-            SaveConfigFile(
-                parameters=parameters,
-                file_path=file_path,
-                exclusion=["file_path", "save_as", "headless", "print_only"],
-            )
-        except OSError as exc:
-            msg = f"Failed to write training config {file_path}: {exc}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
+        if not try_save_training_config(parameters, file_path, headless=headless):
             return TRAIN_BUTTON_VISIBLE
 
         env = setup_environment()

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -22,6 +22,7 @@ from .common_gui import (
     SaveConfigFile,
     scriptdir,
     train_inpainting_changed,
+    try_save_training_config,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -1408,10 +1409,6 @@ def train_model(
         )
         return TRAIN_BUTTON_VISIBLE
 
-    if output_dir != "":
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-
     if stop_text_encoder_training > 0:
         output_message(
             msg='Output "stop text encoder training" is not yet supported. Ignoring',
@@ -2389,16 +2386,7 @@ def train_model(
 
         log.info(f"Saving training config to {file_path}...")
 
-        try:
-            SaveConfigFile(
-                parameters=parameters,
-                file_path=file_path,
-                exclusion=["file_path", "save_as", "headless", "print_only"],
-            )
-        except OSError as exc:
-            msg = f"Failed to write training config {file_path}: {exc}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
+        if not try_save_training_config(parameters, file_path, headless=headless):
             return TRAIN_BUTTON_VISIBLE
 
         # log.info(run_cmd)

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -13,8 +13,10 @@ from .common_gui import (
     get_executable_path,
     get_file_path,
     get_saveasfile_path,
+    join_config_path,
     output_message,
     print_command_and_toml,
+    require_writable_directory,
     resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
@@ -27,6 +29,7 @@ from .common_gui import (
     validate_toml_file,
     validate_args_setting,
     setup_environment,
+    write_toml_config,
 )
 from .class_accelerate_launch import AccelerateLaunch
 from .class_configuration_file import ConfigurationFile
@@ -1366,9 +1369,7 @@ def train_model(
     if not validate_file_path(network_weights):
         return TRAIN_BUTTON_VISIBLE
 
-    if not validate_folder_path(
-        output_dir, can_be_written_to=True, create_if_not_exists=True
-    ):
+    if not require_writable_directory(output_dir, headless=headless):
         return TRAIN_BUTTON_VISIBLE
 
     if not validate_model_path(pretrained_model_name_or_path):
@@ -2360,14 +2361,10 @@ def train_model(
 
     current_datetime = datetime.now()
     formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-    tmpfilename = rf"{output_dir}/config_lora-{formatted_datetime}.toml"
+    tmpfilename = join_config_path(output_dir, f"config_lora-{formatted_datetime}.toml")
 
-    # Save the updated TOML data back to the file
-    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
-        toml.dump(config_toml_data, toml_file)
-
-        if not os.path.exists(toml_file.name):
-            log.error(f"Failed to write TOML file: {toml_file.name}")
+    if not write_toml_config(tmpfilename, config_toml_data, headless=headless):
+        return TRAIN_BUTTON_VISIBLE
 
     run_cmd.append("--config_file")
     run_cmd.append(rf"{tmpfilename}")
@@ -2386,16 +2383,23 @@ def train_model(
         # Saving config file for model
         current_datetime = datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-        # config_dir = os.path.dirname(os.path.dirname(train_data_dir))
-        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+        file_path = join_config_path(
+            output_dir, f"{output_name}_{formatted_datetime}.json"
+        )
 
         log.info(f"Saving training config to {file_path}...")
 
-        SaveConfigFile(
-            parameters=parameters,
-            file_path=file_path,
-            exclusion=["file_path", "save_as", "headless", "print_only"],
-        )
+        try:
+            SaveConfigFile(
+                parameters=parameters,
+                file_path=file_path,
+                exclusion=["file_path", "save_as", "headless", "print_only"],
+            )
+        except OSError as exc:
+            msg = f"Failed to write training config {file_path}: {exc}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return TRAIN_BUTTON_VISIBLE
 
         # log.info(run_cmd)
         env = setup_environment()

--- a/kohya_gui/textual_inversion_gui.py
+++ b/kohya_gui/textual_inversion_gui.py
@@ -12,9 +12,11 @@ from .common_gui import (
     get_executable_path,
     get_file_path,
     get_saveasfile_path,
+    join_config_path,
     list_files,
     output_message,
     print_command_and_toml,
+    require_writable_directory,
     resolve_lr_warmup_steps,
     run_cmd_advanced_training,
     SaveConfigFile,
@@ -25,6 +27,7 @@ from .common_gui import (
     validate_model_path,
     validate_args_setting,
     setup_environment,
+    write_toml_config,
 )
 from .class_accelerate_launch import AccelerateLaunch
 from .class_configuration_file import ConfigurationFile
@@ -568,9 +571,7 @@ def train_model(
     ):
         return TRAIN_BUTTON_VISIBLE
 
-    if not validate_folder_path(
-        output_dir, can_be_written_to=True, create_if_not_exists=True
-    ):
+    if not require_writable_directory(output_dir, headless=headless):
         return TRAIN_BUTTON_VISIBLE
 
     if not validate_model_path(pretrained_model_name_or_path):
@@ -902,14 +903,12 @@ def train_model(
 
     current_datetime = datetime.now()
     formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-    tmpfilename = rf"{output_dir}/config_textual_inversion-{formatted_datetime}.toml"
+    tmpfilename = join_config_path(
+        output_dir, f"config_textual_inversion-{formatted_datetime}.toml"
+    )
 
-    # Save the updated TOML data back to the file
-    with open(tmpfilename, "w", encoding="utf-8") as toml_file:
-        toml.dump(config_toml_data, toml_file)
-
-        if not os.path.exists(toml_file.name):
-            log.error(f"Failed to write TOML file: {toml_file.name}")
+    if not write_toml_config(tmpfilename, config_toml_data, headless=headless):
+        return TRAIN_BUTTON_VISIBLE
 
     run_cmd.append("--config_file")
     run_cmd.append(rf"{tmpfilename}")
@@ -928,16 +927,23 @@ def train_model(
         # Saving config file for model
         current_datetime = datetime.now()
         formatted_datetime = current_datetime.strftime("%Y%m%d-%H%M%S")
-        # config_dir = os.path.dirname(os.path.dirname(train_data_dir))
-        file_path = os.path.join(output_dir, f"{output_name}_{formatted_datetime}.json")
+        file_path = join_config_path(
+            output_dir, f"{output_name}_{formatted_datetime}.json"
+        )
 
         log.info(f"Saving training config to {file_path}...")
 
-        SaveConfigFile(
-            parameters=parameters,
-            file_path=file_path,
-            exclusion=["file_path", "save_as", "headless", "print_only"],
-        )
+        try:
+            SaveConfigFile(
+                parameters=parameters,
+                file_path=file_path,
+                exclusion=["file_path", "save_as", "headless", "print_only"],
+            )
+        except OSError as exc:
+            msg = f"Failed to write training config {file_path}: {exc}"
+            log.error(msg)
+            output_message(msg=msg, headless=headless)
+            return TRAIN_BUTTON_VISIBLE
 
         env = setup_environment()
 

--- a/kohya_gui/textual_inversion_gui.py
+++ b/kohya_gui/textual_inversion_gui.py
@@ -21,6 +21,7 @@ from .common_gui import (
     run_cmd_advanced_training,
     SaveConfigFile,
     scriptdir,
+    try_save_training_config,
     update_my_data,
     validate_file_path,
     validate_folder_path,
@@ -933,16 +934,7 @@ def train_model(
 
         log.info(f"Saving training config to {file_path}...")
 
-        try:
-            SaveConfigFile(
-                parameters=parameters,
-                file_path=file_path,
-                exclusion=["file_path", "save_as", "headless", "print_only"],
-            )
-        except OSError as exc:
-            msg = f"Failed to write training config {file_path}: {exc}"
-            log.error(msg)
-            output_message(msg=msg, headless=headless)
+        if not try_save_training_config(parameters, file_path, headless=headless):
             return TRAIN_BUTTON_VISIBLE
 
         env = setup_environment()

--- a/tests/test_training_setup_errors.py
+++ b/tests/test_training_setup_errors.py
@@ -1,0 +1,183 @@
+"""GH #3134: surface clear errors for missing/unwritable output directory
+during training setup instead of uncaught PermissionError tracebacks.
+
+Covers shared helpers and train_model early-return behavior on empty output_dir
+and OSError during TOML write.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import common_gui, textual_inversion_gui
+from conftest import build_train_model_kwargs, mock_executor
+
+_TI_FIXTURE = "test/config/TI-AdamW8bit-toml.json"
+_TI_NUMERIC = (
+    "lr_warmup_steps",
+    "stop_text_encoder_training_pct",
+    "main_process_port",
+    "ip_noise_gamma",
+    "ip_noise_gamma_random_strength",
+    "huber_c",
+    "huber_scale",
+    "save_last_n_epochs",
+    "save_last_n_epochs_state",
+    "noise_offset_random_strength",
+    "max_train_epochs",
+)
+_TI_STRINGS = (
+    "log_with",
+    "log_config",
+    "lr_scheduler_type",
+    "huggingface_repo_id",
+    "huggingface_token",
+    "huggingface_repo_type",
+    "huggingface_repo_visibility",
+    "huggingface_path_in_repo",
+    "metadata_author",
+    "metadata_description",
+    "metadata_license",
+    "metadata_tags",
+    "metadata_title",
+    "dynamo_backend",
+    "dynamo_mode",
+    "extra_accelerate_launch_args",
+)
+
+
+class TestJoinConfigPath(unittest.TestCase):
+    def test_joins_under_base(self):
+        path = common_gui.join_config_path("/models/out", "config_lora-20250101.toml")
+        self.assertEqual(path, os.path.join("/models/out", "config_lora-20250101.toml"))
+
+    def test_empty_base_raises(self):
+        with self.assertRaises(ValueError):
+            common_gui.join_config_path("", "config_ti.toml")
+
+    def test_empty_base_does_not_produce_root_absolute(self):
+        # Regression: f"{''}/config_….toml" → "/config_….toml" on Unix
+        with self.assertRaises(ValueError):
+            common_gui.join_config_path("", "config_textual_inversion-x.toml")
+
+    def test_whitespace_base_raises(self):
+        with self.assertRaises(ValueError):
+            common_gui.join_config_path("   ", "config.toml")
+
+
+class TestRequireWritableDirectory(unittest.TestCase):
+    def test_empty_rejects_with_required_message(self):
+        with patch.object(common_gui, "output_message") as mock_msg:
+            ok = common_gui.require_writable_directory(
+                "", label="Output directory", headless=True
+            )
+        self.assertFalse(ok)
+        msg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+        self.assertIn("required", msg.lower())
+        self.assertIn("output", msg.lower())
+
+    def test_writable_dir_ok(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(common_gui, "output_message") as mock_msg:
+                ok = common_gui.require_writable_directory(tmp, headless=True)
+            self.assertTrue(ok)
+            mock_msg.assert_not_called()
+
+    def test_creates_missing_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "new_out")
+            self.assertFalse(os.path.isdir(target))
+            ok = common_gui.require_writable_directory(target, headless=True)
+            self.assertTrue(ok)
+            self.assertTrue(os.path.isdir(target))
+
+
+class TestWriteTomlConfig(unittest.TestCase):
+    def test_writes_successfully(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "cfg.toml")
+            ok = common_gui.write_toml_config(path, {"a": 1}, headless=True)
+            self.assertTrue(ok)
+            self.assertTrue(os.path.isfile(path))
+
+    def test_oserror_surfaces_message_and_returns_false(self):
+        with patch.object(common_gui, "output_message") as mock_msg:
+            with patch("builtins.open", side_effect=PermissionError("denied")):
+                ok = common_gui.write_toml_config(
+                    "/nope/config.toml", {"a": 1}, headless=True
+                )
+        self.assertFalse(ok)
+        mock_msg.assert_called()
+        msg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+        self.assertIn("config.toml", msg)
+        self.assertTrue(
+            any(k in msg.lower() for k in ("fail", "permission", "denied", "error")),
+            msg=msg,
+        )
+
+
+class TestTextualInversionEmptyOutputDir(unittest.TestCase):
+    def test_empty_output_dir_rejected_without_raising(self):
+        kwargs = build_train_model_kwargs(
+            textual_inversion_gui.train_model,
+            _TI_FIXTURE,
+            numeric_fixups=_TI_NUMERIC,
+            string_overrides=_TI_STRINGS,
+            overrides={
+                "output_dir": "",
+                "print_only": True,
+                "token_string": "sks",
+                "init_word": "person",
+            },
+        )
+        mock_executor(textual_inversion_gui)
+        with patch.object(
+            textual_inversion_gui, "get_executable_path", return_value="accelerate"
+        ):
+            with patch.object(textual_inversion_gui, "output_message") as mock_msg:
+                # require_writable_directory was imported into the TI module;
+                # it calls common_gui.output_message unless we patch the
+                # require helper's message channel via common_gui.
+                with patch.object(common_gui, "output_message", mock_msg):
+                    result = textual_inversion_gui.train_model(**kwargs)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 3)
+        mock_msg.assert_called()
+        msg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+        self.assertIn("required", msg.lower())
+
+    def test_toml_write_failure_returns_idle_without_raising(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            kwargs = build_train_model_kwargs(
+                textual_inversion_gui.train_model,
+                _TI_FIXTURE,
+                numeric_fixups=_TI_NUMERIC,
+                string_overrides=_TI_STRINGS,
+                overrides={
+                    "output_dir": tmp,
+                    "print_only": True,
+                    "token_string": "sks",
+                    "init_word": "person",
+                },
+            )
+            mock_executor(textual_inversion_gui)
+            with patch.object(
+                textual_inversion_gui,
+                "get_executable_path",
+                return_value="accelerate",
+            ):
+                with patch.object(
+                    textual_inversion_gui,
+                    "write_toml_config",
+                    return_value=False,
+                ):
+                    result = textual_inversion_gui.train_model(**kwargs)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(len(result), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Reject empty/unusable **output directory** before training setup with a clear user-facing message (`require_writable_directory`).
- Build per-run config paths with `os.path.join` via `join_config_path` so an empty output dir can never become a root-absolute path like `/config_textual_inversion-….toml` (the #3134 repro).
- Catch `OSError` when writing TOML/JSON training configs and surface a short message instead of an uncaught Gradio traceback.
- Applied consistently across TI, LoRA, DreamBooth, finetune, Anima ControlNet-LLLite, and LECO train entry points.

## Test plan

- [x] `pytest tests/test_training_setup_errors.py` (helpers + TI empty output_dir + write failure)
- [x] `pytest tests/` full suite (294 passed, 1 skipped)
- [ ] Manual: TI train with blank output dir → clear message, no `/config_…` write attempt
- [ ] Manual: unwritable output dir → permission/write failure message in UI

Closes #3134