### PR TITLE
fix: restore TE LR default so LoRA trains UNet+TE again (#3388)

### DIFF
--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -893,6 +893,50 @@ def get_effective_lr_messages(
     return messages
 
 
+# Stock LoRA defaults (v24-style): train both UNet and text encoder unless the
+# user deliberately zeros one side. See GH #3388 / #3430 — a TE LR default of 0
+# silently forced UNet-only training and produced safetensors with no TE keys.
+DEFAULT_TEXT_ENCODER_LR = 0.0001
+DEFAULT_UNET_LR = 0.0001
+
+TEXT_ENCODER_LR_INFO = (
+    "Optional. 0 = do not train text encoder (UNet-only; no TE keys in the "
+    "saved LoRA). Non-zero trains CLIP-L/T5XXL LoRA modules at this rate."
+)
+
+
+def resolve_network_train_flags(
+    text_encoder_lr: float,
+    unet_lr: float,
+    force_unet_only: bool = False,
+) -> tuple[bool, bool]:
+    """Map TE/UNet learning rates to sd-scripts train-mode flags.
+
+    Returns (network_train_unet_only, network_train_text_encoder_only).
+    When both flags are False, both UNet and text-encoder LoRA modules train.
+    """
+    if force_unet_only:
+        return True, False
+    network_train_text_encoder_only = text_encoder_lr != 0 and unet_lr == 0
+    network_train_unet_only = text_encoder_lr == 0 and unet_lr != 0
+    return network_train_unet_only, network_train_text_encoder_only
+
+
+def format_network_train_mode_message(
+    network_train_unet_only: bool,
+    network_train_text_encoder_only: bool,
+) -> str:
+    """User-visible train-mode summary for logs (and similar surfaces)."""
+    if network_train_unet_only:
+        return (
+            "Network train mode: UNet-only (text encoder not trained; "
+            "saved LoRA will have no TE keys)."
+        )
+    if network_train_text_encoder_only:
+        return "Network train mode: text-encoder-only (UNet not trained)."
+    return "Network train mode: UNet and text encoder (both LoRA modules trained)."
+
+
 def append_loraplus_network_args(
     network_args: str,
     loraplus_lr_ratio: float | None,
@@ -1907,14 +1951,19 @@ def train_model(
     ):
         output_message(msg="Please input learning rate values.", headless=headless)
         return TRAIN_BUTTON_VISIBLE
-    # Flag to train text encoder only if its learning rate is non-zero and unet's is zero.
-    network_train_text_encoder_only = (
-        text_encoder_lr_float != 0 and unet_lr_float == 0 and not hunyuan_image_checkbox
+    # HunyuanImage forces UNet-only; otherwise TE/UNet LRs select the mode.
+    network_train_unet_only, network_train_text_encoder_only = (
+        resolve_network_train_flags(
+            text_encoder_lr_float,
+            unet_lr_float,
+            force_unet_only=bool(hunyuan_image_checkbox),
+        )
     )
-    # Flag to train unet only if its learning rate is non-zero and text encoder's is zero.
-    network_train_unet_only = (
-        text_encoder_lr_float == 0 and unet_lr_float != 0
-    ) or hunyuan_image_checkbox
+    log.info(
+        format_network_train_mode_message(
+            network_train_unet_only, network_train_text_encoder_only
+        )
+    )
 
     # Chroma (flux_train_network --model_type=chroma) does not use CLIP-L.
     is_chroma = bool(flux1_checkbox) and str(model_type or "").lower() == "chroma"
@@ -2598,8 +2647,8 @@ def lora_tab(
                 with gr.Row():
                     text_encoder_lr = gr.Number(
                         label="Text Encoder learning rate",
-                        value=0,
-                        info="(Optional) Set CLIP-L and T5XXL learning rates.",
+                        value=DEFAULT_TEXT_ENCODER_LR,
+                        info=TEXT_ENCODER_LR_INFO,
                         minimum=0,
                         maximum=1,
                     )
@@ -2614,8 +2663,8 @@ def lora_tab(
 
                     unet_lr = gr.Number(
                         label="Unet learning rate",
-                        value=0.0001,
-                        info="(Optional)",
+                        value=DEFAULT_UNET_LR,
+                        info="(Optional) 0 = do not train UNet (text-encoder-only when TE LR is non-zero).",
                         minimum=0,
                         maximum=1,
                     )

--- a/tests/test_lora_gui.py
+++ b/tests/test_lora_gui.py
@@ -121,6 +121,104 @@ class TestAppendLoraplusNetworkArgs(unittest.TestCase):
         self.assertEqual(result, " loraplus_unet_lr_ratio=8.0")
 
 
+class TestResolveNetworkTrainFlags(unittest.TestCase):
+    """GH #3388 / #3430: LR values must map to train-mode flags predictably.
+
+    Stock defaults train both UNet and TE (v24-style). TE LR 0 + non-zero
+    Unet LR remains the intentional UNet-only escape hatch.
+    """
+
+    def test_default_lrs_train_both(self):
+        unet_only, te_only = lora_gui.resolve_network_train_flags(
+            lora_gui.DEFAULT_TEXT_ENCODER_LR, lora_gui.DEFAULT_UNET_LR
+        )
+        self.assertFalse(unet_only)
+        self.assertFalse(te_only)
+
+    def test_te_zero_unet_nonzero_is_unet_only(self):
+        unet_only, te_only = lora_gui.resolve_network_train_flags(0.0, 0.0001)
+        self.assertTrue(unet_only)
+        self.assertFalse(te_only)
+
+    def test_te_nonzero_unet_nonzero_trains_both(self):
+        unet_only, te_only = lora_gui.resolve_network_train_flags(0.0001, 0.0001)
+        self.assertFalse(unet_only)
+        self.assertFalse(te_only)
+
+    def test_te_nonzero_unet_zero_is_te_only(self):
+        unet_only, te_only = lora_gui.resolve_network_train_flags(0.0001, 0.0)
+        self.assertFalse(unet_only)
+        self.assertTrue(te_only)
+
+    def test_force_unet_only_overrides_te_lr(self):
+        unet_only, te_only = lora_gui.resolve_network_train_flags(
+            0.0001, 0.0001, force_unet_only=True
+        )
+        self.assertTrue(unet_only)
+        self.assertFalse(te_only)
+
+    def test_both_zero_trains_neither_flag(self):
+        # Main LR path trains both components when neither specific LR is set.
+        unet_only, te_only = lora_gui.resolve_network_train_flags(0.0, 0.0)
+        self.assertFalse(unet_only)
+        self.assertFalse(te_only)
+
+
+class TestFormatNetworkTrainModeMessage(unittest.TestCase):
+    """Train-time log must name the mode and warn about missing TE keys."""
+
+    def test_unet_only_mentions_missing_te_keys(self):
+        msg = lora_gui.format_network_train_mode_message(True, False)
+        self.assertIn("UNet-only", msg)
+        self.assertIn("no TE keys", msg)
+
+    def test_te_only_message(self):
+        msg = lora_gui.format_network_train_mode_message(False, True)
+        self.assertIn("text-encoder-only", msg)
+
+    def test_both_message(self):
+        msg = lora_gui.format_network_train_mode_message(False, False)
+        self.assertIn("UNet and text encoder", msg)
+
+
+class TestDefaultTextEncoderLr(unittest.TestCase):
+    """Fresh LoRA form must default TE LR so both sides train (not UNet-only)."""
+
+    def test_default_te_lr_matches_unet_and_is_nonzero(self):
+        self.assertEqual(lora_gui.DEFAULT_TEXT_ENCODER_LR, 0.0001)
+        self.assertEqual(lora_gui.DEFAULT_UNET_LR, 0.0001)
+        self.assertGreater(lora_gui.DEFAULT_TEXT_ENCODER_LR, 0.0)
+
+
+class TestNetworkTrainModeConfigOutput(unittest.TestCase):
+    """print_only train config reflects LR→flag mapping for #3388."""
+
+    def _run_and_load_toml(self, overrides):
+        kwargs = build_train_model_kwargs(
+            lora_gui.train_model,
+            FIXTURE,
+            numeric_fixups=NUMERIC_FIXUPS,
+            string_overrides=STRING_OVERRIDES,
+            overrides=overrides,
+        )
+        return run_train_model_and_load_toml(lora_gui, kwargs)
+
+    def test_both_lrs_nonzero_does_not_set_unet_only(self):
+        config = self._run_and_load_toml({"text_encoder_lr": 0.0001, "unet_lr": 0.0001})
+        self.assertFalse(config.get("network_train_unet_only", False))
+        self.assertFalse(config.get("network_train_text_encoder_only", False))
+
+    def test_te_zero_unet_nonzero_sets_unet_only(self):
+        config = self._run_and_load_toml({"text_encoder_lr": 0.0, "unet_lr": 0.0001})
+        self.assertTrue(config.get("network_train_unet_only"))
+        self.assertFalse(config.get("network_train_text_encoder_only", False))
+
+    def test_te_nonzero_unet_zero_sets_te_only(self):
+        config = self._run_and_load_toml({"text_encoder_lr": 0.0001, "unet_lr": 0.0})
+        self.assertFalse(config.get("network_train_unet_only", False))
+        self.assertTrue(config.get("network_train_text_encoder_only"))
+
+
 class TestTrainModelConfigOutput(unittest.TestCase):
     """End-to-end: train_model(print_only=True) writes a real TOML file we
     can inspect for the specific keys #3520 flagged.


### PR DESCRIPTION
## Summary

- Restores the LoRA tab **Text Encoder learning rate** default to `0.0001` (matching Unet LR / v24 behavior) so a fresh form trains **both** UNet and text-encoder LoRA modules instead of silently becoming UNet-only.
- Documents that TE LR `0` means UNet-only / no TE keys in the saved LoRA (field `info` text).
- Logs the effective network train mode at train start (UNet-only, TE-only, or both), including a clear UNet-only warning about missing TE keys.
- Extracts pure helpers `resolve_network_train_flags` / `format_network_train_mode_message` with unit + print-only config regression tests.

**Closes #3388.** Also co-fixes the same root cause as **#3430** (quality drop vs v24 when `text_encoder_lr` is 0).

## Why

In v25+, stock defaults were TE LR `0` + Unet LR `0.0001`, which set `network_train_unet_only` with no error. Saved safetensors then lacked TE keys and identity/detail learning regressed for users who expected v24-style both-side training.

UNet-only remains available: set Text Encoder LR to `0` deliberately (still recommended for some SDXL workflows).

## Test plan

- [x] `pytest tests/test_lora_gui.py` — 36 passed (includes new LR→flag mapping cases)
- [x] Full suite: `pytest tests/ test/test_allowed_paths.py` — 336 passed
- [ ] Manual: open LoRA tab with no config loaded → TE LR shows `0.0001`; start print-only train → log shows “UNet and text encoder”; set TE LR to `0` → log shows UNet-only / no TE keys; generated config has `network_train_unet_only = true`
