### PR TITLE
fix: preflight DreamBooth image-folder layout before train (GH #3374)

### DIFF
--- a/kohya_gui/common_gui.py
+++ b/kohya_gui/common_gui.py
@@ -1350,80 +1350,82 @@ def run_cmd_advanced_training(run_cmd: list = [], **kwargs):
     return run_cmd
 
 
-def verify_image_folder_pattern(folder_path: str) -> bool:
-    """
-    Verify the image folder pattern in the given folder path.
+# DreamBooth / LoRA / TI folder-mode concept dirs: <repeats>_<name>
+# Name may include letters, numbers, underscores, hyphens, and spaces
+# (see docs/image_folder_structure.md — e.g. "30_black mamba").
+_IMAGE_FOLDER_CONCEPT_PATTERN = re.compile(r"^\d+_.+$")
+_IMAGE_FOLDER_STRUCTURE_DOC = "docs/image_folder_structure.md"
 
-    Args:
-        folder_path (str): The path to the folder containing image folders.
+
+def verify_image_folder_pattern(
+    folder_path: str,
+    *,
+    headless: bool = False,
+    label: str = "Image folder",
+) -> bool:
+    """Verify DreamBooth-style ``N_name`` subfolders under ``folder_path``.
+
+    ``folder_path`` must be the **parent** of concept folders named
+    ``<repeats>_<name>`` (e.g. ``10_my_concept``), not the leaf folder that
+    contains the images. Empty ``folder_path`` is treated as "nothing to
+    check" (callers skip when a dataset TOML is used instead).
 
     Returns:
-        bool: True if the image folder pattern is valid, False otherwise.
+        True when the layout is valid (or path is empty); False otherwise.
+        On failure, logs and surfaces a user-facing message via
+        :func:`output_message`.
     """
-    # Initialize the return value to True
-    return_value = True
+    if folder_path is None or not str(folder_path).strip():
+        return True
 
-    # Log the start of the verification process
+    folder_path = str(folder_path).strip()
     log.info(f"Verifying image folder pattern of {folder_path}...")
 
-    # Check if the folder exists
+    parent_hint = (
+        f"{label} must be the parent of folders named <repeats>_<name> "
+        f"(e.g. 10_my_concept), not the folder that contains the images "
+        f"directly. See {_IMAGE_FOLDER_STRUCTURE_DOC}."
+    )
+
     if not os.path.isdir(folder_path):
-        # Log an error message if the folder does not exist
-        log.error(
-            f"...the provided path '{folder_path}' is not a valid folder. "
-            "Please follow the folder structure documentation found at docs\image_folder_structure.md ..."
+        msg = (
+            f"{label} preflight failed: '{folder_path}' is not a valid folder. "
+            f"{parent_hint}"
         )
-        # Return False to indicate that the folder pattern is not valid
+        log.error(msg)
+        output_message(msg=msg, headless=headless)
         return False
 
-    # Create a regular expression pattern to match the required sub-folder names
-    # The pattern should start with one or more digits (\d+) followed by an underscore (_)
-    # After the underscore, it should match one or more word characters (\w+), which can be letters, numbers, or underscores
-    # Example of a valid pattern matching name: 123_example_folder
-    pattern = r"^\d+_\w+"
-
-    # Get the list of sub-folders in the directory
     subfolders = [
-        os.path.join(folder_path, subfolder)
-        for subfolder in os.listdir(folder_path)
-        if os.path.isdir(os.path.join(folder_path, subfolder))
+        name
+        for name in os.listdir(folder_path)
+        if os.path.isdir(os.path.join(folder_path, name))
     ]
-
-    # Check the pattern of each sub-folder
-    matching_subfolders = [
-        subfolder
-        for subfolder in subfolders
-        if re.match(pattern, os.path.basename(subfolder))
+    matching = [
+        name for name in subfolders if _IMAGE_FOLDER_CONCEPT_PATTERN.match(name)
     ]
+    non_matching = [name for name in subfolders if name not in matching]
 
-    # Print non-matching sub-folders
-    non_matching_subfolders = set(subfolders) - set(matching_subfolders)
-    if non_matching_subfolders:
-        # Log an error message if any sub-folders do not match the pattern
-        log.error(
-            f"...the following folders do not match the required pattern <number>_<text>: {', '.join(non_matching_subfolders)}"
+    if not matching:
+        detail = (
+            f"Found subfolders that do not match <repeats>_<name>: "
+            f"{', '.join(non_matching)}. "
+            if non_matching
+            else "No concept subfolders found. "
         )
-        # Log an error message suggesting to follow the folder structure documentation
-        log.error(
-            f"...please follow the folder structure documentation found at docs\image_folder_structure.md ..."
-        )
-        # Return False to indicate that the folder pattern is not valid
+        msg = f"{label} preflight failed for '{folder_path}'. {detail}{parent_hint}"
+        log.error(msg)
+        output_message(msg=msg, headless=headless)
         return False
 
-    # Check if no sub-folders exist
-    if not matching_subfolders:
-        # Log an error message if no image folders are found
-        log.error(
-            f"...no image folders found in {folder_path}. "
-            "Please follow the folder structure documentation found at docs\image_folder_structure.md ..."
+    if non_matching:
+        log.warning(
+            f"...ignoring non-matching subfolders under {folder_path}: "
+            f"{', '.join(non_matching)}"
         )
-        # Return False to indicate that the folder pattern is not valid
-        return False
 
-    # Log the successful verification
-    log.info(f"...valid")
-    # Return True to indicate that the folder pattern is valid
-    return return_value
+    log.info(f"...valid ({len(matching)} concept folder(s))")
+    return True
 
 
 def SaveConfigFile(

--- a/kohya_gui/dreambooth_gui.py
+++ b/kohya_gui/dreambooth_gui.py
@@ -26,6 +26,7 @@ from .common_gui import (
     validate_folder_path,
     validate_model_path,
     validate_args_setting,
+    verify_image_folder_pattern,
     setup_environment,
     write_toml_config,
 )
@@ -736,6 +737,18 @@ def train_model(
 
     if not validate_model_path(vae):
         return TRAIN_BUTTON_VISIBLE
+
+    # DreamBooth-style layout: train_data_dir must be parent of N_name folders.
+    # Skip when a dataset TOML defines the layout instead (GH #3374).
+    if not dataset_config:
+        if not verify_image_folder_pattern(
+            train_data_dir, headless=headless, label="Image folder"
+        ):
+            return TRAIN_BUTTON_VISIBLE
+        if not verify_image_folder_pattern(
+            reg_data_dir, headless=headless, label="Regularisation folder"
+        ):
+            return TRAIN_BUTTON_VISIBLE
 
     #
     # End of path validation

--- a/kohya_gui/lora_gui.py
+++ b/kohya_gui/lora_gui.py
@@ -29,6 +29,7 @@ from .common_gui import (
     validate_model_path,
     validate_toml_file,
     validate_args_setting,
+    verify_image_folder_pattern,
     setup_environment,
     write_toml_config,
 )
@@ -1562,6 +1563,18 @@ def train_model(
 
     if not validate_model_path(vae):
         return TRAIN_BUTTON_VISIBLE
+
+    # DreamBooth-style layout: train_data_dir must be parent of N_name folders.
+    # Skip when a dataset TOML defines the layout instead (GH #3374).
+    if not dataset_config:
+        if not verify_image_folder_pattern(
+            train_data_dir, headless=headless, label="Image folder"
+        ):
+            return TRAIN_BUTTON_VISIBLE
+        if not verify_image_folder_pattern(
+            reg_data_dir, headless=headless, label="Regularisation folder"
+        ):
+            return TRAIN_BUTTON_VISIBLE
 
     #
     # End of path validation

--- a/kohya_gui/textual_inversion_gui.py
+++ b/kohya_gui/textual_inversion_gui.py
@@ -27,6 +27,7 @@ from .common_gui import (
     validate_folder_path,
     validate_model_path,
     validate_args_setting,
+    verify_image_folder_pattern,
     setup_environment,
     write_toml_config,
 )
@@ -589,6 +590,18 @@ def train_model(
 
     if not validate_model_path(vae):
         return TRAIN_BUTTON_VISIBLE
+
+    # DreamBooth-style layout: train_data_dir must be parent of N_name folders.
+    # Skip when a dataset TOML defines the layout instead (GH #3374).
+    if not dataset_config:
+        if not verify_image_folder_pattern(
+            train_data_dir, headless=headless, label="Image folder"
+        ):
+            return TRAIN_BUTTON_VISIBLE
+        if not verify_image_folder_pattern(
+            reg_data_dir, headless=headless, label="Regularisation folder"
+        ):
+            return TRAIN_BUTTON_VISIBLE
 
     #
     # End of path validation

--- a/tests/test_verify_image_folder_pattern.py
+++ b/tests/test_verify_image_folder_pattern.py
@@ -1,0 +1,290 @@
+"""GH #3374: DreamBooth/LoRA/TI image-folder preflight.
+
+``verify_image_folder_pattern`` must reject common path mistakes before
+sd-scripts starts and emits the opaque "No data found" error.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from kohya_gui import common_gui
+
+
+def _touch_image(folder: str, name: str = "img.jpg") -> None:
+    path = os.path.join(folder, name)
+    with open(path, "wb") as fh:
+        fh.write(b"\x00")
+
+
+class TestVerifyImageFolderPattern(unittest.TestCase):
+    def test_valid_layout_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            concept = os.path.join(tmp, "10_my_concept")
+            os.makedirs(concept)
+            _touch_image(concept)
+            with patch.object(common_gui, "output_message") as mock_msg:
+                ok = common_gui.verify_image_folder_pattern(tmp, headless=True)
+            self.assertTrue(ok)
+            mock_msg.assert_not_called()
+
+    def test_spaced_concept_name_accepted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            concept = os.path.join(tmp, "30_black mamba")
+            os.makedirs(concept)
+            _touch_image(concept)
+            self.assertTrue(common_gui.verify_image_folder_pattern(tmp, headless=True))
+
+    def test_leaf_folder_with_images_only_fails(self):
+        """User pointed Image folder at the N_name leaf instead of its parent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            leaf = os.path.join(tmp, "10_concept")
+            os.makedirs(leaf)
+            _touch_image(leaf)
+            with patch.object(common_gui, "output_message") as mock_msg:
+                ok = common_gui.verify_image_folder_pattern(leaf, headless=True)
+            self.assertFalse(ok)
+            msg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+            self.assertIn("parent", msg.lower())
+            self.assertIn("image_folder_structure", msg)
+
+    def test_non_matching_subfolder_name_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = os.path.join(tmp, "goth")
+            os.makedirs(bad)
+            _touch_image(bad)
+            with patch.object(common_gui, "output_message") as mock_msg:
+                ok = common_gui.verify_image_folder_pattern(tmp, headless=True)
+            self.assertFalse(ok)
+            msg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+            self.assertTrue(
+                any(s in msg for s in ("goth", "N_name", "repeats", "<number>")),
+                msg=msg,
+            )
+            self.assertIn("image_folder_structure", msg)
+
+    def test_empty_path_skipped(self):
+        with patch.object(common_gui, "output_message") as mock_msg:
+            ok = common_gui.verify_image_folder_pattern("", headless=True)
+        self.assertTrue(ok)
+        mock_msg.assert_not_called()
+
+    def test_missing_path_fails(self):
+        with patch.object(common_gui, "output_message") as mock_msg:
+            ok = common_gui.verify_image_folder_pattern(
+                os.path.join(tempfile.gettempdir(), "kohya_ss_no_such_dir_3374"),
+                headless=True,
+            )
+        self.assertFalse(ok)
+        mock_msg.assert_called()
+
+    def test_matching_plus_extra_subfolder_still_passes(self):
+        """At least one valid concept folder is enough; extras are warned only."""
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "10_concept"))
+            os.makedirs(os.path.join(tmp, "notes"))
+            self.assertTrue(common_gui.verify_image_folder_pattern(tmp, headless=True))
+
+
+class TestTrainModelImageFolderPreflight(unittest.TestCase):
+    """LoRA train_model aborts on bad layout and skips when dataset TOML is set."""
+
+    NUMERIC_FIXUPS = (
+        "max_train_steps",
+        "max_train_epochs",
+        "num_processes",
+        "num_machines",
+        "gradient_accumulation_steps",
+        "seed",
+        "vae_batch_size",
+        "save_every_n_steps",
+        "save_every_n_epochs",
+        "save_last_n_steps",
+        "save_last_n_steps_state",
+        "save_last_n_epochs",
+        "save_last_n_epochs_state",
+        "lr_scheduler_num_cycles",
+        "min_bucket_reso",
+        "max_bucket_reso",
+        "bucket_reso_steps",
+        "max_data_loader_n_workers",
+        "keep_tokens",
+        "clip_skip",
+        "max_token_length",
+        "caption_dropout_every_n_epochs",
+        "min_snr_gamma",
+        "min_timestep",
+        "max_timestep",
+        "sample_every_n_steps",
+        "sample_every_n_epochs",
+        "gpu_ids",
+        "main_process_port",
+        "num_cpu_threads_per_process",
+        "t5xxl_max_token_length",
+        "block_lr_zero_threshold",
+    )
+    STRING_OVERRIDES = (
+        "ae",
+        "clip_l",
+        "t5xxl",
+        "sd3_clip_l",
+        "sd3_t5xxl",
+        "t5xxl_device",
+        "t5xxl_dtype",
+        "huggingface_repo_id",
+        "huggingface_token",
+        "huggingface_repo_type",
+        "huggingface_repo_visibility",
+        "huggingface_path_in_repo",
+        "metadata_author",
+        "metadata_description",
+        "metadata_license",
+        "metadata_tags",
+        "metadata_title",
+        "log_with",
+        "log_config",
+        "loss_type",
+        "huber_schedule",
+        "lr_scheduler_type",
+        "dynamo_backend",
+        "dynamo_mode",
+        "extra_accelerate_launch_args",
+        "network_weights",
+        "model_type",
+        "model_prediction_type",
+        "timestep_sampling",
+        "train_blocks",
+        "weighting_scheme",
+        "in_dims",
+        "base_weights",
+        "base_weights_multiplier",
+        "LyCORIS_preset",
+        "network_args",
+        "dataset_config",
+        "log_tracker_config",
+        "resume",
+        "vae",
+        "reg_data_dir",
+    )
+
+    def _kwargs(self, overrides):
+        from conftest import build_train_model_kwargs
+        from kohya_gui import lora_gui
+
+        return build_train_model_kwargs(
+            lora_gui.train_model,
+            "test/config/locon-AdamW8bit-toml.json",
+            numeric_fixups=self.NUMERIC_FIXUPS,
+            string_overrides=self.STRING_OVERRIDES,
+            overrides=overrides,
+        )
+
+    def test_lora_rejects_leaf_folder_before_launch(self):
+        from conftest import mock_executor
+        from kohya_gui import lora_gui
+
+        with tempfile.TemporaryDirectory() as tmp:
+            leaf = os.path.join(tmp, "10_concept")
+            os.makedirs(leaf)
+            _touch_image(leaf)
+            out = os.path.join(tmp, "out")
+            os.makedirs(out)
+            # Pretend a pretrained model path exists so earlier path checks pass.
+            model = os.path.join(tmp, "model.safetensors")
+            with open(model, "wb") as fh:
+                fh.write(b"x")
+
+            kwargs = self._kwargs(
+                {
+                    "print_only": True,
+                    "train_data_dir": leaf,
+                    "dataset_config": "",
+                    "output_dir": out,
+                    "logging_dir": os.path.join(tmp, "log"),
+                    "pretrained_model_name_or_path": model,
+                    "reg_data_dir": "",
+                    "resume": "",
+                    "vae": "",
+                    "network_weights": "",
+                    "log_tracker_config": "",
+                    "LyCORIS_preset": "attn-mlp",
+                }
+            )
+            mock_executor(lora_gui)
+            with patch.object(
+                lora_gui, "get_executable_path", return_value="accelerate"
+            ):
+                with patch.object(lora_gui, "validate_model_path", return_value=True):
+                    with patch.object(common_gui, "output_message") as mock_msg:
+                        with patch.object(lora_gui, "output_message", mock_msg):
+                            result = lora_gui.train_model(**kwargs)
+
+            self.assertIsNotNone(result)
+            mock_msg.assert_called()
+            msg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+            self.assertIn("parent", msg.lower())
+
+    def test_lora_skips_preflight_when_dataset_config_set(self):
+        from conftest import mock_executor
+        from kohya_gui import lora_gui
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Deliberately invalid DreamBooth layout (flat images).
+            flat = os.path.join(tmp, "flat")
+            os.makedirs(flat)
+            _touch_image(flat)
+            out = os.path.join(tmp, "out")
+            os.makedirs(out)
+            model = os.path.join(tmp, "model.safetensors")
+            with open(model, "wb") as fh:
+                fh.write(b"x")
+            toml_path = os.path.join(tmp, "dataset.toml")
+            with open(toml_path, "w", encoding="utf-8") as fh:
+                fh.write("[general]\n")
+
+            kwargs = self._kwargs(
+                {
+                    "print_only": True,
+                    "train_data_dir": flat,
+                    "dataset_config": toml_path,
+                    "output_dir": out,
+                    "logging_dir": os.path.join(tmp, "log"),
+                    "pretrained_model_name_or_path": model,
+                    "reg_data_dir": "",
+                    "resume": "",
+                    "vae": "",
+                    "network_weights": "",
+                    "log_tracker_config": "",
+                    "LyCORIS_preset": "attn-mlp",
+                }
+            )
+            mock_executor(lora_gui)
+            with patch.object(
+                lora_gui, "get_executable_path", return_value="accelerate"
+            ):
+                with patch.object(lora_gui, "validate_model_path", return_value=True):
+                    with patch.object(
+                        lora_gui, "validate_file_path", return_value=True
+                    ):
+                        with patch.object(
+                            lora_gui, "validate_toml_file", return_value=True
+                        ):
+                            with patch.object(
+                                common_gui,
+                                "verify_image_folder_pattern",
+                            ) as mock_verify:
+                                with patch.object(
+                                    lora_gui, "write_toml_config", return_value=True
+                                ):
+                                    with patch.object(
+                                        lora_gui,
+                                        "print_command_and_toml",
+                                    ):
+                                        lora_gui.train_model(**kwargs)
+
+            mock_verify.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Run `verify_image_folder_pattern` on LoRA / DreamBooth / Textual Inversion train start when no dataset TOML is set, so wrong `train_data_dir` (and optional `reg_data_dir`) fails **before** sd-scripts with a clear parent-of-`N_name` message and a link to `docs/image_folder_structure.md`.
- Fix the concept-folder regex to accept spaced names documented as valid (e.g. `30_black mamba`).
- Add unit + LoRA integration tests for valid layout, leaf-folder mistake, non-matching names, spaced names, and dataset-config skip.

This addresses the long-running support cluster around `No data found… train_data_dir must be the parent of folders with images` (duplicates #3004, #3181, #2428).

## Test plan

- [x] `uv run black` on touched files
- [x] `PYTHONPATH=. uv run pytest tests/ test/test_allowed_paths.py` (357 passed)
- [ ] Manual smoke (optional): LoRA tab → point Image folder at leaf `10_concept` → expect preflight error; point at parent of `10_concept` → preflight passes

Closes #3374