### PR TITLE
fix: BLIP2 caption load + XPU device selection (#3367, #2992, #3037)

### DIFF
--- a/kohya_gui/blip2_caption_gui.py
+++ b/kohya_gui/blip2_caption_gui.py
@@ -9,27 +9,69 @@ from .custom_logging import setup_logging
 # Set up logging
 log = setup_logging()
 
+# Salesforce/blip2-opt-2.7b tip tokenizer JSON breaks TokenizerFast (ModelWrapper)
+# with transformers==4.54.1. Pin a known-good revision (#2992, #3037, #3367).
+BLIP2_MODEL_ID = "Salesforce/blip2-opt-2.7b"
+BLIP2_HF_REVISION = "51572668da0eb669e01a189dc22abe6088589a24"
+
+
+def get_caption_device(torch_module=None):
+    """Return preferred device string: cuda → xpu → mps → cpu.
+
+    Mirrors sd-scripts device preference without importing the submodule.
+    ``torch_module`` is injectable for unit tests (defaults to global torch).
+    """
+    t = torch if torch_module is None else torch_module
+    try:
+        if hasattr(t, "cuda") and t.cuda.is_available():
+            return "cuda"
+    except Exception:
+        pass
+    try:
+        if hasattr(t, "xpu") and t.xpu.is_available():
+            return "xpu"
+    except Exception:
+        pass
+    try:
+        if hasattr(t, "mps") and t.mps.is_available():
+            return "mps"
+    except Exception:
+        pass
+    return "cpu"
+
+
+def get_blip2_processor_load_kwargs():
+    """Kwargs for Blip2Processor.from_pretrained (revision + slow tokenizer)."""
+    return {
+        "revision": BLIP2_HF_REVISION,
+        "use_fast": False,
+    }
+
+
+def get_blip2_model_load_kwargs(torch_dtype=None):
+    """Kwargs for Blip2ForConditionalGeneration.from_pretrained."""
+    kwargs = {"revision": BLIP2_HF_REVISION}
+    if torch_dtype is not None:
+        kwargs["torch_dtype"] = torch_dtype
+    return kwargs
+
 
 def load_model():
     # Lazy import: transformers' Blip2 stack pulls TensorFlow at import time
     # (oneDNN INFO spam + slower GUI cold start). Only needed when captioning.
     from transformers import Blip2Processor, Blip2ForConditionalGeneration
 
-    # Set the device to GPU if available, otherwise use CPU
-    if hasattr(torch, "cuda") and torch.cuda.is_available():
-        device = "cuda"
-    elif hasattr(torch, "mps") and torch.mps.is_available():
-        device = "mps"
-    else:
-        device = "cpu"
+    device = get_caption_device()
 
-    # Initialize the BLIP2 processor
-    processor = Blip2Processor.from_pretrained("Salesforce/blip2-opt-2.7b")
+    # Initialize the BLIP2 processor (pinned revision; avoid fast-tokenizer ModelWrapper)
+    processor = Blip2Processor.from_pretrained(
+        BLIP2_MODEL_ID, **get_blip2_processor_load_kwargs()
+    )
     log.debug("Processor initialized: %s", processor)
 
     # Initialize the BLIP2 model
     model = Blip2ForConditionalGeneration.from_pretrained(
-        "Salesforce/blip2-opt-2.7b", torch_dtype=torch.float16
+        BLIP2_MODEL_ID, **get_blip2_model_load_kwargs(torch_dtype=torch.float16)
     )
 
     # Move the model to the specified device

--- a/tests/test_blip2_caption_gui.py
+++ b/tests/test_blip2_caption_gui.py
@@ -1,0 +1,131 @@
+"""BLIP2 caption GUI (#3367, #2992, #3037): device selection and HF load kwargs.
+
+Exercises shipped helpers in kohya_gui.blip2_caption_gui — no live HF download,
+no real XPU/CUDA hardware.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from kohya_gui import blip2_caption_gui
+
+
+def _mock_torch(*, cuda=False, xpu=False, mps=False):
+    """Minimal torch stand-in with controllable backend availability."""
+    t = SimpleNamespace()
+    t.cuda = SimpleNamespace(is_available=lambda: bool(cuda))
+    t.xpu = SimpleNamespace(is_available=lambda: bool(xpu))
+    t.mps = SimpleNamespace(is_available=lambda: bool(mps))
+    t.float16 = "float16-sentinel"
+    return t
+
+
+class TestGetCaptionDevice(unittest.TestCase):
+    def test_prefers_cuda_over_xpu_mps_cpu(self):
+        t = _mock_torch(cuda=True, xpu=True, mps=True)
+        self.assertEqual(blip2_caption_gui.get_caption_device(t), "cuda")
+
+    def test_prefers_xpu_when_no_cuda(self):
+        t = _mock_torch(cuda=False, xpu=True, mps=True)
+        self.assertEqual(blip2_caption_gui.get_caption_device(t), "xpu")
+
+    def test_prefers_mps_when_no_cuda_or_xpu(self):
+        t = _mock_torch(cuda=False, xpu=False, mps=True)
+        self.assertEqual(blip2_caption_gui.get_caption_device(t), "mps")
+
+    def test_falls_back_to_cpu(self):
+        t = _mock_torch(cuda=False, xpu=False, mps=False)
+        self.assertEqual(blip2_caption_gui.get_caption_device(t), "cpu")
+
+    def test_missing_xpu_attr_does_not_raise(self):
+        t = SimpleNamespace(
+            cuda=SimpleNamespace(is_available=lambda: False),
+            mps=SimpleNamespace(is_available=lambda: False),
+        )
+        self.assertEqual(blip2_caption_gui.get_caption_device(t), "cpu")
+
+    def test_xpu_is_available_raising_falls_through(self):
+        def _boom():
+            raise RuntimeError("xpu driver broken")
+
+        t = SimpleNamespace(
+            cuda=SimpleNamespace(is_available=lambda: False),
+            xpu=SimpleNamespace(is_available=_boom),
+            mps=SimpleNamespace(is_available=lambda: True),
+        )
+        self.assertEqual(blip2_caption_gui.get_caption_device(t), "mps")
+
+
+class TestBlip2LoadKwargs(unittest.TestCase):
+    def test_processor_kwargs_include_revision_and_use_fast_false(self):
+        kwargs = blip2_caption_gui.get_blip2_processor_load_kwargs()
+        self.assertEqual(kwargs["revision"], blip2_caption_gui.BLIP2_HF_REVISION)
+        self.assertIs(kwargs["use_fast"], False)
+        self.assertEqual(
+            blip2_caption_gui.BLIP2_HF_REVISION,
+            "51572668da0eb669e01a189dc22abe6088589a24",
+        )
+
+    def test_model_kwargs_include_revision_and_optional_dtype(self):
+        bare = blip2_caption_gui.get_blip2_model_load_kwargs()
+        self.assertEqual(bare["revision"], blip2_caption_gui.BLIP2_HF_REVISION)
+        self.assertNotIn("torch_dtype", bare)
+        self.assertNotIn("use_fast", bare)
+
+        with_dtype = blip2_caption_gui.get_blip2_model_load_kwargs(
+            torch_dtype="float16-sentinel"
+        )
+        self.assertEqual(with_dtype["revision"], blip2_caption_gui.BLIP2_HF_REVISION)
+        self.assertEqual(with_dtype["torch_dtype"], "float16-sentinel")
+
+    def test_model_id_constant(self):
+        self.assertEqual(blip2_caption_gui.BLIP2_MODEL_ID, "Salesforce/blip2-opt-2.7b")
+
+
+class TestLoadModelUsesShippedHelpers(unittest.TestCase):
+    """Drive load_model() with mocked transformers — asserts real call kwargs."""
+
+    def test_load_model_passes_revision_use_fast_and_moves_to_device(self):
+        mock_processor_cls = MagicMock()
+        mock_model_cls = MagicMock()
+        mock_processor = MagicMock(name="processor")
+        mock_model = MagicMock(name="model")
+        mock_processor_cls.from_pretrained.return_value = mock_processor
+        mock_model_cls.from_pretrained.return_value = mock_model
+
+        fake_transformers = SimpleNamespace(
+            Blip2Processor=mock_processor_cls,
+            Blip2ForConditionalGeneration=mock_model_cls,
+        )
+
+        with (
+            patch.dict("sys.modules", {"transformers": fake_transformers}),
+            patch.object(
+                blip2_caption_gui, "get_caption_device", return_value="xpu"
+            ) as mock_dev,
+            patch.object(blip2_caption_gui.torch, "float16", "float16-sentinel"),
+        ):
+            processor, model, device = blip2_caption_gui.load_model()
+
+        mock_dev.assert_called_once_with()
+        self.assertIs(processor, mock_processor)
+        self.assertIs(model, mock_model)
+        self.assertEqual(device, "xpu")
+
+        proc_args, proc_kwargs = mock_processor_cls.from_pretrained.call_args
+        self.assertEqual(proc_args[0], blip2_caption_gui.BLIP2_MODEL_ID)
+        self.assertEqual(proc_kwargs["revision"], blip2_caption_gui.BLIP2_HF_REVISION)
+        self.assertIs(proc_kwargs["use_fast"], False)
+
+        model_args, model_kwargs = mock_model_cls.from_pretrained.call_args
+        self.assertEqual(model_args[0], blip2_caption_gui.BLIP2_MODEL_ID)
+        self.assertEqual(model_kwargs["revision"], blip2_caption_gui.BLIP2_HF_REVISION)
+        self.assertEqual(model_kwargs["torch_dtype"], "float16-sentinel")
+        self.assertNotIn("use_fast", model_kwargs)
+
+        mock_model.to.assert_called_once_with("xpu")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix BLIP2 captioning crash (`ModelWrapper` / `TokenizerFast.from_file`) by pinning `Salesforce/blip2-opt-2.7b` to HF revision `51572668da0eb669e01a189dc22abe6088589a24` and loading the processor with `use_fast=False` (addresses #3367 BLIP2 path, #2992, #3037).
- Prefer caption device order **cuda → xpu → mps → cpu** so Intel Arc / native `torch.xpu` hosts place the model on XPU (#3367).
- Add unit tests for device selection and `from_pretrained` kwargs (mocked; no HF download / no GPU required).

## Related issues
| Issue | Treatment |
|-------|-----------|
| #3367 BLIP2 load + XPU device | Fixed in this PR |
| #2992 BLIP2 ModelWrapper | Same load fix |
| #3037 BLIP2 fresh install | Same load fix (submodule-missing path out of scope) |
| #3367 BLIP fairscale / `torch.cuda.comm` | **Not fixed in-tree** — lives in `sd-scripts/finetune/blip/vit.py` (submodule ownership). Ready-to-paste upstream try/except no-op wrapper documented in triage. |
| #3499 native XPU install | Already fixed via #3566 — no change |
| #3333 oneAPI libsycl, #3424 multi-GPU IPEX | Deferred (orthogonal) |

### Upstream snippet for BLIP (sd-scripts)
```python
# finetune/blip/vit.py — replace unconditional fairscale import
try:
    from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
except Exception:  # missing torch.cuda.comm on XPU-only / CPU-only builds
    def checkpoint_wrapper(module, *args, **kwargs):
        return module
```

## Test plan
- [x] `python -m pytest tests/test_blip2_caption_gui.py -q` (10 passed, run twice)
- [x] `python -m pytest tests/ test/test_allowed_paths.py -q` (367 passed)
- [ ] Manual: BLIP2 caption on a small folder (CUDA or XPU) if hardware available