### PR TITLE
feat: surface training exit code and log tail on failure (#3435)

### DIFF
--- a/kohya_gui/class_command_executor.py
+++ b/kohya_gui/class_command_executor.py
@@ -1,12 +1,96 @@
+import collections
 import subprocess
-import psutil
+import sys
+import threading
 import time
-import gradio as gr
+from typing import Deque, Optional, TextIO, Tuple
 
+import gradio as gr
+import psutil
+
+from .common_gui import output_message
 from .custom_logging import setup_logging
 
 # Set up logging
 log = setup_logging()
+
+# How many trailing log lines to attach to a failure summary.
+_DEFAULT_LOG_TAIL_LINES = 40
+
+
+def tail_lines(text: Optional[str], max_lines: int = _DEFAULT_LOG_TAIL_LINES) -> str:
+    """Return the last ``max_lines`` lines of ``text`` (empty-safe)."""
+    if not text:
+        return ""
+    lines = text.splitlines()
+    if max_lines <= 0:
+        return ""
+    return "\n".join(lines[-max_lines:])
+
+
+def read_log_tail(path: str, max_lines: int = _DEFAULT_LOG_TAIL_LINES) -> str:
+    """Read the last ``max_lines`` lines from a log file; empty if missing."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return tail_lines(f.read(), max_lines=max_lines)
+    except OSError:
+        return ""
+
+
+def drain_stream_to_buffer(
+    stream: TextIO,
+    buffer: Deque[str],
+    *,
+    dest: Optional[TextIO] = None,
+) -> None:
+    """Read lines from ``stream`` into ``buffer``, optionally echoing to ``dest``.
+
+    Used to tee subprocess output so a short failure tail is available without
+    hiding live console logs. Safe to call on a background thread.
+    """
+    try:
+        for line in iter(stream.readline, ""):
+            if dest is not None:
+                try:
+                    dest.write(line)
+                    dest.flush()
+                except OSError:
+                    pass
+            buffer.append(line.rstrip("\n\r"))
+    except (OSError, ValueError):
+        # Stream closed underfoot (process exit) — ignore.
+        pass
+    finally:
+        try:
+            stream.close()
+        except OSError:
+            pass
+
+
+def summarize_training_end(
+    returncode: Optional[int],
+    *,
+    user_stopped: bool = False,
+    log_tail: str = "",
+) -> Tuple[str, str]:
+    """Build a (level, message) pair for end-of-training status.
+
+    Levels: ``info`` or ``error``. User-initiated stop is always reported
+    as cancelled (info), even when the OS exit code is non-zero.
+    """
+    if user_stopped:
+        return "info", "Training was stopped by the user."
+
+    if returncode is None:
+        return "info", "Training has ended."
+
+    if returncode == 0:
+        return "info", "Training has ended successfully (exit code 0)."
+
+    msg = f"Training failed with exit code {returncode}."
+    if log_tail and log_tail.strip():
+        msg = f"{msg}\n\nLast log lines:\n{log_tail.strip()}"
+    return "error", msg
 
 
 class CommandExecutor:
@@ -20,12 +104,19 @@ class CommandExecutor:
         """
         self.headless = headless
         self.process = None
-        
+        self._stopped_by_user = False
+        self._output_lines: Deque[str] = collections.deque(
+            maxlen=_DEFAULT_LOG_TAIL_LINES
+        )
+        self._tee_thread: Optional[threading.Thread] = None
+
         with gr.Row():
             self.button_run = gr.Button("Start training", variant="primary")
 
             self.button_stop_training = gr.Button(
-                "Stop training", visible=self.process is not None or headless, variant="stop"
+                "Stop training",
+                visible=self.process is not None or headless,
+                variant="stop",
             )
 
     def execute_command(self, run_cmd: str, **kwargs):
@@ -39,16 +130,41 @@ class CommandExecutor:
         if self.process and self.process.poll() is None:
             log.info("The command is already running. Please wait for it to finish.")
         else:
-            # for i, item in enumerate(run_cmd):
-            #     log.info(f"{i}: {item}")
-
             # Reconstruct the safe command string for display
             command_to_run = " ".join(run_cmd)
             log.info(f"Executing command: {command_to_run}")
 
+            self._stopped_by_user = False
+            self._output_lines = collections.deque(maxlen=_DEFAULT_LOG_TAIL_LINES)
+            self._tee_thread = None
+
+            # Tee child stdout/stderr into a ring buffer (and the console) so
+            # failure summaries can include a traceback tail. Skip if the
+            # caller already redirected either stream.
+            tee_output = "stdout" not in kwargs and "stderr" not in kwargs
+            popen_kwargs = dict(kwargs)
+            if tee_output:
+                popen_kwargs["stdout"] = subprocess.PIPE
+                popen_kwargs["stderr"] = subprocess.STDOUT
+                popen_kwargs.setdefault("text", True)
+                popen_kwargs.setdefault("encoding", "utf-8")
+                popen_kwargs.setdefault("errors", "replace")
+                # Line-buffered text mode when supported.
+                popen_kwargs.setdefault("bufsize", 1)
+
             # Execute the command securely
-            self.process = subprocess.Popen(run_cmd, **kwargs)
+            self.process = subprocess.Popen(run_cmd, **popen_kwargs)
             log.debug("Command executed.")
+
+            if tee_output and self.process.stdout is not None:
+                self._tee_thread = threading.Thread(
+                    target=drain_stream_to_buffer,
+                    args=(self.process.stdout, self._output_lines),
+                    kwargs={"dest": sys.stdout},
+                    name="command-executor-tee",
+                    daemon=True,
+                )
+                self._tee_thread.start()
 
     def kill_command(self):
         """
@@ -61,6 +177,7 @@ class CommandExecutor:
                 for child in parent.children(recursive=True):
                     child.kill()
                 parent.kill()
+                self._stopped_by_user = True
                 log.info("The running process has been terminated.")
             except psutil.NoSuchProcess:
                 # Explicitly handle the case where the process does not exist
@@ -76,11 +193,45 @@ class CommandExecutor:
 
         return gr.Button(visible=True), gr.Button(visible=False or self.headless)
 
+    def _join_tee(self, timeout: float = 2.0) -> None:
+        thread = self._tee_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+
+    def _collect_log_tail(self) -> str:
+        """Prefer teed process lines; fall back to GUI setup.log."""
+        self._join_tee()
+        if self._output_lines:
+            return "\n".join(self._output_lines)
+        # custom_logging writes the GUI log here (cwd-relative).
+        return read_log_tail("setup.log", max_lines=_DEFAULT_LOG_TAIL_LINES)
+
     def wait_for_training_to_end(self):
         while self.is_running():
             time.sleep(1)
             log.debug("Waiting for training to end...")
-        log.info("Training has ended.")
+
+        returncode: Optional[int] = None
+        if self.process is not None:
+            # Ensure returncode is populated after the process has exited.
+            returncode = self.process.poll()
+            if returncode is None:
+                returncode = self.process.returncode
+
+        include_tail = returncode not in (None, 0) and not self._stopped_by_user
+        log_tail = self._collect_log_tail() if include_tail else ""
+        level, message = summarize_training_end(
+            returncode,
+            user_stopped=self._stopped_by_user,
+            log_tail=log_tail,
+        )
+
+        if level == "error":
+            log.error(message)
+            output_message(msg=message, title="Training failed", headless=self.headless)
+        else:
+            log.info(message)
+
         return gr.Button(visible=True), gr.Button(visible=False or self.headless)
 
     def is_running(self):

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -1,0 +1,218 @@
+"""GH #3435: surface exit code + short log tail when training subprocess ends.
+
+Covers pure helpers and CommandExecutor.wait_for_training_to_end behavior
+with mocked process handles (no real training).
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import gradio as gr
+
+from kohya_gui import class_command_executor as ce
+
+
+class TestTailLines(unittest.TestCase):
+    def test_returns_last_n_lines(self):
+        text = "\n".join(f"line{i}" for i in range(10))
+        self.assertEqual(ce.tail_lines(text, max_lines=3), "line7\nline8\nline9")
+
+    def test_short_text_unchanged(self):
+        self.assertEqual(ce.tail_lines("a\nb", max_lines=10), "a\nb")
+
+    def test_empty(self):
+        self.assertEqual(ce.tail_lines("", max_lines=5), "")
+
+    def test_none_safe(self):
+        self.assertEqual(ce.tail_lines(None, max_lines=5), "")
+
+
+class TestDrainStreamToBuffer(unittest.TestCase):
+    def test_drains_and_bounds_buffer(self):
+        import collections
+        import io
+
+        stream = io.StringIO("a\nb\nc\nd\n")
+        buf = collections.deque(maxlen=2)
+        dest = io.StringIO()
+        ce.drain_stream_to_buffer(stream, buf, dest=dest)
+        self.assertEqual(list(buf), ["c", "d"])
+        self.assertEqual(dest.getvalue(), "a\nb\nc\nd\n")
+
+
+class TestReadLogTail(unittest.TestCase):
+    def test_reads_last_lines_from_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "setup.log")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("\n".join(f"L{i}" for i in range(20)) + "\n")
+            tail = ce.read_log_tail(path, max_lines=3)
+            self.assertEqual(tail, "L17\nL18\nL19")
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(ce.read_log_tail("/no/such/setup.log"), "")
+
+
+class TestSummarizeTrainingEnd(unittest.TestCase):
+    def test_success_exit_zero(self):
+        level, msg = ce.summarize_training_end(0, user_stopped=False, log_tail="")
+        self.assertEqual(level, "info")
+        self.assertIn("success", msg.lower())
+        self.assertNotIn("failed", msg.lower())
+
+    def test_failure_includes_exit_code(self):
+        level, msg = ce.summarize_training_end(1, user_stopped=False, log_tail="")
+        self.assertEqual(level, "error")
+        self.assertIn("1", msg)
+        self.assertIn("fail", msg.lower())
+
+    def test_failure_includes_log_tail(self):
+        level, msg = ce.summarize_training_end(
+            2, user_stopped=False, log_tail="RuntimeError: boom"
+        )
+        self.assertEqual(level, "error")
+        self.assertIn("2", msg)
+        self.assertIn("RuntimeError: boom", msg)
+
+    def test_user_stop_is_cancelled_not_failed(self):
+        # Kill often yields non-zero; must not look like a training failure.
+        level, msg = ce.summarize_training_end(
+            1, user_stopped=True, log_tail="whatever"
+        )
+        self.assertEqual(level, "info")
+        self.assertRegex(msg.lower(), r"stop|cancel")
+        self.assertNotIn("failed", msg.lower())
+
+    def test_none_returncode_generic_end(self):
+        level, msg = ce.summarize_training_end(None, user_stopped=False, log_tail="")
+        self.assertEqual(level, "info")
+        self.assertIn("ended", msg.lower())
+
+
+class TestWaitForTrainingToEnd(unittest.TestCase):
+    def _make_executor(self, headless=True):
+        with gr.Blocks():
+            return ce.CommandExecutor(headless=headless)
+
+    def test_nonzero_exit_logs_failure_with_code_and_idle_buttons(self):
+        executor = self._make_executor(headless=True)
+        proc = MagicMock()
+        proc.poll.return_value = 7  # already finished
+        proc.returncode = 7
+        executor.process = proc
+
+        with (
+            patch.object(ce, "log") as mock_log,
+            patch.object(ce, "output_message") as mock_msg,
+            patch.object(ce, "read_log_tail", return_value="Traceback: OOM"),
+            patch.object(ce.time, "sleep"),
+        ):
+            start_btn, stop_btn = executor.wait_for_training_to_end()
+
+        error_msgs = [c.args[0] for c in mock_log.error.call_args_list if c.args]
+        self.assertTrue(error_msgs, msg="expected log.error for failed training")
+        self.assertTrue(
+            any("7" in m and "fail" in m.lower() for m in error_msgs),
+            msg=error_msgs,
+        )
+        self.assertTrue(
+            any("OOM" in m or "Traceback" in m for m in error_msgs),
+            msg=error_msgs,
+        )
+        mock_msg.assert_called()
+        msg_arg = mock_msg.call_args.kwargs.get("msg") or mock_msg.call_args[0][0]
+        self.assertIn("7", msg_arg)
+
+        # Idle: Start visible, Stop hidden (headless keeps Stop visible per existing)
+        self.assertTrue(
+            start_btn["visible"] if isinstance(start_btn, dict) else start_btn.visible
+        )
+        # headless=True → stop remains visible (False or True → True)
+        stop_visible = (
+            stop_btn["visible"] if isinstance(stop_btn, dict) else stop_btn.visible
+        )
+        self.assertTrue(stop_visible)
+
+    def test_zero_exit_does_not_report_failure(self):
+        executor = self._make_executor(headless=True)
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        executor.process = proc
+
+        with (
+            patch.object(ce, "log") as mock_log,
+            patch.object(ce, "output_message") as mock_msg,
+            patch.object(ce.time, "sleep"),
+        ):
+            executor.wait_for_training_to_end()
+
+        mock_log.error.assert_not_called()
+        mock_msg.assert_not_called()
+        info_msgs = [c.args[0] for c in mock_log.info.call_args_list if c.args]
+        self.assertTrue(
+            any("success" in m.lower() or "ended" in m.lower() for m in info_msgs)
+        )
+
+    def test_user_stop_not_reported_as_failure(self):
+        executor = self._make_executor(headless=True)
+        proc = MagicMock()
+        proc.poll.return_value = 1
+        proc.returncode = 1
+        executor.process = proc
+        executor._stopped_by_user = True
+
+        with (
+            patch.object(ce, "log") as mock_log,
+            patch.object(ce, "output_message") as mock_msg,
+            patch.object(ce.time, "sleep"),
+        ):
+            executor.wait_for_training_to_end()
+
+        mock_log.error.assert_not_called()
+        info_msgs = [c.args[0] for c in mock_log.info.call_args_list if c.args]
+        self.assertTrue(
+            any("stop" in m.lower() or "cancel" in m.lower() for m in info_msgs),
+            msg=info_msgs,
+        )
+
+    def test_kill_command_sets_user_stopped_flag(self):
+        executor = self._make_executor(headless=True)
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        proc.pid = 12345
+        executor.process = proc
+
+        parent = MagicMock()
+        parent.children.return_value = []
+        with patch.object(ce.psutil, "Process", return_value=parent):
+            executor.kill_command()
+
+        self.assertTrue(executor._stopped_by_user)
+
+    def test_headed_idle_buttons_after_end(self):
+        executor = self._make_executor(headless=False)
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        executor.process = proc
+
+        with patch.object(ce, "log"), patch.object(ce.time, "sleep"):
+            start_btn, stop_btn = executor.wait_for_training_to_end()
+
+        self.assertTrue(start_btn.visible)
+        self.assertFalse(stop_btn.visible)
+
+    def test_collect_log_tail_prefers_process_buffer(self):
+        executor = self._make_executor(headless=True)
+        executor._output_lines.append("CUDA out of memory")
+        with patch.object(ce, "read_log_tail") as mock_read:
+            tail = executor._collect_log_tail()
+        self.assertEqual(tail, "CUDA out of memory")
+        mock_read.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- When a training subprocess managed by `CommandExecutor` finishes, the GUI now distinguishes **success**, **failure**, and **user stop** instead of only logging a generic \"Training has ended.\"
- **Failure (non-zero exit):** `log.error` + `output_message` with the numeric exit code and a short tail of process output (stdout/stderr teed into a ring buffer while still printed live; falls back to `setup.log`).
- **Success (exit 0):** clear success info message.
- **User Stop:** treated as cancelled (info), not as a training failure, even when the OS exit code is non-zero after kill.
- Implemented once on the shared executor path so LoRA, DreamBooth, finetune, TI, and other tabs that wait on that path all inherit the behavior.

Closes #3435

## Test plan
- [x] `pytest tests/test_command_executor.py` (18 tests) — exit code messaging, log tail, user-stop, headed/headless button idle state, tee drain helper
- [x] Full suite: `pytest tests/` — 384 passed
- [ ] Manual smoke: start a training config that fails quickly; confirm GUI/log shows exit code + tail
- [ ] Manual smoke: Start then Stop; confirm cancelled message, not failure
- [ ] Manual smoke: successful short run still ends cleanly with success message