### PR TITLE
feat: add Chroma model type to Flux LoRA training GUI

### DIFF
--- a/kohya_gui/class_flux1.py
+++ b/kohya_gui/class_flux1.py
@@ -34,6 +34,21 @@ class flux1Training:
             "Flux.1", open=True, visible=False, elem_classes=["flux1_background"]
         ) as flux1_accordion:
             with gr.Group():
+                # Chroma is network-training only (flux_train_network.py).
+                # Finetune/DreamBooth use flux_train.py without model_type.
+                with gr.Row(visible=not finetuning):
+                    self.model_type = gr.Dropdown(
+                        label="Base Model Type",
+                        choices=["flux", "chroma"],
+                        value=self.config.get("flux1.model_type", "flux"),
+                        info=(
+                            "flux: standard FLUX.1 (CLIP-L + T5 + AE). "
+                            "chroma: Chroma / FLUX.1-schnell based (no CLIP-L; "
+                            "guidance_scale=0.0 and apply_t5_attn_mask recommended)."
+                        ),
+                        interactive=True,
+                    )
+
                 with gr.Row():
                     self.ae = gr.Textbox(
                         label="VAE Path",
@@ -53,16 +68,21 @@ class flux1Training:
                         show_progress=False,
                     )
 
+                    # CLIP-L is required for flux, unused for chroma.
+                    # Finetune path always shows CLIP-L (no Chroma model_type there).
+                    _initial_model_type = self.config.get("flux1.model_type", "flux")
+                    _clip_l_visible = finetuning or _initial_model_type != "chroma"
                     self.clip_l = gr.Textbox(
                         label="CLIP-L Path",
                         placeholder="Path to CLIP-L model",
                         value=self.config.get("flux1.clip_l", ""),
                         interactive=True,
+                        visible=_clip_l_visible,
                     )
                     self.clip_l_button = gr.Button(
                         document_symbol,
                         elem_id="open_folder_small",
-                        visible=(not headless),
+                        visible=(not headless) and _clip_l_visible,
                         interactive=True,
                     )
                     self.clip_l_button.click(
@@ -338,3 +358,39 @@ class flux1Training:
                     inputs=[self.flux1_checkbox],
                     outputs=[flux1_accordion],
                 )
