### PR TITLE
fix: quiet TensorFlow oneDNN noise on GUI startup

### DIFF
--- a/kohya_gui.py
+++ b/kohya_gui.py
@@ -3,6 +3,14 @@ import sys
 import argparse
 import subprocess
 import contextlib
+
+# Quiet TensorFlow C++ INFO noise (oneDNN notices) before any import that may
+# pull TF in transitively (e.g. transformers BLIP2 / WD14 Keras path).
+# setdefault keeps user/shell overrides. Matches setup_environment() for train
+# subprocesses (TF_ENABLE_ONEDNN_OPTS).
+os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
 import gradio as gr
 
 from kohya_gui.class_gui_config import KohyaSSGUIConfig
@@ -260,9 +268,10 @@ if __name__ == "__main__":
     # Set up logging based on the debug flag
     log = setup_logging(debug=args.debug)
 
-    # Verify requirements unless `noverify` flag is set
+    # Verify requirements unless `noverify` flag is set.
+    # gui-uv.* always passes --noverify (uv owns deps); log at info, not warning.
     if args.noverify:
-        log.warning("Skipping requirements verification.")
+        log.info("Skipping requirements verification.")
     else:
         # Run the validation command to verify requirements
         validation_command = [

--- a/kohya_gui/blip2_caption_gui.py
+++ b/kohya_gui/blip2_caption_gui.py
@@ -1,5 +1,4 @@
 from PIL import Image
-from transformers import Blip2Processor, Blip2ForConditionalGeneration
 import torch
 import gradio as gr
 import os
@@ -12,18 +11,21 @@ log = setup_logging()
 
 
 def load_model():
-    # Set the device to GPU if available, otherwise use CPU
-    if hasattr(torch, 'cuda') and torch.cuda.is_available():
-        device = 'cuda'
-    elif hasattr(torch, 'mps') and torch.mps.is_available():
-        device = 'mps'
-    else:
-        device = 'cpu'
+    # Lazy import: transformers' Blip2 stack pulls TensorFlow at import time
+    # (oneDNN INFO spam + slower GUI cold start). Only needed when captioning.
+    from transformers import Blip2Processor, Blip2ForConditionalGeneration
 
+    # Set the device to GPU if available, otherwise use CPU
+    if hasattr(torch, "cuda") and torch.cuda.is_available():
+        device = "cuda"
+    elif hasattr(torch, "mps") and torch.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
 
     # Initialize the BLIP2 processor
     processor = Blip2Processor.from_pretrained("Salesforce/blip2-opt-2.7b")
-    log.debug('Processor initialized: %s', processor)
+    log.debug("Processor initialized: %s", processor)
 
     # Initialize the BLIP2 model
     model = Blip2ForConditionalGeneration.from_pretrained(
@@ -327,7 +329,7 @@ def gradio_blip2_caption_gui_tab(headless=False, directory_path=None):
             with gr.Tab("Nucleus sampling"):
                 with gr.Row():
                     do_sample = gr.Checkbox(label="Sample", value=True)
-                    
+
                     temperature = gr.Slider(
                         minimum=0.5,
                         maximum=1.0,

--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1796,6 +1796,8 @@ def setup_environment():
         rf"{scriptdir}{os.pathsep}{scriptdir}/sd-scripts{os.pathsep}{env.get('PYTHONPATH', '')}"
     )
     env["TF_ENABLE_ONEDNN_OPTS"] = "0"
+    # Suppress TensorFlow C++ INFO (oneDNN notices) in training/caption subprocesses.
+    env.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
 
     if os.name == "nt":
         env["XFORMERS_FORCE_DISABLE_TRITON"] = "1"


### PR DESCRIPTION
## Summary
- Stop TensorFlow oneDNN INFO spam on GUI cold start by lazy-importing BLIP2 transformers classes (they were loaded via Utilities at import time).
- Set `TF_ENABLE_ONEDNN_OPTS=0` and `TF_CPP_MIN_LOG_LEVEL=2` early in `kohya_gui.py` (and in training subprocess env) so any remaining TF load stays quiet; `setdefault` preserves user overrides.
- Downgrade intentional `--noverify` skip (used by `gui-uv.*`) from WARNING to INFO.

## Test plan
- [x] Importing `kohya_gui.utilities` / full GUI module set no longer prints oneDNN lines; `tensorflow` not in `sys.modules` until BLIP2 is used
- [x] `log.info("Skipping requirements verification.")` for `--noverify`
- [x] `pytest tests/test_wd14_caption_gui.py tests/test_tensorboard_visibility.py` — 25 passed
- [ ] Manual: restart GUI via `gui-uv.bat` and confirm clean console

## Notes
Not a functional training change; only startup noise / import timing for BLIP2 captioning.