+
+                # Apply Chroma-safe defaults when the user switches to chroma;
+                # hide CLIP-L (not used). Switching back to flux only restores
+                # CLIP-L visibility — other fields stay as the user left them.
+                if not finetuning:
+
+                    def model_type_change(selected: str):
+                        is_chroma = selected == "chroma"
+                        clip_visible = not is_chroma
+                        if is_chroma:
+                            return (
+                                gr.Textbox(visible=clip_visible),
+                                gr.Button(visible=(not headless) and clip_visible),
+                                gr.Number(value=0.0),
+                                gr.Checkbox(value=True),
+                                gr.Dropdown(value="sigmoid"),
+                            )
+                        return (
+                            gr.Textbox(visible=clip_visible),
+                            gr.Button(visible=(not headless) and clip_visible),
+                            gr.Number(),
+                            gr.Checkbox(),
+                            gr.Dropdown(),
+                        )
+
+                    self.model_type.change(
+                        model_type_change,
+                        inputs=[self.model_type],
+                        outputs=[
+                            self.clip_l,
+                            self.clip_l_button,
+                            self.guidance_scale,
+                            self.apply_t5_attn_mask,
+                            self.timestep_sampling,
+                        ],
+                    )

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -289,6 +289,7 @@ def save_configuration(
     # Flux1
     flux1_cache_text_encoder_outputs,
     flux1_cache_text_encoder_outputs_to_disk,
+    model_type,
     ae,
     clip_l,
     t5xxl,
@@ -635,6 +636,7 @@ def open_configuration(
     # Flux1
     flux1_cache_text_encoder_outputs,
     flux1_cache_text_encoder_outputs_to_disk,
+    model_type,
     ae,
     clip_l,
     t5xxl,
@@ -1145,6 +1147,7 @@ def train_model(
     # Flux1
     flux1_cache_text_encoder_outputs,
     flux1_cache_text_encoder_outputs_to_disk,
+    model_type,
     ae,
     clip_l,
     t5xxl,
@@ -1913,12 +1916,15 @@ def train_model(
         text_encoder_lr_float == 0 and unet_lr_float != 0
     ) or hunyuan_image_checkbox
 
+    # Chroma (flux_train_network --model_type=chroma) does not use CLIP-L.
+    is_chroma = bool(flux1_checkbox) and str(model_type or "").lower() == "chroma"
+
     clip_l_value = None
     if sd3_checkbox:
         # print("Setting clip_l_value to sd3_clip_l")
         # print("sd3_clip_l: ", sd3_clip_l)
         clip_l_value = sd3_clip_l
-    elif flux1_checkbox:
+    elif flux1_checkbox and not is_chroma:
         clip_l_value = clip_l
 
     t5xxl_value = None
@@ -2173,6 +2179,9 @@ def train_model(
         # Flux.1 specific parameters
         # "cache_text_encoder_outputs": see previous assignment above for code
         # "cache_text_encoder_outputs_to_disk": see previous assignment above for code
+        # model_type: only emit for chroma so default flux stays byte-compatible
+        # with pre-change configs (sd-scripts defaults to flux when omitted).
+        "model_type": "chroma" if is_chroma else None,
         "ae": (lumina_ae if lumina_checkbox else ae if flux1_checkbox else None),
         # "clip_l": see previous assignment above for code
         "t5xxl": t5xxl_value,
@@ -2345,6 +2354,8 @@ def train_model(
 
     # Given dictionary `config_toml_data`
     # Remove all values = ""
+    # NOTE: `0.0 in [False]` is True in Python, so guidance_scale=0.0 is
+    # dropped here. Chroma re-injects it immediately below.
     config_toml_data = {
         key: value
         for key, value in config_toml_data.items()
@@ -2352,6 +2363,14 @@ def train_model(
     }
 
     config_toml_data["max_data_loader_n_workers"] = int(max_data_loader_n_workers)
+
+    # Chroma backend contract (flux_train_network.py):
+    # - apply_t5_attn_mask is hard-required (assert)
+    # - guidance_scale=0.0 is required by docs; the filter above drops 0.0
+    #   because 0.0 == False in Python, so re-emit explicitly
+    if is_chroma:
+        config_toml_data["apply_t5_attn_mask"] = True
+        config_toml_data["guidance_scale"] = float(guidance_scale)
 
     # Sort the dictionary by keys
     config_toml_data = dict(sorted(config_toml_data.items()))
@@ -3658,6 +3677,7 @@ def lora_tab(
                 "flux1_cache_text_encoder_outputs_to_disk",
                 flux1_training.flux1_cache_text_encoder_outputs_to_disk,
             ),
+            ("model_type", flux1_training.model_type),
             ("ae", flux1_training.ae),
             ("clip_l", flux1_training.clip_l),
             ("t5xxl", flux1_training.t5xxl),

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -92,6 +92,7 @@ STRING_OVERRIDES = (
     "dynamo_mode",
     "extra_accelerate_launch_args",
     "network_weights",
+    "model_type",
     "model_prediction_type",
     "timestep_sampling",
     "train_blocks",
@@ -222,6 +223,123 @@ class TestLoraTrainInpainting(unittest.TestCase):
         self.assertTrue(config.get("train_inpainting"))
         self.assertFalse(config.get("cache_latents"))
         self.assertFalse(config.get("cache_latents_to_disk"))
+
+
+class TestChromaModelType(unittest.TestCase):
+    """GH issue #3227: expose sd-scripts Chroma LoRA training via model_type.
+
+    flux_train_network.py accepts --model_type {flux,chroma}. Chroma does not
+    use CLIP-L, requires guidance_scale=0.0 and apply_t5_attn_mask, and keeps
+    AE/T5XXL the same as Flux.
+    """
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides=overrides,
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_flux_default_omits_model_type_and_keeps_clip_l(self):
+        # Existing Flux users who never touch the new control must stay
+        # byte-compatible: no required model_type, clip_l still forwarded.
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "clip_l": "/models/clip_l.safetensors",
+                "ae": "/models/ae.safetensors",
+                "t5xxl": "/models/t5xxl.safetensors",
+                "model_type": "flux",
+            }
+        )
+        self.assertNotIn("model_type", config)
+        self.assertEqual(config.get("clip_l"), "/models/clip_l.safetensors")
+
+    def test_empty_model_type_treated_as_flux(self):
+        # Fixture/legacy configs without the field default to "" — same as flux.
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "clip_l": "/models/clip_l.safetensors",
+                "model_type": "",
+            }
+        )
+        self.assertNotIn("model_type", config)
+        self.assertEqual(config.get("clip_l"), "/models/clip_l.safetensors")
+
+    def test_chroma_emits_model_type_and_omits_clip_l(self):
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "model_type": "chroma",
+                "clip_l": "/models/clip_l.safetensors",
+                "ae": "/models/ae.safetensors",
+                "t5xxl": "/models/t5xxl.safetensors",
+                "guidance_scale": 0.0,
+                "apply_t5_attn_mask": True,
+                "timestep_sampling": "sigmoid",
+            }
+        )
+        self.assertEqual(config.get("model_type"), "chroma")
+        self.assertNotIn("clip_l", config)
+        self.assertEqual(config.get("ae"), "/models/ae.safetensors")
+        self.assertEqual(config.get("t5xxl"), "/models/t5xxl.safetensors")
+        self.assertEqual(config.get("guidance_scale"), 0.0)
+        self.assertTrue(config.get("apply_t5_attn_mask"))
+        self.assertEqual(config.get("timestep_sampling"), "sigmoid")
+
+    def test_chroma_does_not_require_clip_l_to_start(self):
+        # Empty CLIP-L must not block Chroma launch path in generated config.
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "model_type": "chroma",
+                "clip_l": "",
+                "ae": "/models/ae.safetensors",
+                "t5xxl": "/models/t5xxl.safetensors",
+            }
+        )
+        self.assertEqual(config.get("model_type"), "chroma")
+        self.assertNotIn("clip_l", config)
+
+    def test_chroma_forces_apply_t5_attn_mask(self):
+        # sd-scripts asserts apply_t5_attn_mask for chroma; the GUI must not
+        # emit a config that dies at trainer startup when the box is unchecked.
+        config = self._run_and_load_toml(
+            {
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "model_type": "chroma",
+                "apply_t5_attn_mask": False,
+                "guidance_scale": 0.0,
+            }
+        )
+        self.assertEqual(config.get("model_type"), "chroma")
+        self.assertTrue(config.get("apply_t5_attn_mask"))
+        self.assertEqual(config.get("guidance_scale"), 0.0)
+
+    def test_chroma_model_type_persisted_in_saved_json(self):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides={
+                "flux1_checkbox": True,
+                "LoRA_type": "Flux1",
+                "model_type": "chroma",
+                "clip_l": "",
+            },
+        )
+        config = run_train_model_and_load_saved_json(lora_gui, kwargs)
+        self.assertEqual(config.get("model_type"), "chroma")
 
 
 class TestLoraGuiFieldRegistry(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Expose sd-scripts Chroma LoRA training in the Flux.1 accordion via a **Base Model Type** selector (`flux` | `chroma`).
- When **chroma** is selected: emit `model_type=chroma`, omit `clip_l`, force `apply_t5_attn_mask` (sd-scripts hard assert), re-emit `guidance_scale` even when `0.0` (falsy-filter workaround), and apply UI defaults (guidance 0.0, T5 mask on, sigmoid sampling) on first switch.
- When **flux** (default): omit `model_type` so existing Flux configs stay byte-compatible; CLIP-L still required/forwarded as before.
- LoRA path only (`flux_train_network.py`). Finetune/DreamBooth hide the control (`finetuning=True`). No `sd-scripts/` edits.

## Test plan
- [x] `pytest tests/test_lora_gui.py::TestChromaModelType` — flux omit / chroma emit / empty clip_l / force T5 mask / JSON persist
- [x] `pytest tests/test_lora_gui.py::TestLoraGuiFieldRegistry` — `model_type` order matches train/save/open signatures
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` (322 passed, 1 skipped)
- [ ] Manual GUI smoke: enable Flux.1, switch Base Model Type to chroma, confirm CLIP-L hides and defaults apply; Print command shows `model_type = "chroma"` without `clip_l`

Closes #3227